### PR TITLE
Preserve streamed text across provider harnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Streamed responses preserve repeated letters, punctuation, spaces, blank lines, and Markdown boundaries across supported providers.
+
 ## [0.1.13] - 2026-08-27
 
 ### Added

--- a/src-tauri/src/session_store.rs
+++ b/src-tauri/src/session_store.rs
@@ -1182,6 +1182,23 @@ mod tests {
     }
 
     #[test]
+    fn streamed_text_round_trips_exactly() {
+        let store = SessionStore::open_in_memory().unwrap();
+        let conn = store.conn.lock().unwrap();
+        let text = "# Result\n\nbookkeeper..\n\nfirst line  \nsecond line\n\n```ts\nconst value = \"hello\";\n```";
+        let mut row = sample("s1", "/tmp/a", "Exact text");
+        row.blocks = json!([
+            { "id": "u1", "role": "user", "text": "Return exact Markdown" },
+            { "id": "a1", "role": "assistant", "text": text }
+        ]);
+
+        upsert_session(&conn, &row).unwrap();
+        let stored = get_session(&conn, "s1").unwrap().unwrap();
+
+        assert_eq!(stored.blocks[1]["text"], text);
+    }
+
+    #[test]
     fn context_usage_round_trips() {
         let store = SessionStore::open_in_memory().unwrap();
         let conn = store.conn.lock().unwrap();

--- a/src/lib/handoffTurn.ts
+++ b/src/lib/handoffTurn.ts
@@ -4,7 +4,6 @@ import {
   respondHarnessApproval,
   sendHarnessTurn,
 } from "./harness/registry";
-import { mergeStream } from "./harness/streamText";
 import type { HarnessId } from "./session";
 
 const HANDOFF_TIMEOUT_MS = 45_000;
@@ -32,7 +31,7 @@ export async function requestOutgoingHandoff(input: {
       text: buildOutgoingHandoffPrompt(input.userRequest),
       onEvent: (event) => {
         if (event.type === "message.delta") {
-          brief = mergeStream(brief, event.text);
+          brief += event.text;
         }
         if (event.type === "approval.requested") {
           respondHarnessApproval(

--- a/src/lib/harness/apply.test.ts
+++ b/src/lib/harness/apply.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { newSession } from "../session";
-import { appendUser, applyHarnessEvent, appendSteerUser, stopStreaming } from "./apply";
+import {
+  appendUser,
+  applyHarnessEvent,
+  appendSteerUser,
+  stopStreaming,
+} from "./apply";
+import type { HarnessEvent } from "./types";
 
 let now = 0;
 
@@ -50,6 +56,106 @@ describe("turn duration", () => {
   });
 });
 
+describe("streamed text fidelity", () => {
+  it("appends repeated assistant boundaries verbatim", () => {
+    let session = newSession("cursor", "/tmp");
+    for (const text of ["hel", "lo", "\n", "\n", "Wait.", ". Next"]) {
+      session = applyHarnessEvent(session, { type: "message.delta", text });
+    }
+
+    expect(session.blocks).toMatchObject([
+      {
+        role: "assistant",
+        text: "hello\n\nWait.. Next",
+        streaming: true,
+      },
+    ]);
+  });
+
+  it("appends whitespace-only reasoning boundaries verbatim", () => {
+    let session = newSession("codex", "/tmp");
+    for (const text of ["thinking", " ", " ", "\n", "\n"]) {
+      session = applyHarnessEvent(session, { type: "reasoning.delta", text });
+    }
+
+    expect(session.blocks).toMatchObject([
+      {
+        role: "reasoning",
+        text: "thinking  \n\n",
+        streaming: true,
+      },
+    ]);
+  });
+});
+
+describe("transcript ordering", () => {
+  it("keeps assistant text on both sides of a tool in separate blocks", () => {
+    const events: HarnessEvent[] = [
+      { type: "message.delta", text: "before" },
+      {
+        type: "tool.started",
+        callId: "read-1",
+        title: "Read file",
+        kind: "read",
+      },
+      { type: "message.delta", text: "after" },
+    ];
+
+    const session = events.reduce(applyHarnessEvent, newSession("pi", "/tmp"));
+
+    expect(session.blocks).toMatchObject([
+      { role: "assistant", text: "before", streaming: false },
+      { role: "tool", tool: { callId: "read-1" } },
+      { role: "assistant", text: "after", streaming: true },
+    ]);
+  });
+
+  it("keeps reasoning text on both sides of a tool in separate blocks", () => {
+    const events: HarnessEvent[] = [
+      { type: "reasoning.delta", text: "before" },
+      {
+        type: "tool.started",
+        callId: "read-1",
+        title: "Read file",
+        kind: "read",
+      },
+      { type: "reasoning.delta", text: "after" },
+    ];
+
+    const session = events.reduce(
+      applyHarnessEvent,
+      newSession("codex", "/tmp"),
+    );
+
+    expect(session.blocks).toMatchObject([
+      { role: "reasoning", text: "before", streaming: false },
+      { role: "tool", tool: { callId: "read-1" } },
+      { role: "reasoning", text: "after", streaming: true },
+    ]);
+  });
+
+  it("preserves a complete Markdown fixture", () => {
+    const chunks = [
+      "# Result\n",
+      "\n",
+      "- book",
+      "keeper\n",
+      "\nfirst line ",
+      " \nsecond line\n",
+      "\n```ts\n",
+      'const value = "bookkeeper";\n',
+      "```",
+    ];
+    const session = chunks.reduce(
+      (current, text) =>
+        applyHarnessEvent(current, { type: "message.delta", text }),
+      newSession("cursor", "/tmp"),
+    );
+
+    expect(session.blocks[0]?.text).toBe(chunks.join(""));
+  });
+});
+
 describe("appendSteerUser", () => {
   it("appends a user message without sealing an in-flight assistant block", () => {
     let session = appendUser(newSession("cursor", "/tmp"), "build it");
@@ -68,6 +174,41 @@ describe("appendSteerUser", () => {
     });
     expect(session.blocks[2]?.startedAt).toBeUndefined();
     expect(session.busy).toBe(true);
+  });
+
+  it("completion seals text streams from both sides of an in-turn steer", () => {
+    let session = appendUser(newSession("claude", "/tmp"), "build it");
+    session = applyHarnessEvent(session, {
+      type: "reasoning.delta",
+      text: "before reasoning",
+    });
+    session = applyHarnessEvent(session, {
+      type: "message.delta",
+      text: "before answer",
+    });
+    session = appendSteerUser(session, "focus on tests");
+    session = applyHarnessEvent(session, {
+      type: "reasoning.delta",
+      text: "after reasoning",
+    });
+    session = applyHarnessEvent(session, {
+      type: "message.delta",
+      text: "after answer",
+    });
+
+    session = applyHarnessEvent(session, { type: "reasoning.completed" });
+    session = applyHarnessEvent(session, { type: "message.completed" });
+
+    const textBlocks = session.blocks.filter(
+      (block) => block.role === "assistant" || block.role === "reasoning",
+    );
+    expect(textBlocks.map((block) => block.text)).toEqual([
+      "before reasoning",
+      "before answer",
+      "after reasoning",
+      "after answer",
+    ]);
+    expect(textBlocks.every((block) => block.streaming === false)).toBe(true);
   });
 });
 
@@ -90,7 +231,10 @@ describe("status blocks", () => {
   it("still appends a status that differs from the last one", () => {
     let session = appendUser(newSession("claude", "/tmp"), "go");
     session = applyHarnessEvent(session, { type: "status", text: "Retrying" });
-    session = applyHarnessEvent(session, { type: "status", text: "Compacting" });
+    session = applyHarnessEvent(session, {
+      type: "status",
+      text: "Compacting",
+    });
     expect(
       session.blocks.filter((block) => block.role === "system"),
     ).toHaveLength(2);
@@ -150,7 +294,9 @@ describe("tool enrichment", () => {
       callId: "call_1",
       preview: { kind: "read", path: "src/App.tsx", fileName: "App.tsx" },
     });
-    const tool = session.blocks.find((block) => block.tool?.callId === "call_1");
+    const tool = session.blocks.find(
+      (block) => block.tool?.callId === "call_1",
+    );
     expect(tool?.text).toBe("Read src/App.tsx");
     expect(tool?.tool?.preview?.path).toBe("src/App.tsx");
   });

--- a/src/lib/harness/apply.ts
+++ b/src/lib/harness/apply.ts
@@ -8,7 +8,6 @@ import {
   mergeToolPreview,
   stubFilePreview,
 } from "./preview";
-import { mergeStream } from "./streamText";
 import type { HarnessEvent } from "./types";
 
 export function applyHarnessEvent(
@@ -17,11 +16,11 @@ export function applyHarnessEvent(
 ): Session {
   switch (event.type) {
     case "message.delta":
-      return patchStreaming(session, "assistant", event.text, true);
+      return appendStreamingText(session, "assistant", event.text);
     case "message.completed":
       return finishRole(session, "assistant");
     case "reasoning.delta":
-      return patchStreaming(session, "reasoning", event.text, true);
+      return appendStreamingText(session, "reasoning", event.text);
     case "reasoning.completed":
       return finishRole(session, "reasoning");
     case "tool.started":
@@ -174,22 +173,19 @@ function appendBlock(session: Session, block: Block): Session {
 }
 
 /** Append to the latest block only when it is the same role; never splice into an earlier one. */
-function patchStreaming(
+function appendStreamingText(
   session: Session,
   role: "assistant" | "reasoning",
   text: string,
-  streaming: boolean,
 ): Session {
-  if (!text && role === "reasoning") return session;
+  if (!text) return session;
   const last = session.blocks[session.blocks.length - 1];
   if (last?.role === role) {
-    const nextText = mergeStream(last.text, text);
-    if (nextText === last.text && last.streaming === streaming) return session;
     const blocks = session.blocks.slice();
     blocks[blocks.length - 1] = {
       ...last,
-      text: nextText,
-      streaming,
+      text: last.text + text,
+      streaming: true,
     };
     return { ...session, blocks };
   }
@@ -198,7 +194,7 @@ function patchStreaming(
     id: crypto.randomUUID(),
     role,
     text,
-    streaming,
+    streaming: true,
   });
   return { ...session, blocks };
 }
@@ -305,13 +301,13 @@ function upsertTool(
   const index = findToolIndex(session, patch);
   if (index < 0) {
     const detail = capToolDetail(patch.detail);
-    const preview = fillPreview(
-      patch.preview,
-      detail,
+    const preview = fillPreview(patch.preview, detail, patch.kind, patch.title);
+    const label = finalToolLabel(
+      session,
       patch.kind,
-      patch.title,
+      displayLabel(patch),
+      preview,
     );
-    const label = finalToolLabel(session, patch.kind, displayLabel(patch), preview);
     return appendBlock(session, {
       id: crypto.randomUUID(),
       role: "tool",
@@ -402,7 +398,9 @@ function fillPreview(
   kind?: string,
   title?: string,
 ): ToolPreview | undefined {
-  if (preview?.lines?.some((line) => line.kind === "add" || line.kind === "del")) {
+  if (
+    preview?.lines?.some((line) => line.kind === "add" || line.kind === "del")
+  ) {
     return preview;
   }
   if (preview) return { ...preview, lines: undefined };
@@ -530,9 +528,7 @@ function isCallId(value: string): boolean {
   const text = value.trim();
   return (
     /^(call[-_]?|tool[-_])[a-z0-9_-]+$/i.test(text) ||
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-      text,
-    )
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(text)
   );
 }
 

--- a/src/lib/harness/claude.ts
+++ b/src/lib/harness/claude.ts
@@ -9,9 +9,11 @@ import {
   writeChild,
 } from "./child";
 import {
+  applyClaudeCompletedText,
+  applyClaudeTextDelta,
   askUserQuestionAllowInput,
-  assistantTextBlocks,
-  assistantToolUses,
+  completedAssistantParts,
+  createClaudeTextState,
   contextFromResult,
   contextUsedFromAssistant,
   buildClaudeSpawnArgs,
@@ -22,9 +24,11 @@ import {
   extractAskUserQuestionTitle,
   extractExitPlanModePlan,
   inputJsonDeltaFromEvent,
+  invalidateClaudeTextTail,
   isClaudeUltracodeEffort,
   isSubagentMessage,
   isTodoTool,
+  markClaudeContentPublished,
   normalizeClaudeCliEffort,
   parseControlCancelId,
   parseControlRequest,
@@ -32,6 +36,7 @@ import {
   planTextFromTodos,
   previewFromTool,
   resolveClaudeApiModelId,
+  reconcileClaudeCompletedTool,
   runtimeModeToPermission,
   sessionIdFromMessage,
   statusTextFromSystem,
@@ -47,9 +52,15 @@ import {
   turnStatusFromResult,
   type ClaudeCliSettings,
   type ClaudeControlRequest,
+  type ClaudeTextState,
+  type ClaudeToolUse,
 } from "./claudeProtocol";
-import { mergeStream } from "./streamText";
-import type { ApprovalDecision, HarnessEvent, SendTurnInput, SteerTurnInput } from "./types";
+import type {
+  ApprovalDecision,
+  HarnessEvent,
+  SendTurnInput,
+  SteerTurnInput,
+} from "./types";
 
 type PendingApproval = {
   requestId: string;
@@ -86,8 +97,7 @@ type Live = {
   activeTurn: boolean;
   initDone: (() => void) | null;
   initialized: boolean;
-  emittedAssistant: string;
-  emittedReasoning: string;
+  textState: ClaudeTextState;
 };
 
 type Resume = {
@@ -101,7 +111,8 @@ const liveByThread = new Map<string, Live>();
 const resumeByThread = new Map<string, Resume>();
 const cancelledThreads = new Set<string>();
 
-let resolveClaudeBinaryImpl: () => Promise<{ path: string }> = resolveClaudeBinary;
+let resolveClaudeBinaryImpl: () => Promise<{ path: string }> =
+  resolveClaudeBinary;
 
 /** Test seam. */
 export function setClaudeBinaryResolver(
@@ -122,16 +133,18 @@ export async function sendClaudeTurn(input: SendTurnInput): Promise<void> {
 
   live.onEvent = input.onEvent;
   live.runtimeMode = input.runtimeMode;
-  live.turns = live.turns.catch(() => undefined).then(async () => {
-    live.cancelled = false;
-    live.muteUpdates = false;
-    try {
-      await runTurn(live, input);
-    } catch (error) {
-      if (live.cancelled) return;
-      throw error;
-    }
-  });
+  live.turns = live.turns
+    .catch(() => undefined)
+    .then(async () => {
+      live.cancelled = false;
+      live.muteUpdates = false;
+      try {
+        await runTurn(live, input);
+      } catch (error) {
+        if (live.cancelled) return;
+        throw error;
+      }
+    });
   await live.turns;
 }
 
@@ -147,6 +160,7 @@ export async function steerClaudeTurn(input: SteerTurnInput): Promise<void> {
   const content = (message.message as { content: unknown[] }).content;
   if (content.length === 0) return;
 
+  live.textState = invalidateClaudeTextTail(live.textState);
   await writeJson(input.sessionId, message);
 }
 
@@ -240,8 +254,13 @@ async function ensureLive(input: SendTurnInput): Promise<Live> {
 
   const { path } = await resolveClaudeBinaryImpl();
   const liveRef: { current: Live | null } = { current: null };
-  const claudeSessionId = canResume && resume ? resume.sessionId : crypto.randomUUID();
-  const launch = launchOptions(input, canResume ? resume?.sessionId : undefined, claudeSessionId);
+  const claudeSessionId =
+    canResume && resume ? resume.sessionId : crypto.randomUUID();
+  const launch = launchOptions(
+    input,
+    canResume ? resume?.sessionId : undefined,
+    claudeSessionId,
+  );
 
   const live: Live = {
     cwd: input.cwd,
@@ -263,8 +282,7 @@ async function ensureLive(input: SendTurnInput): Promise<Live> {
     activeTurn: false,
     initDone: null,
     initialized: false,
-    emittedAssistant: "",
-    emittedReasoning: "",
+    textState: createClaudeTextState(0),
   };
   liveRef.current = live;
 
@@ -330,8 +348,7 @@ async function runTurn(live: Live, input: SendTurnInput): Promise<void> {
   const content = (message.message as { content: unknown[] }).content;
   if (content.length === 0) return;
 
-  live.emittedAssistant = "";
-  live.emittedReasoning = "";
+  live.textState = createClaudeTextState(live.textState.recordSequence + 1);
   live.toolsByIndex.clear();
   live.toolsById.clear();
 
@@ -400,7 +417,8 @@ function handleLine(sessionId: string, live: Live, line: string): void {
 
   if (
     type === "system" &&
-    (stringField(rec, "subtype") === "init" || stringField(rec, "subtype") === "initialized")
+    (stringField(rec, "subtype") === "init" ||
+      stringField(rec, "subtype") === "initialized")
   ) {
     markInitialized(live);
   }
@@ -428,7 +446,10 @@ function handleLine(sessionId: string, live: Live, line: string): void {
   }
   if (type === "system") {
     const text = statusTextFromSystem(rec);
-    if (text) live.onEvent({ type: "status", text });
+    if (text) {
+      live.textState = invalidateClaudeTextTail(live.textState);
+      live.onEvent({ type: "status", text });
+    }
   }
 }
 
@@ -437,18 +458,15 @@ function handleStreamEvent(live: Live, rec: Record<string, unknown>): void {
   const delta = streamDeltaFromEvent(rec);
   if (delta) {
     if (subagent) return;
-    if (delta.kind === "assistant") {
-      live.emittedAssistant = mergeStream(live.emittedAssistant, delta.text);
-      live.onEvent({ type: "message.delta", text: delta.text });
-    } else {
-      live.emittedReasoning = mergeStream(live.emittedReasoning, delta.text);
-      live.onEvent({ type: "reasoning.delta", text: delta.text });
-    }
+    const result = applyClaudeTextDelta(live.textState, delta);
+    live.textState = result.state;
+    if (result.event) live.onEvent(result.event);
     return;
   }
 
   const started = toolStartFromEvent(rec);
   if (started) {
+    live.textState = markClaudeContentPublished(live.textState, started.index);
     const tool: InFlightTool = {
       id: started.id,
       name: started.name,
@@ -499,38 +517,47 @@ function handleAssistant(live: Live, rec: Record<string, unknown>): void {
   const used = contextUsedFromAssistant(rec);
   if (used !== undefined) live.onEvent({ type: "context", used });
 
-  const snapshot = assistantTextBlocks(rec).join("");
-  if (snapshot && snapshot !== live.emittedAssistant) {
-    const next = mergeStream(live.emittedAssistant, snapshot);
-    const delta = next.slice(live.emittedAssistant.length);
-    live.emittedAssistant = next;
-    if (delta) live.onEvent({ type: "message.delta", text: delta });
+  for (const part of completedAssistantParts(rec)) {
+    if (part.kind === "text" || part.kind === "thinking") {
+      const result = applyClaudeCompletedText(live.textState, part);
+      live.textState = result.state;
+      if (result.event) live.onEvent(result.event);
+      continue;
+    }
+    const tool = reconcileClaudeCompletedTool(live.textState, {
+      contentIndex: part.contentIndex,
+      alreadyPublished: live.toolsById.has(part.use.id),
+    });
+    live.textState = tool.state;
+    if (tool.publish) emitCompletedClaudeTool(live, part.use);
   }
 
-  for (const use of assistantToolUses(rec)) {
-    if (live.toolsById.has(use.id)) continue;
-    const tool: InFlightTool = {
-      id: use.id,
-      name: use.name,
-      input: use.input,
-      partialJson: "",
-      title: toolTitle(use.name, use.input),
-    };
-    live.toolsById.set(use.id, tool);
-    live.onEvent({
-      type: "tool.started",
-      callId: tool.id,
-      title: tool.title,
-      kind: toolKindFromName(tool.name),
-      status: "pending",
-      preview: previewFromTool(tool.name, tool.input),
-    });
-    if (use.name === "ExitPlanMode") {
-      const plan = extractExitPlanModePlan(use.input);
-      if (plan) live.onEvent({ type: "plan", text: plan });
-    }
-    emitPlanIfNeeded(live, tool.name, tool.input);
+  live.textState = createClaudeTextState(live.textState.recordSequence + 1);
+}
+
+function emitCompletedClaudeTool(live: Live, use: ClaudeToolUse): void {
+  if (live.toolsById.has(use.id)) return;
+  const tool: InFlightTool = {
+    id: use.id,
+    name: use.name,
+    input: use.input,
+    partialJson: "",
+    title: toolTitle(use.name, use.input),
+  };
+  live.toolsById.set(use.id, tool);
+  live.onEvent({
+    type: "tool.started",
+    callId: tool.id,
+    title: tool.title,
+    kind: toolKindFromName(tool.name),
+    status: "pending",
+    preview: previewFromTool(tool.name, tool.input),
+  });
+  if (use.name === "ExitPlanMode") {
+    const plan = extractExitPlanModePlan(use.input);
+    if (plan) live.onEvent({ type: "plan", text: plan });
   }
+  emitPlanIfNeeded(live, tool.name, tool.input);
 }
 
 function handleUser(live: Live, rec: Record<string, unknown>): void {
@@ -578,6 +605,7 @@ async function handleControlRequest(
 
   const toolName = control.toolName ?? "tool";
   const input = control.input ?? {};
+  live.textState = invalidateClaudeTextTail(live.textState);
 
   if (live.cancelled || live.muteUpdates) {
     await writeJson(
@@ -599,7 +627,13 @@ async function handleControlRequest(
       kind: "other",
       callId: control.toolUseId,
     });
-    const decision = await waitApproval(live, uiId, control.requestId, input, "question");
+    const decision = await waitApproval(
+      live,
+      uiId,
+      control.requestId,
+      input,
+      "question",
+    );
     live.onEvent({ type: "approval.resolved", requestId: uiId, decision });
     const response =
       decision === "allow"
@@ -651,7 +685,13 @@ async function handleControlRequest(
     callId: control.toolUseId,
     preview: previewFromTool(toolName, input),
   });
-  const decision = await waitApproval(live, uiId, control.requestId, input, "permission");
+  const decision = await waitApproval(
+    live,
+    uiId,
+    control.requestId,
+    input,
+    "permission",
+  );
   live.onEvent({ type: "approval.resolved", requestId: uiId, decision });
   await writeJson(
     sessionId,
@@ -710,6 +750,7 @@ function finishActiveTurn(live: Live, extraEvents: HarnessEvent[] = []): void {
   live.turnEndPending = false;
   live.activeTurn = false;
   for (const event of extraEvents) live.onEvent(event);
+  live.textState = createClaudeTextState(live.textState.recordSequence + 1);
   const done = live.turnDone;
   const failed = live.turnFailed;
   live.turnDone = null;

--- a/src/lib/harness/claudeProtocol.test.ts
+++ b/src/lib/harness/claudeProtocol.test.ts
@@ -1,19 +1,25 @@
 import { describe, expect, it } from "vitest";
 import { modelsForClaudeVersion } from "./claudeCatalog";
 import {
+  applyClaudeCompletedText,
   applyClaudePromptEffortPrefix,
+  applyClaudeTextDelta,
   askUserQuestionAllowInput,
   buildClaudeSpawnArgs,
   buildClaudeUserMessage,
+  completedAssistantParts,
+  createClaudeTextState,
   contextFromResult,
   contextUsedFromAssistant,
   extractExitPlanModePlan,
   isTodoTool,
+  markClaudeContentPublished,
   normalizeClaudeCliEffort,
   parseClaudeVersion,
   parseControlRequest,
   planTextFromTodos,
   resolveClaudeApiModelId,
+  reconcileClaudeCompletedTool,
   runtimeModeToPermission,
   statusTextFromSystem,
   streamDeltaFromEvent,
@@ -34,8 +40,12 @@ describe("runtimeModeToPermission", () => {
 
 describe("normalizeClaudeCliEffort", () => {
   it("drops ultrathink and maps ultracode to xhigh", () => {
-    expect(normalizeClaudeCliEffort("ultrathink", "claude-sonnet-5")).toBeUndefined();
-    expect(normalizeClaudeCliEffort("ultracode", "claude-opus-5")).toBe("xhigh");
+    expect(
+      normalizeClaudeCliEffort("ultrathink", "claude-sonnet-5"),
+    ).toBeUndefined();
+    expect(normalizeClaudeCliEffort("ultracode", "claude-opus-5")).toBe(
+      "xhigh",
+    );
   });
 
   it("maps xhigh to max on older models", () => {
@@ -50,17 +60,21 @@ describe("normalizeClaudeCliEffort", () => {
 
 describe("applyClaudePromptEffortPrefix", () => {
   it("prefixes ultrathink on the prompt", () => {
-    expect(applyClaudePromptEffortPrefix("Investigate the edge cases", "ultrathink")).toBe(
-      "Ultrathink:\nInvestigate the edge cases",
-    );
+    expect(
+      applyClaudePromptEffortPrefix("Investigate the edge cases", "ultrathink"),
+    ).toBe("Ultrathink:\nInvestigate the edge cases");
     expect(applyClaudePromptEffortPrefix("hello", "high")).toBe("hello");
   });
 });
 
 describe("resolveClaudeApiModelId", () => {
   it("appends [1m] for the 1M context window", () => {
-    expect(resolveClaudeApiModelId("claude-opus-5", "1m")).toBe("claude-opus-5[1m]");
-    expect(resolveClaudeApiModelId("claude-sonnet-5", "200k")).toBe("claude-sonnet-5");
+    expect(resolveClaudeApiModelId("claude-opus-5", "1m")).toBe(
+      "claude-opus-5[1m]",
+    );
+    expect(resolveClaudeApiModelId("claude-sonnet-5", "200k")).toBe(
+      "claude-sonnet-5",
+    );
   });
 });
 
@@ -80,7 +94,12 @@ describe("buildClaudeSpawnArgs", () => {
     expect(args).toContain("--include-partial-messages");
     expect(args).toContain("--setting-sources=user,project,local");
     expect(args).toEqual(
-      expect.arrayContaining(["--model", "claude-sonnet-5", "--effort", "high"]),
+      expect.arrayContaining([
+        "--model",
+        "claude-sonnet-5",
+        "--effort",
+        "high",
+      ]),
     );
     expect(args).toEqual(
       expect.arrayContaining(["--permission-mode", "acceptEdits"]),
@@ -177,19 +196,53 @@ describe("stream mapping", () => {
         type: "stream_event",
         event: {
           type: "content_block_delta",
+          index: 2,
           delta: { type: "text_delta", text: "Hi" },
         },
       }),
-    ).toEqual({ kind: "assistant", text: "Hi" });
+    ).toEqual({ kind: "assistant", contentIndex: 2, text: "Hi" });
     expect(
       streamDeltaFromEvent({
         type: "stream_event",
         event: {
           type: "content_block_delta",
+          index: 0,
           delta: { type: "thinking_delta", thinking: "hmm" },
         },
       }),
-    ).toEqual({ kind: "reasoning", text: "hmm" });
+    ).toEqual({ kind: "reasoning", contentIndex: 0, text: "hmm" });
+    expect(
+      streamDeltaFromEvent({
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          index: 3,
+          delta: { type: "text_delta", text: "\n" },
+        },
+      }),
+    ).toEqual({ kind: "assistant", contentIndex: 3, text: "\n" });
+  });
+
+  it("keeps completed content in native index order", () => {
+    expect(
+      completedAssistantParts({
+        message: {
+          content: [
+            { type: "text", text: "before" },
+            { type: "tool_use", id: "toolu_1", name: "Read", input: {} },
+            { type: "text", text: "after" },
+          ],
+        },
+      }),
+    ).toEqual([
+      { kind: "text", contentIndex: 0, text: "before" },
+      {
+        kind: "tool",
+        contentIndex: 1,
+        use: { id: "toolu_1", name: "Read", input: {} },
+      },
+      { kind: "text", contentIndex: 2, text: "after" },
+    ]);
   });
 
   it("reads tool_use content blocks", () => {
@@ -216,6 +269,109 @@ describe("stream mapping", () => {
   });
 });
 
+describe("Claude text state", () => {
+  it("reconciles streamed text by content index", () => {
+    const delta = applyClaudeTextDelta(createClaudeTextState(1), {
+      kind: "assistant",
+      contentIndex: 0,
+      text: "before",
+    });
+    expect(delta.event).toEqual({ type: "message.delta", text: "before" });
+    expect(
+      applyClaudeCompletedText(delta.state, {
+        kind: "text",
+        contentIndex: 0,
+        text: "before",
+      }).event,
+    ).toBeUndefined();
+  });
+
+  it("emits missing content only after the published index", () => {
+    let state = createClaudeTextState(1);
+    state = markClaudeContentPublished(state, 1);
+    const earlier = applyClaudeCompletedText(state, {
+      kind: "text",
+      contentIndex: 0,
+      text: "before",
+    });
+    expect(earlier.conflict).toBe("position");
+
+    const later = applyClaudeCompletedText(state, {
+      kind: "text",
+      contentIndex: 2,
+      text: "after",
+    });
+    expect(later.event).toEqual({ type: "message.delta", text: "after" });
+  });
+
+  it("replays a completed text-tool-text record in index order", () => {
+    const parts = completedAssistantParts({
+      message: {
+        content: [
+          { type: "text", text: "before" },
+          { type: "tool_use", id: "toolu_1", name: "Read", input: {} },
+          { type: "text", text: "after" },
+        ],
+      },
+    });
+    let state = createClaudeTextState(1);
+    const events: Array<{ type: string; text?: string; callId?: string }> = [];
+    for (const part of parts) {
+      if (part.kind === "tool") {
+        state = markClaudeContentPublished(state, part.contentIndex);
+        events.push({ type: "tool.started", callId: part.use.id });
+        continue;
+      }
+      const result = applyClaudeCompletedText(state, part);
+      state = result.state;
+      if (result.event) events.push(result.event);
+    }
+    expect(events).toEqual([
+      { type: "message.delta", text: "before" },
+      { type: "tool.started", callId: "toolu_1" },
+      { type: "message.delta", text: "after" },
+    ]);
+  });
+
+  it("keeps a partial text tail when completion repeats an earlier tool", () => {
+    let state = markClaudeContentPublished(createClaudeTextState(1), 1);
+    state = applyClaudeTextDelta(state, {
+      kind: "assistant",
+      contentIndex: 2,
+      text: "aft",
+    }).state;
+
+    const tool = reconcileClaudeCompletedTool(state, {
+      contentIndex: 1,
+      alreadyPublished: true,
+    });
+    const completed = applyClaudeCompletedText(tool.state, {
+      kind: "text",
+      contentIndex: 2,
+      text: "after",
+    });
+
+    expect(tool.publish).toBe(false);
+    expect(completed.event).toEqual({ type: "message.delta", text: "er" });
+  });
+
+  it("rejects a suffix after a tool invalidates the text tail", () => {
+    const delta = applyClaudeTextDelta(createClaudeTextState(1), {
+      kind: "assistant",
+      contentIndex: 0,
+      text: "hel",
+    });
+    const state = markClaudeContentPublished(delta.state, 1);
+    const completed = applyClaudeCompletedText(state, {
+      kind: "text",
+      contentIndex: 0,
+      text: "hello",
+    });
+    expect(completed.event).toBeUndefined();
+    expect(completed.conflict).toBe("position");
+  });
+});
+
 describe("turnStatusFromResult", () => {
   it("treats aborted terminals as interrupted", () => {
     expect(
@@ -234,12 +390,16 @@ describe("turnStatusFromResult", () => {
 
 describe("modelsForClaudeVersion", () => {
   it("hides Opus 5 until 2.1.219", () => {
-    const old = modelsForClaudeVersion("2.1.100").map((model) => model.nativeId);
+    const old = modelsForClaudeVersion("2.1.100").map(
+      (model) => model.nativeId,
+    );
     expect(old).not.toContain("claude-opus-5");
     expect(old).not.toContain("claude-opus-4-8");
     expect(old).toContain("claude-sonnet-4-6");
 
-    const next = modelsForClaudeVersion("2.1.233").map((model) => model.nativeId);
+    const next = modelsForClaudeVersion("2.1.233").map(
+      (model) => model.nativeId,
+    );
     expect(next).toContain("claude-opus-5");
     expect(next).toContain("claude-fable-5");
     expect(next).toContain("claude-sonnet-5");
@@ -359,7 +519,9 @@ describe("contextUsedFromAssistant", () => {
   });
 
   it("ignores a message with no usage", () => {
-    expect(contextUsedFromAssistant({ type: "assistant", message: {} })).toBeUndefined();
+    expect(
+      contextUsedFromAssistant({ type: "assistant", message: {} }),
+    ).toBeUndefined();
   });
 });
 
@@ -388,8 +550,16 @@ describe("contextFromResult", () => {
         cache_read_input_tokens: 90_000,
         output_tokens: 500,
         iterations: [
-          { input_tokens: 5, cache_read_input_tokens: 20_000, output_tokens: 200 },
-          { input_tokens: 5, cache_read_input_tokens: 70_000, output_tokens: 300 },
+          {
+            input_tokens: 5,
+            cache_read_input_tokens: 20_000,
+            output_tokens: 200,
+          },
+          {
+            input_tokens: 5,
+            cache_read_input_tokens: 70_000,
+            output_tokens: 300,
+          },
         ],
       },
       modelUsage: { "claude-opus-5": { contextWindow: 200000 } },

--- a/src/lib/harness/claudeProtocol.ts
+++ b/src/lib/harness/claudeProtocol.ts
@@ -1,5 +1,6 @@
 import type { Attachment, RuntimeMode, ToolPreview } from "../session";
 import { composeToolTitle, extractToolPreview } from "./preview";
+import { classifyCompletedText } from "./streamText";
 import type { ApprovalDecision, HarnessEvent } from "./types";
 
 /** Claude Code versions that first ship Opus 5 / Fable 5 / Opus 4.8 / 4.7. */
@@ -398,22 +399,154 @@ export function turnStatusFromResult(rec: Record<string, unknown>): {
   return { status: "failed", error: error ?? "Claude turn failed." };
 }
 
-export function streamDeltaFromEvent(
-  rec: Record<string, unknown>,
-): { kind: "assistant" | "reasoning"; text: string } | null {
+export type ClaudeTextState = {
+  recordSequence: number;
+  entries: ReadonlyMap<string, string>;
+  tailKey: string | null;
+  highestPublishedContentIndex: number;
+  fallbackAllowed: boolean;
+};
+
+export type ClaudeTextStateResult = {
+  state: ClaudeTextState;
+  event?: Extract<HarnessEvent, { type: "message.delta" | "reasoning.delta" }>;
+  conflict?: "position" | "text";
+};
+
+export function createClaudeTextState(recordSequence: number): ClaudeTextState {
+  return {
+    recordSequence,
+    entries: new Map(),
+    tailKey: null,
+    highestPublishedContentIndex: -1,
+    fallbackAllowed: true,
+  };
+}
+
+export function invalidateClaudeTextTail(
+  state: ClaudeTextState,
+): ClaudeTextState {
+  return { ...state, tailKey: null, fallbackAllowed: false };
+}
+
+export function markClaudeContentPublished(
+  state: ClaudeTextState,
+  contentIndex: number,
+): ClaudeTextState {
+  return {
+    ...state,
+    tailKey: null,
+    highestPublishedContentIndex: Math.max(
+      state.highestPublishedContentIndex,
+      contentIndex,
+    ),
+  };
+}
+
+export function reconcileClaudeCompletedTool(
+  state: ClaudeTextState,
+  input: { contentIndex: number; alreadyPublished: boolean },
+): { state: ClaudeTextState; publish: boolean } {
+  if (input.alreadyPublished) return { state, publish: false };
+  return {
+    state: markClaudeContentPublished(state, input.contentIndex),
+    publish: true,
+  };
+}
+
+export function applyClaudeTextDelta(
+  state: ClaudeTextState,
+  delta: {
+    kind: "assistant" | "reasoning";
+    contentIndex: number;
+    text: string;
+  },
+): ClaudeTextStateResult {
+  const key = `${delta.kind}:${delta.contentIndex}`;
+  const entries = new Map(state.entries);
+  entries.set(key, (entries.get(key) ?? "") + delta.text);
+  return {
+    state: {
+      ...state,
+      entries,
+      tailKey: key,
+      highestPublishedContentIndex: Math.max(
+        state.highestPublishedContentIndex,
+        delta.contentIndex,
+      ),
+    },
+    event: claudeTextEvent(delta.kind, delta.text),
+  };
+}
+
+export function applyClaudeCompletedText(
+  state: ClaudeTextState,
+  part: Extract<ClaudeCompletedPart, { kind: "text" | "thinking" }>,
+): ClaudeTextStateResult {
+  const role = part.kind === "text" ? "assistant" : "reasoning";
+  const key = `${role}:${part.contentIndex}`;
+  const streamed = state.entries.get(key);
+  const relationship = classifyCompletedText({
+    streamed: streamed ?? "",
+    completed: part.text,
+  });
+  if (relationship.kind === "already-emitted") return { state };
+  if (relationship.kind === "conflict") {
+    return { state, conflict: "text" };
+  }
+  const positionSafe =
+    streamed === undefined
+      ? state.fallbackAllowed &&
+        part.contentIndex > state.highestPublishedContentIndex
+      : state.tailKey === key;
+  if (!positionSafe) return { state, conflict: "position" };
+
+  const text =
+    relationship.kind === "fallback" ? relationship.text : relationship.suffix;
+  const entries = new Map(state.entries);
+  entries.set(key, part.text);
+  return {
+    state: {
+      ...state,
+      entries,
+      tailKey: key,
+      highestPublishedContentIndex: Math.max(
+        state.highestPublishedContentIndex,
+        part.contentIndex,
+      ),
+    },
+    ...(text ? { event: claudeTextEvent(role, text) } : {}),
+  };
+}
+
+function claudeTextEvent(
+  role: "assistant" | "reasoning",
+  text: string,
+): Extract<HarnessEvent, { type: "message.delta" | "reasoning.delta" }> {
+  return role === "assistant"
+    ? { type: "message.delta", text }
+    : { type: "reasoning.delta", text };
+}
+
+export function streamDeltaFromEvent(rec: Record<string, unknown>): {
+  kind: "assistant" | "reasoning";
+  contentIndex: number;
+  text: string;
+} | null {
   const event = asRecord(rec.event);
   if (!event || stringField(event, "type") !== "content_block_delta") {
     return null;
   }
+  const contentIndex = typeof event.index === "number" ? event.index : -1;
   const delta = asRecord(event.delta);
   const deltaType = stringField(delta, "type") ?? "";
   if (deltaType === "text_delta") {
     const text = typeof delta?.text === "string" ? delta.text : "";
-    return text ? { kind: "assistant", text } : null;
+    return text ? { kind: "assistant", contentIndex, text } : null;
   }
   if (deltaType === "thinking_delta") {
     const text = typeof delta?.thinking === "string" ? delta.thinking : "";
-    return text ? { kind: "reasoning", text } : null;
+    return text ? { kind: "reasoning", contentIndex, text } : null;
   }
   return null;
 }
@@ -471,6 +604,47 @@ export function isSubagentMessage(rec: Record<string, unknown>): boolean {
   return typeof parent === "string" && parent.length > 0;
 }
 
+export type ClaudeToolUse = {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+};
+
+export type ClaudeCompletedPart =
+  | { kind: "text"; contentIndex: number; text: string }
+  | { kind: "thinking"; contentIndex: number; text: string }
+  | { kind: "tool"; contentIndex: number; use: ClaudeToolUse };
+
+export function completedAssistantParts(
+  rec: Record<string, unknown>,
+): ClaudeCompletedPart[] {
+  const content = asRecord(rec.message)?.content;
+  if (!Array.isArray(content)) return [];
+  return content.flatMap((block, contentIndex): ClaudeCompletedPart[] => {
+    const row = asRecord(block);
+    const type = stringField(row, "type");
+    if (type === "text") {
+      const text = typeof row?.text === "string" ? row.text : "";
+      return text ? [{ kind: "text", contentIndex, text }] : [];
+    }
+    if (type === "thinking") {
+      const text = typeof row?.thinking === "string" ? row.thinking : "";
+      return text ? [{ kind: "thinking", contentIndex, text }] : [];
+    }
+    if (type !== "tool_use") return [];
+    const id = stringField(row, "id");
+    const name = stringField(row, "name");
+    if (!id || !name) return [];
+    return [
+      {
+        kind: "tool",
+        contentIndex,
+        use: { id, name, input: asRecord(row?.input) ?? {} },
+      },
+    ];
+  });
+}
+
 export function assistantTextBlocks(rec: Record<string, unknown>): string[] {
   const message = asRecord(rec.message);
   const content = message?.content;
@@ -483,11 +657,9 @@ export function assistantTextBlocks(rec: Record<string, unknown>): string[] {
   });
 }
 
-export function assistantToolUses(rec: Record<string, unknown>): Array<{
-  id: string;
-  name: string;
-  input: Record<string, unknown>;
-}> {
+export function assistantToolUses(
+  rec: Record<string, unknown>,
+): ClaudeToolUse[] {
   const message = asRecord(rec.message);
   const content = message?.content;
   if (!Array.isArray(content)) return [];

--- a/src/lib/harness/claudeText.ts
+++ b/src/lib/harness/claudeText.ts
@@ -8,6 +8,7 @@ import {
   writeChild,
 } from "./child";
 import {
+  asRecord,
   assistantTextBlocks,
   buildClaudeSpawnArgs,
   buildClaudeUserMessage,
@@ -15,7 +16,13 @@ import {
   stringField,
   turnStatusFromResult,
 } from "./claudeProtocol";
-import { mergeStream } from "./streamText";
+import {
+  applyCollectedTextUpdate,
+  createCollectedTextState,
+  selectCollectedText,
+  type CollectedTextState,
+  type CollectedTextUpdate,
+} from "./streamText";
 
 const TEXT_CHILD_ID = "monocode-claude-text";
 const INIT_TIMEOUT_MS = 8_000;
@@ -25,7 +32,8 @@ const TEXT_MODEL = "claude-haiku-4-5";
 type LiveText = {
   cwd: string;
   collecting: boolean;
-  output: string;
+  textState: CollectedTextState;
+  recordSequence: number;
   closed: boolean;
   ready: boolean;
   turnDone: (() => void) | null;
@@ -35,6 +43,11 @@ type LiveText = {
 
 let live: LiveText | null = null;
 let turns: Promise<void> = Promise.resolve();
+
+export function requireClaudeTextOutput(output: string): string {
+  if (!output.trim()) throw new Error("Claude returned empty output.");
+  return output;
+}
 
 function pickTextModel(): string {
   const models = modelsFor("claude");
@@ -50,9 +63,11 @@ export async function stopClaudeTextPrompt(): Promise<void> {
 
 export function warmupClaudeText(cwd: string): Promise<void> {
   if (!cwd || cwd === "~") return Promise.resolve();
-  const run = turns.catch(() => undefined).then(async () => {
-    await ensureLive(cwd);
-  });
+  const run = turns
+    .catch(() => undefined)
+    .then(async () => {
+      await ensureLive(cwd);
+    });
   turns = run.then(
     () => undefined,
     () => undefined,
@@ -79,7 +94,8 @@ async function promptOnLive(input: {
   timeoutMs?: number;
 }): Promise<string> {
   const session = await ensureLive(input.cwd);
-  session.output = "";
+  session.textState = createCollectedTextState();
+  session.recordSequence = 0;
   session.collecting = true;
   const timeoutMs = input.timeoutMs ?? REQUEST_TIMEOUT_MS;
 
@@ -104,9 +120,7 @@ async function promptOnLive(input: {
       }),
     ]);
 
-    const output = session.output.trim();
-    if (!output) throw new Error("Claude returned empty output.");
-    return output;
+    return requireClaudeTextOutput(selectCollectedText(session.textState));
   } catch (error) {
     if (session.closed) await dropLive();
     throw error;
@@ -128,7 +142,8 @@ async function startLive(cwd: string): Promise<LiveText> {
   const session: LiveText = {
     cwd,
     collecting: false,
-    output: "",
+    textState: createCollectedTextState(),
+    recordSequence: 0,
     closed: false,
     ready: false,
     turnDone: null,
@@ -186,6 +201,23 @@ async function dropLive(): Promise<void> {
   await killChild(TEXT_CHILD_ID).catch(() => undefined);
 }
 
+export function claudeTextUpdateFromRecord(
+  rec: Record<string, unknown>,
+  scopeId: string,
+): CollectedTextUpdate | null {
+  const type = stringField(rec, "type");
+  if (type === "assistant") {
+    const text = assistantTextBlocks(rec).join("");
+    return text ? { kind: "completed", scopeId, text } : null;
+  }
+  if (type !== "stream_event") return null;
+  const delta = asRecord(asRecord(rec.event)?.delta);
+  return stringField(delta, "type") === "text_delta" &&
+    typeof delta?.text === "string"
+    ? { kind: "delta", scopeId, text: delta.text }
+    : null;
+}
+
 function handleLine(session: LiveText, line: string): void {
   const rec = parseJsonLine(line);
   if (!rec) return;
@@ -200,20 +232,18 @@ function handleLine(session: LiveText, line: string): void {
     session.readyDone = null;
   }
   if (!session.collecting) return;
+  const update = claudeTextUpdateFromRecord(
+    rec,
+    `record:${session.recordSequence}`,
+  );
+  if (update) {
+    session.textState = applyCollectedTextUpdate(session.textState, update);
+  }
   if (type === "assistant") {
-    const snapshot = assistantTextBlocks(rec).join("");
-    if (snapshot) session.output = mergeStream(session.output, snapshot);
+    session.recordSequence += 1;
     return;
   }
-  if (type === "stream_event") {
-    const event = rec.event;
-    if (!event || typeof event !== "object") return;
-    const delta = (event as { delta?: { type?: string; text?: string } }).delta;
-    if (delta?.type === "text_delta" && typeof delta.text === "string") {
-      session.output = mergeStream(session.output, delta.text);
-    }
-    return;
-  }
+  if (update) return;
   if (type === "result") {
     const result = turnStatusFromResult(rec);
     if (result.status === "failed") {

--- a/src/lib/harness/codex.ts
+++ b/src/lib/harness/codex.ts
@@ -8,18 +8,27 @@ import {
   watchChild,
 } from "./child";
 import {
+  applyCodexTextUpdate,
   asRecord,
   buildThreadStartParams,
   buildTurnStartParams,
   buildTurnSteerParams,
+  createCodexTextState,
   isRecoverableThreadResumeError,
   mapApprovalRequest,
+  invalidateCodexTextTail,
   mapCodexNotification,
   toCodexApprovalDecision,
   type CodexApprovalKind,
+  type CodexTextState,
 } from "./codexProtocol";
 import { JsonRpcClient, type JsonRpcId } from "./jsonRpc";
-import type { ApprovalDecision, HarnessEvent, SendTurnInput, SteerTurnInput } from "./types";
+import type {
+  ApprovalDecision,
+  HarnessEvent,
+  SendTurnInput,
+  SteerTurnInput,
+} from "./types";
 
 type PendingApproval = {
   rpcId: JsonRpcId;
@@ -45,6 +54,7 @@ type Live = {
   /** turn/completed arrived before runTurn registered turnDone. */
   turnEndPending: boolean;
   turnWatchdog?: ReturnType<typeof setTimeout>;
+  textState: CodexTextState;
 };
 
 const TURN_WATCHDOG_MS = 2_000;
@@ -58,7 +68,8 @@ const liveByThread = new Map<string, Live>();
 const resumeByThread = new Map<string, Resume>();
 const cancelledThreads = new Set<string>();
 
-let resolveCodexBinaryImpl: () => Promise<{ path: string }> = resolveCodexBinary;
+let resolveCodexBinaryImpl: () => Promise<{ path: string }> =
+  resolveCodexBinary;
 
 /** Test seam. */
 export function setCodexBinaryResolver(
@@ -79,16 +90,18 @@ export async function sendCodexTurn(input: SendTurnInput): Promise<void> {
 
   live.onEvent = input.onEvent;
   live.runtimeMode = input.runtimeMode;
-  live.turns = live.turns.catch(() => undefined).then(async () => {
-    live.cancelled = false;
-    live.muteUpdates = false;
-    try {
-      await runTurn(live, input);
-    } catch (error) {
-      if (live.cancelled) return;
-      throw error;
-    }
-  });
+  live.turns = live.turns
+    .catch(() => undefined)
+    .then(async () => {
+      live.cancelled = false;
+      live.muteUpdates = false;
+      try {
+        await runTurn(live, input);
+      } catch (error) {
+        if (live.cancelled) return;
+        throw error;
+      }
+    });
   await live.turns;
 }
 
@@ -112,6 +125,7 @@ export async function steerCodexTurn(input: SteerTurnInput): Promise<void> {
     return;
   }
 
+  live.textState = invalidateCodexTextTail(live.textState);
   await live.rpc.request("turn/steer", params);
 }
 
@@ -314,6 +328,7 @@ async function ensureLive(input: SendTurnInput): Promise<Live> {
       turnDone: null,
       turnFailed: null,
       turnEndPending: false,
+      textState: createCodexTextState(),
     };
     liveRef.current = live;
     liveByThread.set(input.sessionId, live);
@@ -359,6 +374,7 @@ async function runTurn(live: Live, input: SendTurnInput): Promise<void> {
     return;
   }
 
+  live.textState = createCodexTextState();
   const turnPromise = new Promise<void>((resolve, reject) => {
     live.turnDone = resolve;
     live.turnFailed = reject;
@@ -389,13 +405,17 @@ async function runTurn(live: Live, input: SendTurnInput): Promise<void> {
   }
 }
 
-function handleNotification(
-  live: Live,
-  method: string,
-  params: unknown,
-): void {
+function handleNotification(live: Live, method: string, params: unknown): void {
   const mapped = mapCodexNotification(method, params);
+  for (const update of mapped.textUpdates ?? []) {
+    const result = applyCodexTextUpdate(live.textState, update);
+    live.textState = result.state;
+    if (result.event) live.onEvent(result.event);
+  }
   for (const event of mapped.events) {
+    if (invalidatesCodexTextTail(event)) {
+      live.textState = invalidateCodexTextTail(live.textState);
+    }
     live.onEvent(event);
   }
   if (mapped.activeTurnId !== undefined) {
@@ -409,6 +429,19 @@ function handleNotification(
   }
 }
 
+function invalidatesCodexTextTail(event: HarnessEvent): boolean {
+  return (
+    event.type === "message.completed" ||
+    event.type === "reasoning.completed" ||
+    event.type === "tool.started" ||
+    event.type === "tool.updated" ||
+    event.type === "approval.requested" ||
+    event.type === "plan" ||
+    event.type === "status" ||
+    event.type === "session.error"
+  );
+}
+
 function finishActiveTurn(live: Live, extraEvents: HarnessEvent[] = []): void {
   if (live.turnWatchdog) {
     clearTimeout(live.turnWatchdog);
@@ -419,6 +452,7 @@ function finishActiveTurn(live: Live, extraEvents: HarnessEvent[] = []): void {
   for (const event of extraEvents) {
     live.onEvent(event);
   }
+  live.textState = createCodexTextState();
   const done = live.turnDone;
   const failed = live.turnFailed;
   live.turnDone = null;

--- a/src/lib/harness/codexProtocol.test.ts
+++ b/src/lib/harness/codexProtocol.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyCodexTextUpdate,
   buildThreadStartParams,
   buildTurnStartParams,
   buildTurnSteerParams,
+  createCodexTextState,
+  invalidateCodexTextTail,
   isRecoverableThreadResumeError,
   mapApprovalRequest,
   mapCodexNotification,
@@ -102,9 +105,9 @@ describe("isRecoverableThreadResumeError", () => {
     expect(
       isRecoverableThreadResumeError(new Error("Thread thr_x not found")),
     ).toBe(true);
-    expect(
-      isRecoverableThreadResumeError(new Error("unknown thread id")),
-    ).toBe(true);
+    expect(isRecoverableThreadResumeError(new Error("unknown thread id"))).toBe(
+      true,
+    );
   });
 
   it("rejects unrelated errors", () => {
@@ -120,18 +123,70 @@ describe("isRecoverableThreadResumeError", () => {
 describe("mapCodexNotification", () => {
   it("maps agent message deltas", () => {
     const mapped = mapCodexNotification("item/agentMessage/delta", {
+      itemId: "msg_1",
       delta: "Hello",
     });
-    expect(mapped.events).toEqual([{ type: "message.delta", text: "Hello" }]);
+    expect(mapped.textUpdates).toEqual([
+      {
+        kind: "delta",
+        itemId: "msg_1",
+        channel: "assistant",
+        text: "Hello",
+      },
+    ]);
+    expect(mapped.events).toEqual([]);
+  });
+
+  it("preserves whitespace-only identified deltas", () => {
+    const mapped = mapCodexNotification("item/agentMessage/delta", {
+      itemId: "msg_1",
+      delta: "\n\n",
+    });
+    expect(mapped.textUpdates).toEqual([
+      {
+        kind: "delta",
+        itemId: "msg_1",
+        channel: "assistant",
+        text: "\n\n",
+      },
+    ]);
   });
 
   it("maps reasoning summary deltas", () => {
     const mapped = mapCodexNotification("item/reasoning/summaryTextDelta", {
+      itemId: "reason_1",
       delta: "thinking…",
     });
-    expect(mapped.events).toEqual([
-      { type: "reasoning.delta", text: "thinking…" },
+    expect(mapped.textUpdates).toEqual([
+      {
+        kind: "delta",
+        itemId: "reason_1",
+        channel: "reasoning-summary",
+        text: "thinking…",
+      },
     ]);
+  });
+
+  it("retains completed agent message identity", () => {
+    const mapped = mapCodexNotification("item/completed", {
+      item: { id: "msg_1", type: "agentMessage", text: "Hello" },
+    });
+    expect(mapped.textUpdates).toEqual([
+      {
+        kind: "completed",
+        itemId: "msg_1",
+        channel: "assistant",
+        text: "Hello",
+      },
+    ]);
+    expect(mapped.events).toEqual([{ type: "message.completed" }]);
+    expect(mapped.scheduleTurnWatchdog).toBe(true);
+  });
+
+  it("rejects anonymous text deltas", () => {
+    expect(
+      mapCodexNotification("item/agentMessage/delta", { delta: "Hello" }),
+    ).toEqual({ events: [] });
   });
 
   it("ignores userMessage items echoed by Codex", () => {
@@ -247,9 +302,85 @@ describe("mapCodexNotification", () => {
   });
 
   it("ignores unknown methods", () => {
-    expect(mapCodexNotification("future/unknown", { x: 1 }).events).toEqual(
-      [],
+    expect(mapCodexNotification("future/unknown", { x: 1 }).events).toEqual([]);
+  });
+});
+
+describe("Codex text state", () => {
+  it("deduplicates an equal completed value", () => {
+    let state = createCodexTextState();
+    state = applyCodexTextUpdate(state, {
+      kind: "started",
+      itemId: "msg_1",
+      channel: "assistant",
+    }).state;
+    const delta = applyCodexTextUpdate(state, {
+      kind: "delta",
+      itemId: "msg_1",
+      channel: "assistant",
+      text: "Hello",
+    });
+    expect(delta.event).toEqual({ type: "message.delta", text: "Hello" });
+
+    const completed = applyCodexTextUpdate(delta.state, {
+      kind: "completed",
+      itemId: "msg_1",
+      channel: "assistant",
+      text: "Hello",
+    });
+    expect(completed.event).toBeUndefined();
+    expect(completed.conflict).toBeUndefined();
+  });
+
+  it("emits a completed-only fallback while the item is at the tail", () => {
+    const started = applyCodexTextUpdate(createCodexTextState(), {
+      kind: "started",
+      itemId: "msg_1",
+      channel: "assistant",
+    });
+    const completed = applyCodexTextUpdate(started.state, {
+      kind: "completed",
+      itemId: "msg_1",
+      channel: "assistant",
+      text: "Hello",
+    });
+    expect(completed.event).toEqual({ type: "message.delta", text: "Hello" });
+  });
+
+  it("rejects a completion after another transcript operation", () => {
+    const started = applyCodexTextUpdate(createCodexTextState(), {
+      kind: "started",
+      itemId: "msg_1",
+      channel: "assistant",
+    });
+    const completed = applyCodexTextUpdate(
+      invalidateCodexTextTail(started.state),
+      {
+        kind: "completed",
+        itemId: "msg_1",
+        channel: "assistant",
+        text: "Hello",
+      },
     );
+    expect(completed.event).toBeUndefined();
+    expect(completed.conflict).toBe("position");
+  });
+
+  it("rejects divergent completed text", () => {
+    const delta = applyCodexTextUpdate(createCodexTextState(), {
+      kind: "delta",
+      itemId: "msg_1",
+      channel: "assistant",
+      text: "help",
+    });
+    const completed = applyCodexTextUpdate(delta.state, {
+      kind: "completed",
+      itemId: "msg_1",
+      channel: "assistant",
+      text: "hello",
+    });
+    expect(completed.event).toBeUndefined();
+    expect(completed.conflict).toBe("text");
   });
 });
 
@@ -316,9 +447,9 @@ describe("parseCodexModelList", () => {
     const luna = models.find((m) => m.nativeId === "gpt-5.6-luna");
     expect(luna?.settings?.some((s) => s.id === "reasoningEffort")).toBe(true);
     expect(luna?.settings?.some((s) => s.id === "serviceTier")).toBe(true);
-    expect(
-      luna?.settings?.find((s) => s.id === "reasoningEffort")?.value,
-    ).toBe("medium");
+    expect(luna?.settings?.find((s) => s.id === "reasoningEffort")?.value).toBe(
+      "medium",
+    );
   });
 });
 

--- a/src/lib/harness/codexProtocol.ts
+++ b/src/lib/harness/codexProtocol.ts
@@ -1,8 +1,6 @@
 import type { RuntimeMode, ToolPreview } from "../session";
-import {
-  composeToolTitle,
-  extractToolPreview,
-} from "./preview";
+import { composeToolTitle, extractToolPreview } from "./preview";
+import { classifyCompletedText } from "./streamText";
 import type { HarnessEvent } from "./types";
 
 /** Codex approval / sandbox settings for thread/start and turn/start. */
@@ -150,6 +148,15 @@ export function stringField(
   return typeof value === "string" && value.trim() ? value : undefined;
 }
 
+export function textField(
+  rec: Record<string, unknown> | null | undefined,
+  key: string,
+): string | undefined {
+  if (!rec) return undefined;
+  const value = rec[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 function numberField(
   rec: Record<string, unknown> | null | undefined,
   key: string,
@@ -161,10 +168,7 @@ function numberField(
 export type CodexApprovalKind = "command" | "file-change" | "permissions";
 
 export type CodexApprovalDecisionWire =
-  | "accept"
-  | "acceptForSession"
-  | "decline"
-  | "cancel";
+  "accept" | "acceptForSession" | "decline" | "cancel";
 
 export function toCodexApprovalDecision(
   decision: "allow" | "deny",
@@ -176,8 +180,98 @@ export function toCodexApprovalDecision(
   return "accept";
 }
 
+export type CodexTextChannel =
+  "assistant" | "reasoning-summary" | "reasoning-content";
+
+export type CodexTextUpdate =
+  | {
+      kind: "started";
+      itemId: string;
+      channel: CodexTextChannel;
+    }
+  | {
+      kind: "delta" | "completed";
+      itemId: string;
+      channel: CodexTextChannel;
+      text: string;
+    };
+
+type CodexTextLedgerEntry = {
+  streamed: string;
+};
+
+export type CodexTextState = {
+  entries: ReadonlyMap<string, CodexTextLedgerEntry>;
+  tailKey: string | null;
+};
+
+export type CodexTextUpdateResult = {
+  state: CodexTextState;
+  event?: Extract<HarnessEvent, { type: "message.delta" | "reasoning.delta" }>;
+  conflict?: "position" | "text";
+};
+
+export function createCodexTextState(): CodexTextState {
+  return { entries: new Map(), tailKey: null };
+}
+
+export function invalidateCodexTextTail(state: CodexTextState): CodexTextState {
+  return state.tailKey === null ? state : { ...state, tailKey: null };
+}
+
+export function applyCodexTextUpdate(
+  state: CodexTextState,
+  update: CodexTextUpdate,
+): CodexTextUpdateResult {
+  const key = `${update.itemId}:${update.channel}`;
+  const entries = new Map(state.entries);
+  if (update.kind === "started") {
+    entries.set(key, { streamed: "" });
+    return { state: { entries, tailKey: key } };
+  }
+
+  const current = entries.get(key);
+  if (update.kind === "delta") {
+    const streamed = (current?.streamed ?? "") + update.text;
+    entries.set(key, { streamed });
+    return {
+      state: { entries, tailKey: key },
+      event: codexTextEvent(update.channel, update.text),
+    };
+  }
+
+  const relationship = classifyCompletedText({
+    streamed: current?.streamed ?? "",
+    completed: update.text,
+  });
+  if (relationship.kind === "already-emitted") return { state };
+  if (relationship.kind === "conflict") {
+    return { state, conflict: "text" };
+  }
+  if (!current || state.tailKey !== key) {
+    return { state, conflict: "position" };
+  }
+  const text =
+    relationship.kind === "fallback" ? relationship.text : relationship.suffix;
+  entries.set(key, { streamed: update.text });
+  return {
+    state: { entries, tailKey: key },
+    ...(text ? { event: codexTextEvent(update.channel, text) } : {}),
+  };
+}
+
+function codexTextEvent(
+  channel: CodexTextChannel,
+  text: string,
+): Extract<HarnessEvent, { type: "message.delta" | "reasoning.delta" }> {
+  return channel === "assistant"
+    ? { type: "message.delta", text }
+    : { type: "reasoning.delta", text };
+}
+
 export type MappedCodexNotification = {
   events: HarnessEvent[];
+  textUpdates?: CodexTextUpdate[];
   /** When set, the active turn finished. */
   turnCompleted?: {
     status: "completed" | "failed" | "interrupted" | "cancelled";
@@ -200,25 +294,19 @@ export function mapCodexNotification(
   if (!rec) return { events: [] };
 
   if (method === "item/agentMessage/delta") {
-    const delta = stringField(rec, "delta") ?? "";
-    if (!delta) return { events: [] };
-    return { events: [{ type: "message.delta", text: delta }] };
+    return mapCodexTextDelta(rec, "assistant");
   }
 
   if (method === "item/reasoning/summaryTextDelta") {
-    const delta = stringField(rec, "delta") ?? "";
-    if (!delta) return { events: [] };
-    return { events: [{ type: "reasoning.delta", text: delta }] };
+    return mapCodexTextDelta(rec, "reasoning-summary");
   }
 
   if (method === "item/reasoning/textDelta") {
-    const delta = stringField(rec, "delta") ?? "";
-    if (!delta) return { events: [] };
-    return { events: [{ type: "reasoning.delta", text: delta }] };
+    return mapCodexTextDelta(rec, "reasoning-content");
   }
 
   if (method === "item/plan/delta") {
-    const delta = stringField(rec, "delta") ?? "";
+    const delta = textField(rec, "delta") ?? "";
     if (!delta) return { events: [] };
     return { events: [{ type: "plan", text: delta }] };
   }
@@ -245,7 +333,7 @@ export function mapCodexNotification(
 
   if (method === "item/commandExecution/outputDelta") {
     const itemId = stringField(rec, "itemId") ?? "";
-    const delta = stringField(rec, "delta") ?? "";
+    const delta = textField(rec, "delta") ?? "";
     if (!itemId || !delta) return { events: [] };
     return {
       events: [
@@ -304,6 +392,19 @@ export function mapCodexNotification(
   }
 
   return { events: [] };
+}
+
+function mapCodexTextDelta(
+  rec: Record<string, unknown>,
+  channel: CodexTextChannel,
+): MappedCodexNotification {
+  const itemId = stringField(rec, "itemId");
+  const delta = textField(rec, "delta");
+  if (!itemId || !delta) return { events: [] };
+  return {
+    events: [],
+    textUpdates: [{ kind: "delta", itemId, channel, text: delta }],
+  };
 }
 
 /** Codex thread items MonoCode already renders elsewhere or that are internal metadata. */
@@ -398,48 +499,71 @@ function mapItemLifecycle(
   }
 
   if (itemType === "agentMessage") {
-    // Prefer deltas; completed agent messages may carry full text for non-streaming.
-    if (completed) {
-      const text = stringField(item, "text");
-      const events: HarnessEvent[] = [];
-      if (text) {
-        events.push(
-          { type: "message.delta", text },
-          { type: "message.completed" },
-        );
-      }
+    if (!completed) {
       return {
-        events,
-        scheduleTurnWatchdog: true,
+        events: [],
+        textUpdates: [
+          { kind: "started", itemId: callId, channel: "assistant" },
+        ],
       };
     }
-    return { events: [] };
+    const text = textField(item, "text");
+    return {
+      events: [{ type: "message.completed" }],
+      ...(text
+        ? {
+            textUpdates: [
+              {
+                kind: "completed",
+                itemId: callId,
+                channel: "assistant",
+                text,
+              },
+            ],
+          }
+        : {}),
+      scheduleTurnWatchdog: true,
+    };
   }
 
   if (itemType === "reasoning") {
-    if (completed) {
-      const summary = item.summary;
-      if (Array.isArray(summary)) {
-        const text = summary
+    if (!completed) {
+      return {
+        events: [],
+        textUpdates: [
+          {
+            kind: "started",
+            itemId: callId,
+            channel: "reasoning-summary",
+          },
+        ],
+      };
+    }
+    const summary = item.summary;
+    const text = Array.isArray(summary)
+      ? summary
           .map((part) => {
             if (typeof part === "string") return part;
-            const row = asRecord(part);
-            return stringField(row, "text") ?? "";
+            return textField(asRecord(part), "text") ?? "";
           })
           .filter(Boolean)
-          .join("\n");
-        if (text) {
-          return {
-            events: [
-              { type: "reasoning.delta", text },
-              { type: "reasoning.completed" },
+          .join("\n")
+      : "";
+    return {
+      events: [{ type: "reasoning.completed" }],
+      ...(text
+        ? {
+            textUpdates: [
+              {
+                kind: "completed",
+                itemId: callId,
+                channel: "reasoning-summary",
+                text,
+              },
             ],
-          };
-        }
-      }
-      return { events: [{ type: "reasoning.completed" }] };
-    }
-    return { events: [] };
+          }
+        : {}),
+    };
   }
 
   if (itemType === "plan") {
@@ -464,8 +588,7 @@ function mapToolItem(
     const command = stringField(item, "command") ?? "Shell";
     const status = mapItemStatus(stringField(item, "status"), completed);
     const output =
-      stringField(item, "aggregatedOutput") ??
-      stringField(item, "output");
+      stringField(item, "aggregatedOutput") ?? stringField(item, "output");
     const preview: ToolPreview | undefined = undefined;
     const eventType = completed ? "tool.updated" : "tool.started";
     if (eventType === "tool.started") {
@@ -655,10 +778,7 @@ function buildDiffPreview(
   );
 }
 
-function mapItemStatus(
-  status: string | undefined,
-  completed: boolean,
-): string {
+function mapItemStatus(status: string | undefined, completed: boolean): string {
   if (status === "completed" || status === "failed" || status === "declined") {
     return status === "declined" ? "failed" : status;
   }

--- a/src/lib/harness/codexText.ts
+++ b/src/lib/harness/codexText.ts
@@ -11,9 +11,16 @@ import {
   buildThreadStartParams,
   buildTurnStartParams,
   stringField,
+  textField,
 } from "./codexProtocol";
 import { JsonRpcClient, type JsonRpcId } from "./jsonRpc";
-import { mergeStream } from "./streamText";
+import {
+  applyCollectedTextUpdate,
+  createCollectedTextState,
+  selectCollectedText,
+  type CollectedTextState,
+  type CollectedTextUpdate,
+} from "./streamText";
 
 const TEXT_CHILD_ID = "monocode-codex-text";
 const INIT_TIMEOUT_MS = 60_000;
@@ -29,7 +36,7 @@ type LiveText = {
   model: string;
   effort: string;
   collecting: boolean;
-  output: string;
+  textState: CollectedTextState;
   closed: boolean;
   turnDone: (() => void) | null;
   turnFailed: ((error: Error) => void) | null;
@@ -48,7 +55,9 @@ function pickTextModel(): string {
 
 function pickTextEffort(modelId: string): string {
   const model = modelsFor("codex").find((entry) => entry.nativeId === modelId);
-  const setting = model?.settings?.find((entry) => entry.id === "reasoningEffort");
+  const setting = model?.settings?.find(
+    (entry) => entry.id === "reasoningEffort",
+  );
   const options = setting?.options?.map((option) => option.value) ?? [];
   if (options.includes("low")) return "low";
   if (options.includes("none")) return "none";
@@ -63,9 +72,11 @@ export async function stopCodexTextPrompt(): Promise<void> {
 /** Start the shared Codex app-server in the background so the first prompt is fast. */
 export function warmupCodexText(cwd: string): Promise<void> {
   if (!cwd || cwd === "~") return Promise.resolve();
-  const run = turns.catch(() => undefined).then(async () => {
-    await ensureLive(cwd);
-  });
+  const run = turns
+    .catch(() => undefined)
+    .then(async () => {
+      await ensureLive(cwd);
+    });
   turns = run.then(
     () => undefined,
     () => undefined,
@@ -93,7 +104,7 @@ async function promptOnLive(input: {
   timeoutMs?: number;
 }): Promise<string> {
   const session = await ensureLive(input.cwd);
-  session.output = "";
+  session.textState = createCollectedTextState();
   session.collecting = true;
   const timeoutMs = input.timeoutMs ?? REQUEST_TIMEOUT_MS;
 
@@ -125,7 +136,7 @@ async function promptOnLive(input: {
       }),
     ]);
 
-    return session.output;
+    return selectCollectedText(session.textState);
   } catch (error) {
     await session.rpc
       .request("turn/interrupt", { threadId: session.threadId })
@@ -183,7 +194,7 @@ async function startLive(cwd: string): Promise<LiveText> {
     model,
     effort: pickTextEffort(model),
     collecting: false,
-    output: "",
+    textState: createCollectedTextState(),
     closed: false,
     turnDone: null,
     turnFailed: null,
@@ -257,6 +268,25 @@ async function dropLive(): Promise<void> {
   await killChild(TEXT_CHILD_ID).catch(() => undefined);
 }
 
+export function codexTextUpdateFromNotification(
+  method: string,
+  params: unknown,
+): CollectedTextUpdate | null {
+  const rec = asRecord(params);
+  if (method === "item/agentMessage/delta") {
+    const scopeId =
+      stringField(rec, "itemId") ?? stringField(rec, "item_id");
+    const text = textField(rec, "delta");
+    return scopeId && text ? { kind: "delta", scopeId, text } : null;
+  }
+  if (method !== "item/completed") return null;
+  const item = asRecord(rec?.item);
+  if (stringField(item, "type") !== "agentMessage") return null;
+  const scopeId = stringField(item, "id");
+  const text = textField(item, "text");
+  return scopeId && text ? { kind: "completed", scopeId, text } : null;
+}
+
 function handleNotification(
   session: LiveText | null,
   method: string,
@@ -271,9 +301,9 @@ function handleNotification(
     return;
   }
 
-  if (method === "item/agentMessage/delta") {
-    const delta = stringField(asRecord(params), "delta") ?? "";
-    if (delta) session.output = mergeStream(session.output, delta);
+  const update = codexTextUpdateFromNotification(method, params);
+  if (update) {
+    session.textState = applyCollectedTextUpdate(session.textState, update);
     return;
   }
 

--- a/src/lib/harness/cursor.ts
+++ b/src/lib/harness/cursor.ts
@@ -14,7 +14,12 @@ import {
   type StoredCursorToolCall,
 } from "./cursorStore";
 import { stopCursorTitleGeneration } from "./cursorTitle";
-import type { ApprovalDecision, HarnessEvent, SendTurnInput, SteerTurnInput } from "./types";
+import type {
+  ApprovalDecision,
+  HarnessEvent,
+  SendTurnInput,
+  SteerTurnInput,
+} from "./types";
 import {
   composeToolTitle,
   extractSearchQuery,
@@ -85,19 +90,21 @@ export async function sendCursorTurn(input: SendTurnInput): Promise<void> {
 
   live.onEvent = input.onEvent;
   live.runtimeMode = input.runtimeMode;
-  live.turns = live.turns.catch(() => undefined).then(async () => {
-    live.cancelled = false;
-    live.muteUpdates = false;
-    scheduleCursorToolEnrichment(live, 0);
-    try {
-      await applyModelSelection(live, input);
-      if (live.cancelled) return;
-      await prompt(live, input);
-    } catch (error) {
-      if (live.cancelled) return;
-      throw error;
-    }
-  });
+  live.turns = live.turns
+    .catch(() => undefined)
+    .then(async () => {
+      live.cancelled = false;
+      live.muteUpdates = false;
+      scheduleCursorToolEnrichment(live, 0);
+      try {
+        await applyModelSelection(live, input);
+        if (live.cancelled) return;
+        await prompt(live, input);
+      } catch (error) {
+        if (live.cancelled) return;
+        throw error;
+      }
+    });
   await live.turns;
 }
 
@@ -408,7 +415,10 @@ async function handleRequest(
   }
   if (method === "cursor/ask_question") {
     await live.acp.respond(id, {
-      outcome: { outcome: "skipped", reason: "MonoCode does not collect answers yet" },
+      outcome: {
+        outcome: "skipped",
+        reason: "MonoCode does not collect answers yet",
+      },
     });
     return;
   }
@@ -440,7 +450,10 @@ async function handlePermission(live: Live, id: number, params: unknown) {
   const title =
     composeToolTitle({
       kind,
-      title: toolLabel(tool, subject ?? tool) ?? command ?? stringField(rec ?? {}, "title"),
+      title:
+        toolLabel(tool, subject ?? tool) ??
+        command ??
+        stringField(rec ?? {}, "title"),
       path: preview?.path,
       query:
         preview?.query ??
@@ -500,44 +513,63 @@ async function handlePermission(live: Live, id: number, params: unknown) {
 
   const optionId =
     decision === "allow"
-      ? pickOption(optionIds, ["allow-once", "allow_once", "allow-always", "allow_always"])
+      ? pickOption(optionIds, [
+          "allow-once",
+          "allow_once",
+          "allow-always",
+          "allow_always",
+        ])
       : pickOption(optionIds, ["reject-once", "reject_once", "reject-always"]);
 
   await live.acp.respond(id, {
     outcome: {
       outcome: "selected",
-      optionId: optionId ?? (decision === "allow" ? "allow-once" : "reject-once"),
+      optionId:
+        optionId ?? (decision === "allow" ? "allow-once" : "reject-once"),
     },
   });
 }
 
+export function textEventFromCursorUpdate(
+  params: unknown,
+): Extract<HarnessEvent, { type: "message.delta" | "reasoning.delta" }> | null {
+  const rec = asRecord(params);
+  const update = asRecord(rec?.update) ?? rec;
+  if (!update) return null;
+  const kind = String(
+    update.sessionUpdate ?? update.session_update ?? update.type ?? "",
+  );
+  if (kind === "agent_message_chunk") {
+    const text = textFromContent(update.content ?? update.text);
+    return text ? { type: "message.delta", text } : null;
+  }
+  if (kind === "agent_thought_chunk") {
+    const text = textFromContent(update.content ?? update.text);
+    return text ? { type: "reasoning.delta", text } : null;
+  }
+  return null;
+}
+
 function handleSessionUpdate(live: Live, params: unknown) {
+  const textEvent = textEventFromCursorUpdate(params);
+  if (textEvent) {
+    live.onEvent(textEvent);
+    return;
+  }
+
   const rec = asRecord(params);
   const update = asRecord(rec?.update) ?? rec;
   if (!update) return;
   const kind = String(
     update.sessionUpdate ?? update.session_update ?? update.type ?? "",
   );
-
-  if (kind === "agent_message_chunk" || kind === "agent_message") {
-    // Whole-message arrays contain distinct content blocks; chunks are exact deltas.
-    const text = textFromContent(
-      update.content ?? update.text,
-      kind === "agent_message" ? "\n" : "",
-    );
-    if (text) live.onEvent({ type: "message.delta", text });
-    return;
-  }
-  if (kind === "agent_thought_chunk" || kind === "agent_thought") {
-    const text = textFromContent(
-      update.content ?? update.text,
-      kind === "agent_thought" ? "\n" : "",
-    );
-    if (text) live.onEvent({ type: "reasoning.delta", text });
-    return;
-  }
-  if (kind === "tool_call" || kind === "tool_call_update" || kind === "tool_call_content_chunk") {
-    const tool = asRecord(update.toolCall) ?? asRecord(update.tool_call) ?? update;
+  if (
+    kind === "tool_call" ||
+    kind === "tool_call_update" ||
+    kind === "tool_call_content_chunk"
+  ) {
+    const tool =
+      asRecord(update.toolCall) ?? asRecord(update.tool_call) ?? update;
     const callId = String(
       tool.toolCallId ??
         tool.tool_call_id ??
@@ -761,13 +793,26 @@ function pickAutoOption(
   if (optionIds.length === 0) return null;
   const tool = (kind ?? "").toLowerCase();
   if (runtimeMode === "supervised") return null;
-  if (runtimeMode === "auto-accept-edits" && (tool === "execute" || tool === "other")) {
+  if (
+    runtimeMode === "auto-accept-edits" &&
+    (tool === "execute" || tool === "other")
+  ) {
     return null;
   }
   if (runtimeMode === "full-access") {
-    return pickOption(optionIds, ["allow-always", "allow_always", "allow-once", "allow_once"]);
+    return pickOption(optionIds, [
+      "allow-always",
+      "allow_always",
+      "allow-once",
+      "allow_once",
+    ]);
   }
-  return pickOption(optionIds, ["allow-once", "allow_once", "allow-always", "allow_always"]);
+  return pickOption(optionIds, [
+    "allow-once",
+    "allow_once",
+    "allow-always",
+    "allow_always",
+  ]);
 }
 
 function pickOption(optionIds: string[], preferred: string[]): string | null {
@@ -889,7 +934,9 @@ function toolDetail(
   if (typeof output === "string" && output.trim()) return capToolDetail(output);
   const outputText = textFromContent(output);
   if (outputText.trim()) return capToolDetail(outputText);
-  return inputLabel(update.rawInput ?? tool.rawInput ?? update.input ?? tool.input);
+  return inputLabel(
+    update.rawInput ?? tool.rawInput ?? update.input ?? tool.input,
+  );
 }
 
 const MAX_TOOL_DETAIL_CHARS = 8_000;
@@ -985,8 +1032,7 @@ function contentPath(content: unknown): string | undefined {
   for (const item of content) {
     const rec = asRecord(item);
     const path =
-      rec &&
-      (stringField(rec, "path") ?? contentPath(rec.content ?? rec.diff));
+      rec && (stringField(rec, "path") ?? contentPath(rec.content ?? rec.diff));
     if (path) return path;
   }
   return undefined;
@@ -1060,9 +1106,7 @@ function looksLikeCallId(value: string): boolean {
   const text = value.trim();
   return (
     /^(call[-_]?|tool[-_])[a-z0-9_-]+$/i.test(text) ||
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-      text,
-    )
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(text)
   );
 }
 

--- a/src/lib/harness/cursorLive.test.ts
+++ b/src/lib/harness/cursorLive.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { textEventFromCursorUpdate } from "./cursor";
+
+describe("Cursor ACP v1 text updates", () => {
+  it("preserves exact message chunks", () => {
+    expect(
+      textEventFromCursorUpdate({
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "\n\n" },
+        },
+      }),
+    ).toEqual({ type: "message.delta", text: "\n\n" });
+  });
+
+  it("does not append unproven whole-message replacement updates", () => {
+    expect(
+      textEventFromCursorUpdate({
+        update: {
+          sessionUpdate: "agent_message",
+          messageId: "message-1",
+          content: [
+            { type: "text", text: "First" },
+            { type: "text", text: "Second" },
+          ],
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("maps thought chunks without trimming", () => {
+    expect(
+      textEventFromCursorUpdate({
+        update: {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "  " },
+        },
+      }),
+    ).toEqual({ type: "reasoning.delta", text: "  " });
+  });
+});

--- a/src/lib/harness/cursorText.ts
+++ b/src/lib/harness/cursorText.ts
@@ -6,7 +6,6 @@ import {
   unwatchChild,
   watchChild,
 } from "./child";
-import { mergeStream } from "./streamText";
 
 const TEXT_CHILD_ID = "monocode-text";
 const INIT_TIMEOUT_MS = 60_000;
@@ -42,9 +41,11 @@ export async function stopCursorTextPrompt(childId?: string): Promise<void> {
 /** Start the shared text ACP process in the background so the first prompt is fast. */
 export function warmupCursorText(cwd: string): Promise<void> {
   if (!cwd || cwd === "~") return Promise.resolve();
-  const run = turns.catch(() => undefined).then(async () => {
-    await ensureLive(cwd);
-  });
+  const run = turns
+    .catch(() => undefined)
+    .then(async () => {
+      await ensureLive(cwd);
+    });
   turns = run.then(
     () => undefined,
     () => undefined,
@@ -115,8 +116,9 @@ async function startLive(cwd: string): Promise<LiveText> {
   const acp = new AcpClient(TEXT_CHILD_ID, {
     onNotification: (method, params) => {
       const session = acpRef.session;
-      if (!session || method !== "session/update" || !session.collecting) return;
-      session.output = mergeStream(session.output, textFromUpdate(params));
+      if (!session || method !== "session/update" || !session.collecting)
+        return;
+      session.output += textFromCursorTextUpdate(params);
     },
     onRequest: (id, method, params) => {
       void handleTextRequest(acp, id, method, params);
@@ -172,11 +174,7 @@ async function openSession(session: LiveText, cwd: string): Promise<void> {
   const setup = await session.acp.request<{
     sessionId?: string;
     configOptions?: unknown;
-  }>(
-    "session/new",
-    { cwd, mcpServers: [] },
-    REQUEST_TIMEOUT_MS,
-  );
+  }>("session/new", { cwd, mcpServers: [] }, REQUEST_TIMEOUT_MS);
   const acpSessionId = setup.sessionId?.trim();
   if (!acpSessionId) throw new Error("Cursor did not return a session id");
 
@@ -274,14 +272,14 @@ function extractModelConfigId(raw: unknown): string {
   return "model";
 }
 
-function textFromUpdate(params: unknown): string {
+export function textFromCursorTextUpdate(params: unknown): string {
   const rec = asRecord(params);
   const update = asRecord(rec?.update) ?? rec;
   if (!update) return "";
   const kind = String(
     update.sessionUpdate ?? update.session_update ?? update.type ?? "",
   );
-  if (kind !== "agent_message_chunk" && kind !== "agent_message") return "";
+  if (kind !== "agent_message_chunk") return "";
   return textFromContent(update.content ?? update.text);
 }
 

--- a/src/lib/harness/fxProtocol.test.ts
+++ b/src/lib/harness/fxProtocol.test.ts
@@ -56,12 +56,12 @@ describe("fx protocol", () => {
   });
 
   it("picks allow/reject option ids from ACP permission options", () => {
-    expect(
-      permissionOptionId("allow", ["allow_once", "reject_once"]),
-    ).toBe("allow_once");
-    expect(
-      permissionOptionId("deny", ["allow-once", "reject-once"]),
-    ).toBe("reject-once");
+    expect(permissionOptionId("allow", ["allow_once", "reject_once"])).toBe(
+      "allow_once",
+    );
+    expect(permissionOptionId("deny", ["allow-once", "reject-once"])).toBe(
+      "reject-once",
+    );
   });
 
   it("reads a permission prompt from an ACP request", () => {
@@ -104,6 +104,22 @@ describe("fx protocol", () => {
         content: { type: "text", text: "Hi" },
       }),
     ).toEqual([{ type: "message.delta", text: "Hi" }]);
+    expect(
+      eventsFromAcpUpdate({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "\n\n" },
+      }),
+    ).toEqual([{ type: "message.delta", text: "\n\n" }]);
+    expect(
+      eventsFromAcpUpdate({
+        sessionUpdate: "agent_message",
+        messageId: "message-1",
+        content: [
+          { type: "text", text: "First" },
+          { type: "text", text: "Second" },
+        ],
+      }),
+    ).toEqual([]);
 
     const tools = eventsFromAcpUpdate({
       sessionUpdate: "tool_call",

--- a/src/lib/harness/fxProtocol.ts
+++ b/src/lib/harness/fxProtocol.ts
@@ -158,19 +158,13 @@ export function eventsFromAcpUpdate(params: unknown): HarnessEvent[] {
     update.sessionUpdate ?? update.session_update ?? update.type ?? "",
   );
 
-  if (kind === "agent_message_chunk" || kind === "agent_message") {
-    const text = textFromContent(
-      update.content ?? update.text,
-      kind === "agent_message" ? "\n" : "",
-    );
+  if (kind === "agent_message_chunk") {
+    const text = textFromContent(update.content ?? update.text);
     return text ? [{ type: "message.delta", text }] : [];
   }
 
-  if (kind === "agent_thought_chunk" || kind === "agent_thought") {
-    const text = textFromContent(
-      update.content ?? update.text,
-      kind === "agent_thought" ? "\n" : "",
-    );
+  if (kind === "agent_thought_chunk") {
+    const text = textFromContent(update.content ?? update.text);
     return text ? [{ type: "reasoning.delta", text }] : [];
   }
 

--- a/src/lib/harness/opencode.ts
+++ b/src/lib/harness/opencode.ts
@@ -29,13 +29,19 @@ import {
   sessionErrorMessage,
   stringField,
   textDeltaEvent,
+  textField,
   toOpenCodeFileParts,
   toOpenCodePermissionReply,
   toolKindFromName,
   type OpenCodePart,
 } from "./opencodeProtocol";
 import { composeToolTitle } from "./preview";
-import type { ApprovalDecision, HarnessEvent, SendTurnInput, SteerTurnInput } from "./types";
+import type {
+  ApprovalDecision,
+  HarnessEvent,
+  SendTurnInput,
+  SteerTurnInput,
+} from "./types";
 
 type PendingApproval = {
   id: string;
@@ -53,6 +59,7 @@ type Live = {
   nextApprovalUiId: number;
   partById: Map<string, OpenCodePart>;
   emittedTextByPartId: Map<string, string>;
+  tailTextPartId: string | null;
   messageRoleById: Map<string, "user" | "assistant">;
   cancelled: boolean;
   muteUpdates: boolean;
@@ -95,16 +102,18 @@ export async function sendOpenCodeTurn(input: SendTurnInput): Promise<void> {
 
   live.onEvent = input.onEvent;
   live.runtimeMode = input.runtimeMode;
-  live.turns = live.turns.catch(() => undefined).then(async () => {
-    live.cancelled = false;
-    live.muteUpdates = false;
-    try {
-      await runTurn(live, input);
-    } catch (error) {
-      if (live.cancelled) return;
-      throw error;
-    }
-  });
+  live.turns = live.turns
+    .catch(() => undefined)
+    .then(async () => {
+      live.cancelled = false;
+      live.muteUpdates = false;
+      try {
+        await runTurn(live, input);
+      } catch (error) {
+        if (live.cancelled) return;
+        throw error;
+      }
+    });
   await live.turns;
 }
 
@@ -127,6 +136,7 @@ export async function steerOpenCodeTurn(input: SteerTurnInput): Promise<void> {
   ];
   if (parts.length === 0) return;
 
+  live.tailTextPartId = null;
   await live.client.promptAsync({
     sessionID: live.openCodeSessionId,
     model: parsed,
@@ -277,6 +287,7 @@ async function ensureLive(input: SendTurnInput): Promise<Live> {
       nextApprovalUiId: 1,
       partById: new Map(),
       emittedTextByPartId: new Map(),
+      tailTextPartId: null,
       messageRoleById: new Map(),
       cancelled: false,
       muteUpdates: false,
@@ -420,7 +431,7 @@ function handleEvent(live: Live, event: Record<string, unknown>): void {
     }
     case "message.part.delta": {
       const partID = stringField(properties, "partID");
-      const delta = stringField(properties, "delta") ?? "";
+      const delta = textField(properties, "delta") ?? "";
       if (!partID || !delta) break;
       const existing = live.partById.get(partID);
       if (!existing || roleForPart(live, existing) !== "assistant") break;
@@ -431,6 +442,7 @@ function handleEvent(live: Live, event: Record<string, unknown>): void {
         delta,
       );
       live.emittedTextByPartId.set(partID, nextText);
+      live.tailTextPartId = partID;
       if (existing.type === "text" || existing.type === "reasoning") {
         live.partById.set(partID, { ...existing, text: nextText });
       }
@@ -449,11 +461,14 @@ function handleEvent(live: Live, event: Record<string, unknown>): void {
       break;
     }
     case "permission.asked": {
-      const id = stringField(properties, "id") ?? stringField(properties, "requestID");
+      const id =
+        stringField(properties, "id") ?? stringField(properties, "requestID");
       if (!id) break;
       const permission = stringField(properties, "permission") ?? "tool";
       const patterns = Array.isArray(properties.patterns)
-        ? properties.patterns.filter((item): item is string => typeof item === "string")
+        ? properties.patterns.filter(
+            (item): item is string => typeof item === "string",
+          )
         : [];
       const metadata = asRecord(properties.metadata) ?? {};
       const callId =
@@ -470,7 +485,9 @@ function handleEvent(live: Live, event: Record<string, unknown>): void {
           tool: permission,
           state: {
             ...metadata,
-            input: metadata.input ?? (patterns[0] ? { path: patterns[0] } : undefined),
+            input:
+              metadata.input ??
+              (patterns[0] ? { path: patterns[0] } : undefined),
           },
         }) ??
         (patterns[0]
@@ -489,6 +506,7 @@ function handleEvent(live: Live, event: Record<string, unknown>): void {
           query: preview?.query,
           previewKind: preview?.kind,
         }) || permissionTitle(permission, patterns);
+      live.tailTextPartId = null;
       if (callId) {
         live.onEvent({
           type: "tool.updated",
@@ -510,7 +528,8 @@ function handleEvent(live: Live, event: Record<string, unknown>): void {
       break;
     }
     case "question.asked": {
-      const id = stringField(properties, "id") ?? stringField(properties, "requestID");
+      const id =
+        stringField(properties, "id") ?? stringField(properties, "requestID");
       if (!id) break;
       const questions = Array.isArray(properties.questions)
         ? properties.questions
@@ -521,6 +540,7 @@ function handleEvent(live: Live, event: Record<string, unknown>): void {
         stringField(first, "question") ??
         "OpenCode question";
       const uiId = live.nextApprovalUiId++;
+      live.tailTextPartId = null;
       live.onEvent({
         type: "approval.requested",
         requestId: uiId,
@@ -535,7 +555,10 @@ function handleEvent(live: Live, event: Record<string, unknown>): void {
       const statusType = stringField(status, "type");
       if (statusType === "retry") {
         const message = stringField(status, "message");
-        if (message) live.onEvent({ type: "status", text: message });
+        if (message) {
+          live.tailTextPartId = null;
+          live.onEvent({ type: "status", text: message });
+        }
         break;
       }
       if (statusType === "idle" && live.activeTurn) {
@@ -548,6 +571,7 @@ function handleEvent(live: Live, event: Record<string, unknown>): void {
     }
     case "session.error": {
       const message = sessionErrorMessage(properties.error);
+      live.tailTextPartId = null;
       live.onEvent({ type: "session.error", message });
       finishActiveTurn(live);
       break;
@@ -561,10 +585,7 @@ function handleEvent(live: Live, event: Record<string, unknown>): void {
  * OpenCode reports tokens per assistant message but not the window, so the
  * window comes from the catalog entry for the model that produced it.
  */
-function emitContext(
-  live: Live,
-  info: Record<string, unknown> | null,
-): void {
+function emitContext(live: Live, info: Record<string, unknown> | null): void {
   const used = contextUsedFromMessageInfo(info);
   if (used === undefined) return;
   const providerID = stringField(info, "providerID");
@@ -580,13 +601,17 @@ function emitAssistantText(live: Live, part: OpenCodePart): void {
   const text = part.text;
   if (text === undefined) return;
   const previous = live.emittedTextByPartId.get(part.id);
-  const { latestText, deltaToEmit } = mergeOpenCodeAssistantText(previous, text);
-  live.emittedTextByPartId.set(part.id, latestText);
-  const mapped = textDeltaEvent(part, deltaToEmit);
+  const result = mergeOpenCodeAssistantText(previous, text);
+  if (result.kind === "conflict" || result.kind === "unchanged") return;
+  if (previous !== undefined && live.tailTextPartId !== part.id) return;
+  live.emittedTextByPartId.set(part.id, result.latestText);
+  live.tailTextPartId = part.id;
+  const mapped = textDeltaEvent(part, result.deltaToEmit);
   if (mapped) live.onEvent(mapped);
 }
 
 function emitTool(live: Live, part: OpenCodePart): void {
+  live.tailTextPartId = null;
   const callId = part.callID ?? part.id;
   const tool = part.tool ?? "tool";
   const state = part.state ?? {};
@@ -666,6 +691,7 @@ async function waitApproval(
 function finishActiveTurn(live: Live, extraEvents: HarnessEvent[] = []): void {
   live.turnEndPending = false;
   live.activeTurn = false;
+  live.tailTextPartId = null;
   for (const event of extraEvents) live.onEvent(event);
   const done = live.turnDone;
   const failed = live.turnFailed;
@@ -708,7 +734,9 @@ function roleForPart(
     const known = live.messageRoleById.get(part.messageID);
     if (known) return known;
   }
-  return part.type === "tool" || part.type === "text" || part.type === "reasoning"
+  return part.type === "tool" ||
+    part.type === "text" ||
+    part.type === "reasoning"
     ? "assistant"
     : undefined;
 }

--- a/src/lib/harness/opencodeProtocol.test.ts
+++ b/src/lib/harness/opencodeProtocol.test.ts
@@ -16,8 +16,17 @@ import {
   parseOpenCodeModelSlug,
   parseOpenCodeVersion,
   parseServerUrlFromOutput,
+  textField,
   toOpenCodePermissionReply,
 } from "./opencodeProtocol";
+
+describe("textField", () => {
+  it("preserves whitespace text without weakening metadata fields", () => {
+    const record = { text: "\n\n", id: "  " };
+    expect(textField(record, "text")).toBe("\n\n");
+    expect(textField(record, "missing")).toBeUndefined();
+  });
+});
 
 describe("parseOpenCodeModelSlug", () => {
   it("splits provider/model", () => {
@@ -100,12 +109,12 @@ describe("OpenCode CLI inventory parsers", () => {
       "anthropic/claude-sonnet-4-6",
       "opencode/glm-5",
     ]);
-    expect(models[1].settings?.some((setting) => setting.id === "variant")).toBe(
-      true,
-    );
-    expect(models[0].settings?.find((setting) => setting.id === "agent")?.value).toBe(
-      "build",
-    );
+    expect(
+      models[1].settings?.some((setting) => setting.id === "variant"),
+    ).toBe(true);
+    expect(
+      models[0].settings?.find((setting) => setting.id === "agent")?.value,
+    ).toBe("build");
   });
 
   it("parses agent list headers", () => {
@@ -122,15 +131,26 @@ describe("OpenCode CLI inventory parsers", () => {
 describe("mergeOpenCodeAssistantText", () => {
   it("emits only the new suffix", () => {
     expect(mergeOpenCodeAssistantText("Hel", "Hello")).toEqual({
+      kind: "append",
       latestText: "Hello",
       deltaToEmit: "lo",
     });
   });
 
-  it("keeps a longer snapshot if the next update shrinks", () => {
-    expect(mergeOpenCodeAssistantText("Hello world", "Hello")).toEqual({
-      latestText: "Hello world",
-      deltaToEmit: "",
+  it("recognizes an unchanged snapshot", () => {
+    expect(mergeOpenCodeAssistantText("Hello", "Hello")).toEqual({
+      kind: "unchanged",
+      latestText: "Hello",
+    });
+  });
+
+  it.each([
+    ["Hello world", "Hello"],
+    ["help", "hello"],
+  ])("rejects an incompatible snapshot: %s -> %s", (previous, next) => {
+    expect(mergeOpenCodeAssistantText(previous, next)).toEqual({
+      kind: "conflict",
+      latestText: previous,
     });
   });
 });
@@ -156,9 +176,9 @@ describe("OpenCode helpers", () => {
     expect(inferDefaultVariant("openai", ["low", "medium", "high"])).toBe(
       "medium",
     );
-    expect(
-      inferDefaultAgent([{ name: "plan" }, { name: "build" }]),
-    ).toBe("build");
+    expect(inferDefaultAgent([{ name: "plan" }, { name: "build" }])).toBe(
+      "build",
+    );
   });
 });
 
@@ -187,7 +207,12 @@ describe("contextUsedFromMessageInfo", () => {
   it("treats an all-zero reading as nothing to report", () => {
     expect(
       contextUsedFromMessageInfo({
-        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        tokens: {
+          input: 0,
+          output: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
       }),
     ).toBeUndefined();
   });

--- a/src/lib/harness/opencodeProtocol.ts
+++ b/src/lib/harness/opencodeProtocol.ts
@@ -47,6 +47,15 @@ export function stringField(
   return typeof value === "string" && value.trim() ? value : undefined;
 }
 
+export function textField(
+  rec: Record<string, unknown> | null | undefined,
+  key: string,
+): string | undefined {
+  if (!rec) return undefined;
+  const value = rec[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 export function parseOpenCodeModelSlug(
   slug: string | null | undefined,
 ): ParsedOpenCodeModelSlug | null {
@@ -179,20 +188,26 @@ export function toOpenCodeFileParts(
   return parts;
 }
 
+export type OpenCodeTextSnapshotResult =
+  | { kind: "unchanged"; latestText: string }
+  | { kind: "append"; latestText: string; deltaToEmit: string }
+  | { kind: "conflict"; latestText: string };
+
 export function mergeOpenCodeAssistantText(
   previousText: string | undefined,
   nextText: string,
-): { latestText: string; deltaToEmit: string } {
-  const latestText =
-    previousText &&
-    previousText.length > nextText.length &&
-    previousText.startsWith(nextText)
-      ? previousText
-      : nextText;
-  return {
-    latestText,
-    deltaToEmit: latestText.slice(commonPrefixLength(previousText ?? "", latestText)),
-  };
+): OpenCodeTextSnapshotResult {
+  if (previousText === nextText) {
+    return { kind: "unchanged", latestText: nextText };
+  }
+  if (previousText === undefined || nextText.startsWith(previousText)) {
+    return {
+      kind: "append",
+      latestText: nextText,
+      deltaToEmit: nextText.slice(previousText?.length ?? 0),
+    };
+  }
+  return { kind: "conflict", latestText: previousText };
 }
 
 export function appendOpenCodeAssistantTextDelta(
@@ -200,14 +215,6 @@ export function appendOpenCodeAssistantTextDelta(
   delta: string,
 ): { nextText: string; deltaToEmit: string } {
   return { nextText: previousText + delta, deltaToEmit: delta };
-}
-
-function commonPrefixLength(left: string, right: string): number {
-  let index = 0;
-  while (index < left.length && index < right.length && left[index] === right[index]) {
-    index += 1;
-  }
-  return index;
 }
 
 export function titleCaseSlug(value: string): string {
@@ -238,13 +245,21 @@ export function inferDefaultVariant(
   return undefined;
 }
 
-export function inferDefaultAgent(agents: Array<{ name: string }>): string | undefined {
-  return agents.find((agent) => agent.name === "build")?.name ?? agents[0]?.name;
+export function inferDefaultAgent(
+  agents: Array<{ name: string }>,
+): string | undefined {
+  return (
+    agents.find((agent) => agent.name === "build")?.name ?? agents[0]?.name
+  );
 }
 
 export function toolKindFromName(toolName: string): string {
   const normalized = toolName.toLowerCase();
-  if (normalized.includes("bash") || normalized.includes("command") || normalized.includes("shell")) {
+  if (
+    normalized.includes("bash") ||
+    normalized.includes("command") ||
+    normalized.includes("shell")
+  ) {
     return "shell";
   }
   if (
@@ -267,7 +282,9 @@ export function toolKindFromName(toolName: string): string {
   return toolName;
 }
 
-export function previewFromToolPart(part: OpenCodePart): ToolPreview | undefined {
+export function previewFromToolPart(
+  part: OpenCodePart,
+): ToolPreview | undefined {
   const tool = part.tool ?? "tool";
   const state = part.state ?? {};
   const kind = toolKindFromName(tool);
@@ -292,13 +309,18 @@ export function previewFromToolPart(part: OpenCodePart): ToolPreview | undefined
 export function detailFromToolPart(part: OpenCodePart): string | undefined {
   const state = part.state ?? {};
   const status = typeof state.status === "string" ? state.status : "";
-  if (status === "completed" && typeof state.output === "string") return state.output;
+  if (status === "completed" && typeof state.output === "string")
+    return state.output;
   if (status === "error" && typeof state.error === "string") return state.error;
-  if (status === "running" && typeof state.title === "string") return state.title;
+  if (status === "running" && typeof state.title === "string")
+    return state.title;
   return undefined;
 }
 
-export function permissionTitle(permission: string, patterns: string[]): string {
+export function permissionTitle(
+  permission: string,
+  patterns: string[],
+): string {
   const detail = patterns.length > 0 ? patterns.join("\n") : permission;
   switch (permission) {
     case "bash":
@@ -348,7 +370,9 @@ export function contextUsedFromMessageInfo(
   return used > 0 ? used : undefined;
 }
 
-export function eventSessionId(event: Record<string, unknown>): string | undefined {
+export function eventSessionId(
+  event: Record<string, unknown>,
+): string | undefined {
   const properties = asRecord(event.properties);
   if (!properties) return undefined;
   const sessionID = stringField(properties, "sessionID");

--- a/src/lib/harness/piProtocol.test.ts
+++ b/src/lib/harness/piProtocol.test.ts
@@ -221,6 +221,12 @@ describe("streaming events", () => {
         assistantMessageEvent: { type: "thinking_delta", delta: "hmm" },
       }),
     ).toEqual({ kind: "thinking", text: "hmm" });
+    expect(
+      assistantDeltaFromEvent({
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", delta: "\n\n" },
+      }),
+    ).toEqual({ kind: "text", text: "\n\n" });
 
     expect(
       toolCallStartFromEvent({
@@ -250,7 +256,9 @@ describe("streaming events", () => {
     });
 
     expect(isAgentSettled({ type: "agent_settled" })).toBe(true);
-    expect(agentEndWillRetry({ type: "agent_end", willRetry: true })).toBe(true);
+    expect(agentEndWillRetry({ type: "agent_end", willRetry: true })).toBe(
+      true,
+    );
     expect(agentEndWillRetry({ type: "agent_end" })).toBe(false);
   });
 });
@@ -304,9 +312,12 @@ describe("tools and models", () => {
       }),
     ).toBeUndefined();
     expect(
-      contextFromUsage({
-        usage: { totalTokens: 120 },
-      }, 200),
+      contextFromUsage(
+        {
+          usage: { totalTokens: 120 },
+        },
+        200,
+      ),
     ).toEqual({ used: 120, window: 200 });
     expect(
       contextFromSessionStats({

--- a/src/lib/harness/piProtocol.ts
+++ b/src/lib/harness/piProtocol.ts
@@ -54,7 +54,8 @@ export type PiExtensionUiRequest =
     }
   | {
       id: string;
-      method: "notify" | "setStatus" | "setWidget" | "setTitle" | "set_editor_text";
+      method:
+        "notify" | "setStatus" | "setWidget" | "setTitle" | "set_editor_text";
       title?: string;
     };
 
@@ -80,6 +81,15 @@ export function stringField(
   if (!rec) return undefined;
   const value = rec[key];
   return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+export function textField(
+  rec: Record<string, unknown> | null | undefined,
+  key: string,
+): string | undefined {
+  if (!rec) return undefined;
+  const value = rec[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 export function parseJsonLine(line: string): Record<string, unknown> | null {
@@ -129,7 +139,9 @@ export function buildPiSpawnArgs(
   return args;
 }
 
-export function parsePiModelRef(nativeId: string | undefined): PiModelRef | null {
+export function parsePiModelRef(
+  nativeId: string | undefined,
+): PiModelRef | null {
   if (!nativeId) return null;
   const trimmed = nativeId.trim();
   if (!trimmed) return null;
@@ -188,7 +200,9 @@ export function buildPiSteer(input: {
   return command;
 }
 
-export function parseRpcResponse(rec: Record<string, unknown>): PiRpcResponse | null {
+export function parseRpcResponse(
+  rec: Record<string, unknown>,
+): PiRpcResponse | null {
   if (stringField(rec, "type") !== "response") return null;
   const command = stringField(rec, "command") ?? "unknown";
   const id = stringField(rec, "id");
@@ -353,7 +367,7 @@ export function assistantDeltaFromEvent(
   if (stringField(rec, "type") !== "message_update") return null;
   const event = asRecord(rec.assistantMessageEvent);
   const type = stringField(event, "type");
-  const delta = stringField(event, "delta");
+  const delta = textField(event, "delta");
   if (!delta) return null;
   if (type === "text_delta") return { kind: "text", text: delta };
   if (type === "thinking_delta") return { kind: "thinking", text: delta };
@@ -379,7 +393,7 @@ export function toolCallDeltaFromEvent(
   if (stringField(rec, "type") !== "message_update") return null;
   const event = asRecord(rec.assistantMessageEvent);
   if (stringField(event, "type") !== "toolcall_delta") return null;
-  const delta = stringField(event, "delta");
+  const delta = textField(event, "delta");
   if (!delta) return null;
   return {
     index: numberField(event, "contentIndex") ?? -1,
@@ -432,9 +446,7 @@ export function toolExecutionUpdateFromEvent(
   };
 }
 
-export function toolExecutionEndFromEvent(
-  rec: Record<string, unknown>,
-): {
+export function toolExecutionEndFromEvent(rec: Record<string, unknown>): {
   id: string;
   name?: string;
   detail?: string;
@@ -456,7 +468,9 @@ export function isAgentSettled(rec: Record<string, unknown>): boolean {
   return stringField(rec, "type") === "agent_settled";
 }
 
-export function agentEndWillRetry(rec: Record<string, unknown>): boolean | null {
+export function agentEndWillRetry(
+  rec: Record<string, unknown>,
+): boolean | null {
   if (stringField(rec, "type") !== "agent_end") return null;
   return rec.willRetry === true;
 }
@@ -476,7 +490,9 @@ export function statusFromPiEvent(rec: Record<string, unknown>): string | null {
   return null;
 }
 
-export function tryParseJsonRecord(partial: string): Record<string, unknown> | null {
+export function tryParseJsonRecord(
+  partial: string,
+): Record<string, unknown> | null {
   try {
     return asRecord(JSON.parse(partial));
   } catch {
@@ -644,10 +660,10 @@ export function thinkingSetting(reasoning: boolean): ModelSetting | undefined {
   };
 }
 
-export function isPiThinkingLevel(value: string | undefined): value is PiThinkingLevel {
-  return (
-    !!value && (PI_THINKING_LEVELS as readonly string[]).includes(value)
-  );
+export function isPiThinkingLevel(
+  value: string | undefined,
+): value is PiThinkingLevel {
+  return !!value && (PI_THINKING_LEVELS as readonly string[]).includes(value);
 }
 
 function thinkingLabel(level: PiThinkingLevel): string {
@@ -661,5 +677,7 @@ function numberField(
   key: string,
 ): number | undefined {
   const value = rec?.[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
 }

--- a/src/lib/harness/piText.ts
+++ b/src/lib/harness/piText.ts
@@ -1,10 +1,5 @@
 import { modelsFor } from "../models";
-import {
-  killChild,
-  spawnChild,
-  unwatchChild,
-  watchChild,
-} from "./child";
+import { killChild, spawnChild, unwatchChild, watchChild } from "./child";
 import { PiRpc } from "./piClient";
 import { OMP_FLAVOR, PI_FLAVOR, type PiFlavor } from "./piFlavor";
 import {
@@ -15,7 +10,6 @@ import {
   buildPiSpawnArgs,
   isAgentSettled,
 } from "./piProtocol";
-import { mergeStream } from "./streamText";
 
 const INIT_TIMEOUT_MS = 15_000;
 const REQUEST_TIMEOUT_MS = 45_000;
@@ -66,9 +60,11 @@ export async function stopTextPrompt(flavor: PiFlavor): Promise<void> {
 export function warmupText(flavor: PiFlavor, cwd: string): Promise<void> {
   if (!cwd || cwd === "~") return Promise.resolve();
   const state = stateFor(flavor);
-  const run = state.turns.catch(() => undefined).then(async () => {
-    await ensureLive(flavor, cwd);
-  });
+  const run = state.turns
+    .catch(() => undefined)
+    .then(async () => {
+      await ensureLive(flavor, cwd);
+    });
   state.turns = run.then(
     () => undefined,
     () => undefined,
@@ -240,9 +236,7 @@ async function dropLive(flavor: PiFlavor): Promise<void> {
   if (current) {
     current.closed = true;
     current.rpc.close();
-    current.turnFailed?.(
-      new Error(`${flavor.label} text generator stopped`),
-    );
+    current.turnFailed?.(new Error(`${flavor.label} text generator stopped`));
     current.turnDone = null;
     current.turnFailed = null;
   }
@@ -254,7 +248,7 @@ function handleFrame(session: LiveText, rec: Record<string, unknown>) {
   if (!session.collecting) return;
   const delta = assistantDeltaFromEvent(rec);
   if (delta?.kind === "text") {
-    session.output = mergeStream(session.output, delta.text);
+    session.output += delta.text;
   }
   if (isAgentSettled(rec) || agentEndWillRetry(rec) === false) {
     if (session.turnDone) finishTurn(session);

--- a/src/lib/harness/streamText.test.ts
+++ b/src/lib/harness/streamText.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyCollectedTextUpdate,
+  classifyCompletedText,
+  createCollectedTextState,
+  selectCollectedText,
+  type CollectedTextUpdate,
+} from "./streamText";
+
+describe("classifyCompletedText", () => {
+  it("recognizes an already emitted completed value", () => {
+    expect(
+      classifyCompletedText({ streamed: "complete", completed: "complete" }),
+    ).toEqual({ kind: "already-emitted" });
+  });
+
+  it("returns a completed-only fallback", () => {
+    expect(
+      classifyCompletedText({ streamed: "", completed: "complete" }),
+    ).toEqual({ kind: "fallback", text: "complete" });
+  });
+
+  it("returns only the missing suffix", () => {
+    expect(
+      classifyCompletedText({ streamed: "hel", completed: "hello" }),
+    ).toEqual({ kind: "extends", suffix: "lo" });
+  });
+
+  it.each([
+    { streamed: "hello", completed: "hell" },
+    { streamed: "help", completed: "hello" },
+  ])(
+    "rejects incompatible completed text: $streamed -> $completed",
+    (input) => {
+      expect(classifyCompletedText(input)).toEqual({ kind: "conflict" });
+    },
+  );
+});
+
+describe("collected text state", () => {
+  it("prefers an authoritative completed value for the active scope", () => {
+    let state = createCollectedTextState();
+    state = applyCollectedTextUpdate(state, {
+      kind: "delta",
+      scopeId: "message-1",
+      text: "hello\n\n",
+    });
+    state = applyCollectedTextUpdate(state, {
+      kind: "completed",
+      scopeId: "message-1",
+      text: "hello",
+    });
+
+    expect(selectCollectedText(state)).toBe("hello");
+  });
+
+  it("uses exact streamed text without a completed value", () => {
+    const state = applyCollectedTextUpdate(createCollectedTextState(), {
+      kind: "delta",
+      scopeId: "message-1",
+      text: "bookkeeper\n\n",
+    });
+
+    expect(selectCollectedText(state)).toBe("bookkeeper\n\n");
+  });
+
+  it("does not let a late completion replace a newer native scope", () => {
+    let state = createCollectedTextState();
+    const updates: CollectedTextUpdate[] = [
+      { kind: "delta", scopeId: "message-1", text: "old" },
+      { kind: "delta", scopeId: "message-2", text: "new" },
+      { kind: "completed", scopeId: "message-1", text: "older complete" },
+    ];
+    for (const update of updates) {
+      state = applyCollectedTextUpdate(state, update);
+    }
+
+    expect(selectCollectedText(state)).toBe("new");
+  });
+});

--- a/src/lib/harness/streamText.ts
+++ b/src/lib/harness/streamText.ts
@@ -1,24 +1,61 @@
-/** Join a delta or snapshot onto streamed text without repeating overlapping words. */
-export function mergeStream(existing: string, incoming: string): string {
-  if (!incoming) return existing;
-  if (!existing) return incoming;
-  if (incoming === existing) return existing;
-  if (incoming.startsWith(existing)) return incoming;
-  if (existing.endsWith(incoming)) return existing;
+export type CollectedTextUpdate =
+  | { kind: "delta"; scopeId: string; text: string }
+  | { kind: "completed"; scopeId: string; text: string };
 
-  const trimmed = incoming.trimStart();
-  // Cursor can emit blank lines as standalone deltas. Never deduplicate those
-  // against the empty string: every string technically ends with `""`.
-  if (trimmed && trimmed !== incoming) {
-    if (trimmed === existing || existing.endsWith(trimmed)) return existing;
-    if (trimmed.startsWith(existing)) return trimmed;
-  }
+export type CollectedTextState = {
+  activeScopeId: string | null;
+  entries: ReadonlyMap<
+    string,
+    { streamed: string; completed: string | null }
+  >;
+};
 
-  const maxOverlap = Math.min(existing.length, incoming.length, 1024);
-  for (let k = maxOverlap; k > 0; k--) {
-    if (existing.endsWith(incoming.slice(0, k))) {
-      return existing + incoming.slice(k);
-    }
+export function createCollectedTextState(): CollectedTextState {
+  return { activeScopeId: null, entries: new Map() };
+}
+
+export function applyCollectedTextUpdate(
+  state: CollectedTextState,
+  update: CollectedTextUpdate,
+): CollectedTextState {
+  const existing = state.entries.get(update.scopeId);
+  const entry = existing ?? { streamed: "", completed: null };
+  const entries = new Map(state.entries);
+  entries.set(
+    update.scopeId,
+    update.kind === "delta"
+      ? { ...entry, streamed: entry.streamed + update.text }
+      : { ...entry, completed: update.text },
+  );
+  return {
+    activeScopeId: existing ? state.activeScopeId : update.scopeId,
+    entries,
+  };
+}
+
+export type CompletedTextRelationship =
+  | { kind: "already-emitted" }
+  | { kind: "fallback"; text: string }
+  | { kind: "extends"; suffix: string }
+  | { kind: "conflict" };
+
+export function classifyCompletedText(input: {
+  streamed: string;
+  completed: string;
+}): CompletedTextRelationship {
+  if (input.completed === input.streamed) return { kind: "already-emitted" };
+  if (!input.streamed) return { kind: "fallback", text: input.completed };
+  if (input.completed.startsWith(input.streamed)) {
+    return {
+      kind: "extends",
+      suffix: input.completed.slice(input.streamed.length),
+    };
   }
-  return existing + incoming;
+  return { kind: "conflict" };
+}
+
+export function selectCollectedText(state: CollectedTextState): string {
+  if (!state.activeScopeId) return "";
+  const entry = state.entries.get(state.activeScopeId);
+  return entry?.completed ?? entry?.streamed ?? "";
 }

--- a/src/lib/harness/textCollectors.test.ts
+++ b/src/lib/harness/textCollectors.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  claudeTextUpdateFromRecord,
+  requireClaudeTextOutput,
+} from "./claudeText";
+import { codexTextUpdateFromNotification } from "./codexText";
+import { textFromCursorTextUpdate } from "./cursorText";
+
+describe("one-shot text collectors", () => {
+  it("classifies Codex deltas and completed values", () => {
+    expect(
+      codexTextUpdateFromNotification("item/agentMessage/delta", {
+        itemId: "msg_1",
+        delta: "\n\n",
+      }),
+    ).toEqual({ kind: "delta", scopeId: "msg_1", text: "\n\n" });
+    expect(
+      codexTextUpdateFromNotification("item/completed", {
+        item: { id: "msg_1", type: "agentMessage", text: "complete" },
+      }),
+    ).toEqual({ kind: "completed", scopeId: "msg_1", text: "complete" });
+  });
+
+  it("classifies Claude deltas and completed values", () => {
+    expect(
+      claudeTextUpdateFromRecord(
+        {
+          type: "stream_event",
+          event: { delta: { type: "text_delta", text: "book" } },
+        },
+        "record-1",
+      ),
+    ).toEqual({ kind: "delta", scopeId: "record-1", text: "book" });
+    expect(
+      claudeTextUpdateFromRecord(
+        {
+          type: "assistant",
+          message: {
+            content: [
+              { type: "text", text: "book" },
+              { type: "text", text: "keeper" },
+            ],
+          },
+        },
+        "record-1",
+      ),
+    ).toEqual({
+      kind: "completed",
+      scopeId: "record-1",
+      text: "bookkeeper",
+    });
+  });
+
+  it("validates Claude output without trimming exact outer whitespace", () => {
+    expect(requireClaudeTextOutput("  bookkeeper\n\n")).toBe(
+      "  bookkeeper\n\n",
+    );
+    expect(() => requireClaudeTextOutput(" \n ")).toThrow(
+      "Claude returned empty output",
+    );
+  });
+
+  it("preserves Cursor ACP chunks and ignores replacement updates", () => {
+    expect(
+      textFromCursorTextUpdate({
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "  \n" },
+        },
+      }),
+    ).toBe("  \n");
+    expect(
+      textFromCursorTextUpdate({
+        update: {
+          sessionUpdate: "agent_message",
+          messageId: "message-1",
+          content: { type: "text", text: "complete" },
+        },
+      }),
+    ).toBe("");
+  });
+});

--- a/src/lib/sessionStore.test.ts
+++ b/src/lib/sessionStore.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { newSession } from "./session";
-import {
-  isPersistableId,
-  sanitizeSessionForPersist,
-} from "./sessionStore";
+import { isPersistableId, sanitizeSessionForPersist } from "./sessionStore";
 
 describe("isPersistableId", () => {
   it("accepts alphanumeric ids with hyphens and underscores", () => {
@@ -21,11 +18,12 @@ describe("isPersistableId", () => {
 describe("sanitizeSessionForPersist", () => {
   it("omits a path-like provider session id so upsert can still snapshot git", () => {
     const session = newSession("pi", "/tmp/project");
-    session.providerSessionId =
-      "/Users/me/.pi/agent/sessions/abc.jsonl";
+    session.providerSessionId = "/Users/me/.pi/agent/sessions/abc.jsonl";
     session.blocks = [{ id: "u1", role: "user", text: "hey" }];
 
-    expect(sanitizeSessionForPersist(session).providerSessionId).toBeUndefined();
+    expect(
+      sanitizeSessionForPersist(session).providerSessionId,
+    ).toBeUndefined();
   });
 
   it("keeps a UUID provider session id", () => {
@@ -36,6 +34,28 @@ describe("sanitizeSessionForPersist", () => {
     expect(sanitizeSessionForPersist(session).providerSessionId).toBe(
       "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     );
+  });
+
+  it("preserves streamed text through sanitization and JSON serialization", () => {
+    const text = [
+      "# Result\n",
+      "\n",
+      "bookkeeper..\n",
+      "\nfirst line  \nsecond line\n",
+      '\n```ts\nconst value = "hello";\n```',
+    ].join("");
+    const session = newSession("pi", "/tmp/project");
+    session.blocks = [
+      { id: "u1", role: "user", text: "Return exact Markdown" },
+      { id: "a1", role: "assistant", text, streaming: true },
+    ];
+
+    const persisted = sanitizeSessionForPersist(session);
+    const roundTrip = JSON.parse(JSON.stringify(persisted));
+
+    expect(persisted.blocks[1]?.text).toBe(text);
+    expect(persisted.blocks[1]?.streaming).toBeUndefined();
+    expect(roundTrip).toEqual(persisted);
   });
 
   it("keeps a handoff divider and settles a preparing one", () => {


### PR DESCRIPTION
## What changed

- Appends each text delta exactly once.
- Keeps spaces, blank lines, and repeated characters.
- Preserves the order of text and tool calls.

## Why

The PR resolves the text streaming issue as shown in the images below

<img width="1256" height="1502" alt="CleanShot 2026-08-27 at 07 18 02@2x" src="https://github.com/user-attachments/assets/d12d75da-15bb-4522-939a-0ad2d1ae9498" />


## UI

<img width="1928" height="2348" alt="CleanShot 2026-08-27 at 13 34 42@2x" src="https://github.com/user-attachments/assets/1c73037f-71e1-4a7c-a2db-16f0fb0f8219" />


## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes
