### PR TITLE
Add Git status colors to file explorer

### DIFF
--- a/src/chrome/FileTree.tsx
+++ b/src/chrome/FileTree.tsx
@@ -48,9 +48,17 @@ import {
   type FsEntry,
 } from "../lib/fs";
 import { displayPath, parentPath, rebasePath } from "../lib/paths";
+import { IS_MAC, MOD } from "../lib/platform";
+import type { GitStatusMap } from "../hooks/useGitFileStatuses";
 import { ExplorerMenu, type ExplorerMenuItem } from "./ExplorerMenu";
 import { FileTypeIcon } from "./FileTypeIcon";
-import { IS_MAC, MOD } from "../lib/platform";
+
+const GIT_STATUS_COLOR: Record<string, string> = {
+  modified: "text-amber-400",
+  added: "text-emerald-400",
+  untracked: "text-emerald-400",
+  deleted: "text-red-400",
+};
 
 type Props = {
   cwd: string;
@@ -60,6 +68,7 @@ type Props = {
   onFileDeleted?: (path: string) => void;
   onSearch?: () => void;
   headerEnd?: ReactNode;
+  gitStatuses?: GitStatusMap;
 };
 
 type Creating = { id: number; parent: string; isDir: boolean };
@@ -80,6 +89,7 @@ type TreeCtxValue = {
   renaming: string | null;
   cutPath: string | null;
   epoch: number;
+  gitStatuses?: GitStatusMap;
   onToggle: (path: string) => void;
   onSelect: (path: string) => void;
   onOpenFile: (path: string) => void;
@@ -200,6 +210,7 @@ export function FileTree({
   onFileDeleted,
   onSearch,
   headerEnd,
+  gitStatuses,
 }: Props) {
   const [expanded, setExpanded] = useState(() => loadExpanded(cwd));
   const [selectedPath, setSelectedPath] = useState(() => loadSelected(cwd));
@@ -575,6 +586,7 @@ export function FileTree({
         renaming,
         cutPath: clip?.mode === "cut" ? clip.path : null,
         epoch,
+        gitStatuses,
         onToggle: toggle,
         onSelect,
         onOpenFile,
@@ -775,6 +787,7 @@ function TreeNode({ entry, depth }: { entry: FsEntry; depth: number }) {
     renaming,
     cutPath,
     epoch,
+    gitStatuses,
     onToggle,
     onSelect,
     onOpenFile,
@@ -789,6 +802,10 @@ function TreeNode({ entry, depth }: { entry: FsEntry; depth: number }) {
   const [error, setError] = useState<string | null>(null);
   const selected = selectedPath === entry.path;
   const editing = renaming === entry.path;
+  const gitStatus = entry.isDir
+    ? gitStatuses?.dirs.get(entry.path)
+    : gitStatuses?.files.get(entry.path);
+  const gitColor = gitStatus ? GIT_STATUS_COLOR[gitStatus] : undefined;
 
   useEffect(() => {
     if (!entry.isDir || !open) return;
@@ -868,8 +885,10 @@ function TreeNode({ entry, depth }: { entry: FsEntry; depth: number }) {
           </span>
           <span
             className={`min-w-0 truncate ${
-              entry.ignored ? "italic text-content/50" : ""
-            } `}
+              entry.ignored
+                ? "italic text-content/50"
+                : gitColor ?? ""
+            }`}
           >
             {entry.name}
           </span>

--- a/src/chrome/Sidebar.tsx
+++ b/src/chrome/Sidebar.tsx
@@ -20,6 +20,7 @@ import { sessionDisplayTitle } from "../lib/session";
 import { nextUnseenFinishedSessions } from "../lib/sessionDone";
 import type { SessionSummary } from "../lib/sessionStore";
 import { resolveTabGroupLogo } from "../lib/tabGroups";
+import { useGitFileStatuses } from "../hooks/useGitFileStatuses";
 import { useLockOverscroll } from "../hooks/useLockOverscroll";
 import { useProjectDiffStats } from "../hooks/useProjectDiffStats";
 import { useSessionDiffStats } from "../hooks/useSessionDiffStats";
@@ -150,6 +151,7 @@ function SidebarComponent({
   });
   const canDragTabs = tabOrder.length > 1;
   const projectDiff = useProjectDiffStats(cwd, open);
+  const gitStatuses = useGitFileStatuses(cwd, open && tab === "files");
   const groupLogos = useTabGroupLogos();
   const projectLogoPath = resolveTabGroupLogo(projectName(cwd), groupLogos);
   const sessionDiffs = useSessionDiffStats(
@@ -387,6 +389,7 @@ function SidebarComponent({
               onFileMoved={onFileMoved}
               onFileDeleted={onFileDeleted}
               onSearch={onOpenFilesSearch}
+              gitStatuses={gitStatuses}
               headerEnd={
                 onToggleDiff ? (
                   <DiffStat

--- a/src/hooks/useGitFileStatuses.ts
+++ b/src/hooks/useGitFileStatuses.ts
@@ -1,0 +1,165 @@
+import { useCallback, useSyncExternalStore } from "react";
+import {
+  gitDiffIndex,
+  subscribeGitChanged,
+  type GitDiffIndex,
+} from "../lib/fs";
+import { subscribeDirsChanged } from "../lib/fileTree";
+import { parentPath } from "../lib/paths";
+
+export type GitStatusMap = {
+  files: Map<string, string>;
+  dirs: Map<string, string>;
+};
+
+const STATUS_PRIORITY: Record<string, number> = {
+  modified: 3,
+  deleted: 2,
+  added: 1,
+  untracked: 1,
+};
+
+const EMPTY: GitStatusMap = { files: new Map(), dirs: new Map() };
+
+type Entry = {
+  cwd: string;
+  data: GitStatusMap;
+  listeners: Set<() => void>;
+  inFlight: boolean;
+  pending: boolean;
+  unsubscribeGit: (() => void) | null;
+  unsubscribeDirs: (() => void) | null;
+  onResume: (() => void) | null;
+};
+
+const entries = new Map<string, Entry>();
+
+function entryFor(cwd: string): Entry {
+  const existing = entries.get(cwd);
+  if (existing) return existing;
+  const entry: Entry = {
+    cwd,
+    data: EMPTY,
+    listeners: new Set(),
+    inFlight: false,
+    pending: false,
+    unsubscribeGit: null,
+    unsubscribeDirs: null,
+    onResume: null,
+  };
+  entries.set(cwd, entry);
+  return entry;
+}
+
+function buildStatusMaps(index: GitDiffIndex, cwd: string): GitStatusMap {
+  const files = new Map<string, string>();
+  const dirs = new Map<string, string>();
+  for (const file of index.files) {
+    files.set(file.path, file.status);
+    const prio = STATUS_PRIORITY[file.status] ?? 0;
+    if (prio === 0) continue;
+    let dir = parentPath(file.path);
+    while (dir.length > cwd.length) {
+      const existing = dirs.get(dir);
+      const existingPrio = existing ? (STATUS_PRIORITY[existing] ?? 0) : 0;
+      if (prio > existingPrio) {
+        dirs.set(dir, file.status);
+      } else {
+        break;
+      }
+      dir = parentPath(dir);
+    }
+  }
+  return { files, dirs };
+}
+
+function sameMaps(
+  a: Map<string, string>,
+  b: Map<string, string>,
+): boolean {
+  if (a.size !== b.size) return false;
+  for (const [k, v] of b) {
+    if (a.get(k) !== v) return false;
+  }
+  return true;
+}
+
+function sameData(a: GitStatusMap, b: GitStatusMap): boolean {
+  return sameMaps(a.files, b.files) && sameMaps(a.dirs, b.dirs);
+}
+
+function publish(entry: Entry, data: GitStatusMap) {
+  if (sameData(entry.data, data)) return;
+  entry.data = data;
+  for (const listener of entry.listeners) listener();
+}
+
+async function load(entry: Entry, force = false) {
+  if (entry.inFlight) {
+    entry.pending = true;
+    return;
+  }
+  if (!force && document.hidden) return;
+  entry.inFlight = true;
+  try {
+    const index = await gitDiffIndex(entry.cwd);
+    publish(entry, buildStatusMaps(index, entry.cwd));
+  } catch {
+    publish(entry, EMPTY);
+  } finally {
+    entry.inFlight = false;
+    if (entry.pending) {
+      entry.pending = false;
+      void load(entry, true);
+    }
+  }
+}
+
+function start(entry: Entry) {
+  if (entry.onResume) return;
+  void load(entry, true);
+  entry.onResume = () => {
+    if (!document.hidden) void load(entry, true);
+  };
+  window.addEventListener("focus", entry.onResume);
+  document.addEventListener("visibilitychange", entry.onResume);
+  entry.unsubscribeGit = subscribeGitChanged(entry.onResume);
+  entry.unsubscribeDirs = subscribeDirsChanged(entry.onResume);
+}
+
+function stop(entry: Entry) {
+  if (entry.onResume) {
+    window.removeEventListener("focus", entry.onResume);
+    document.removeEventListener("visibilitychange", entry.onResume);
+  }
+  entry.unsubscribeGit?.();
+  entry.unsubscribeDirs?.();
+  entry.onResume = null;
+  entry.unsubscribeGit = null;
+  entry.unsubscribeDirs = null;
+}
+
+export function useGitFileStatuses(
+  cwd: string,
+  enabled: boolean,
+): GitStatusMap {
+  const active = enabled && Boolean(cwd) && cwd !== "~";
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      if (!active) return () => undefined;
+      const entry = entryFor(cwd);
+      entry.listeners.add(listener);
+      if (entry.listeners.size === 1) start(entry);
+      return () => {
+        entry.listeners.delete(listener);
+        if (entry.listeners.size === 0) stop(entry);
+      };
+    },
+    [active, cwd],
+  );
+  const getSnapshot = useCallback(() => {
+    return active ? entryFor(cwd).data : EMPTY;
+  }, [active, cwd]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}


### PR DESCRIPTION
## What changed

File explorer sidebar now shows Git status colors (green = added, amber = modified, red = deleted), with parent folders inheriting the most significant child status.

## Why

The file explorer showed no Git status indicators, making it hard to spot changed files without expanding every folder.

## Checklist

- [x] I ran `bun run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes