### PR TITLE
Make the tab-closing project aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Closing a tab in Deck keeps the active tab in the current project when another tab from that project is open.
 - Streamed Markdown keeps headings, blank lines, tables, and repeated characters. Completed Claude/Codex snapshots no longer paste the same reply twice. Diagnosed in #15 by @kinsomicrote.
 
 ## [0.1.13] - 2026-08-27

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -177,7 +177,12 @@ import {
   rememberProject,
   sameProjectPath,
 } from "./lib/recents";
-import { findTabForProject, filterTabsForProject, workspaceTabCwd } from "./lib/workspaceTabGroups";
+import {
+  filterTabsForProject,
+  findTabForProject,
+  planWorkspaceTabCloseTarget,
+  workspaceTabCwd,
+} from "./lib/workspaceTabGroups";
 import {
   HARNESS_LABEL,
   canReplaceSessionTitle,
@@ -1395,6 +1400,12 @@ export default function App({
       }
 
       const finishClose = () => {
+        const nextActiveTabId = planWorkspaceTabCloseTarget({
+          tabs: current,
+          sessions: sessionsRef.current,
+          closingTabId: id,
+          scope: deckLayout ? "project" : "workspace",
+        });
         const next = current.filter((t) => t.id !== id);
         const gone = new Set(
           leafIds(closing.layout).filter((paneId) =>
@@ -1410,8 +1421,8 @@ export default function App({
           return updated;
         });
         setTabs(next);
-        if (id === activeTabIdRef.current) {
-          activateTab((next[Math.max(0, index - 1)] ?? next[0]).id);
+        if (id === activeTabIdRef.current && nextActiveTabId) {
+          activateTab(nextActiveTabId);
         }
         void refreshHistory(sidebarCwd);
       };
@@ -1426,7 +1437,14 @@ export default function App({
       }
       finishClose();
     },
-    [dirtyFiles, activateTab, persistSession, refreshHistory, sidebarCwd],
+    [
+      dirtyFiles,
+      activateTab,
+      deckLayout,
+      persistSession,
+      refreshHistory,
+      sidebarCwd,
+    ],
   );
 
   const onGroupNewTab = useCallback(

--- a/src/lib/workspaceTabGroups.test.ts
+++ b/src/lib/workspaceTabGroups.test.ts
@@ -4,6 +4,7 @@ import type { Session } from "./session";
 import {
   filterTabsForProject,
   findTabForProject,
+  planWorkspaceTabCloseTarget,
   replaceGroupInTabOrder,
   workspaceTabProject,
 } from "./workspaceTabGroups";
@@ -60,6 +61,102 @@ describe("filterTabsForProject", () => {
     expect(
       filterTabsForProject(tabs, sessions, "/tmp/beta").map((tab) => tab.id),
     ).toEqual(["t2", "t3"]);
+  });
+});
+
+describe("planWorkspaceTabCloseTarget", () => {
+  const sessions = [
+    session("m1", "/projects/monocode"),
+    session("r1", "/projects/ruler"),
+    session("m2", "/projects/monocode"),
+  ];
+  const tabs = [tab("tm1", "m1"), tab("tr1", "r1"), tab("tm2", "m2")];
+
+  it("uses the global neighbor in workspace scope", () => {
+    expect(
+      planWorkspaceTabCloseTarget({
+        tabs,
+        sessions,
+        closingTabId: "tm2",
+        scope: "workspace",
+      }),
+    ).toBe("tr1");
+  });
+
+  it("prefers the previous same-project tab in project scope", () => {
+    expect(
+      planWorkspaceTabCloseTarget({
+        tabs,
+        sessions,
+        closingTabId: "tm2",
+        scope: "project",
+      }),
+    ).toBe("tm1");
+  });
+
+  it("uses the next same-project tab when none exists to the left", () => {
+    expect(
+      planWorkspaceTabCloseTarget({
+        tabs,
+        sessions,
+        closingTabId: "tm1",
+        scope: "project",
+      }),
+    ).toBe("tm2");
+  });
+
+  it("falls back to the global neighbor when the project has no other tab", () => {
+    expect(
+      planWorkspaceTabCloseTarget({
+        tabs: tabs.slice(0, 2),
+        sessions,
+        closingTabId: "tm1",
+        scope: "project",
+      }),
+    ).toBe("tr1");
+  });
+
+  it("uses the global neighbor for a projectless tab", () => {
+    const projectlessSessions = [
+      ...sessions,
+      session("blank1", "~"),
+      session("blank2", "~"),
+    ];
+    expect(
+      planWorkspaceTabCloseTarget({
+        tabs: [tab("projectless", "blank1"), tabs[1]],
+        sessions: projectlessSessions,
+        closingTabId: "projectless",
+        scope: "project",
+      }),
+    ).toBe("tr1");
+    expect(
+      planWorkspaceTabCloseTarget({
+        tabs: [tab("blank1", "blank1"), tabs[1], tab("blank2", "blank2")],
+        sessions: projectlessSessions,
+        closingTabId: "blank2",
+        scope: "project",
+      }),
+    ).toBe("tr1");
+  });
+
+  it("returns undefined for the sole tab or an unknown tab", () => {
+    expect(
+      planWorkspaceTabCloseTarget({
+        tabs: [tabs[0]],
+        sessions,
+        closingTabId: "tm1",
+        scope: "workspace",
+      }),
+    ).toBeUndefined();
+    expect(
+      planWorkspaceTabCloseTarget({
+        tabs,
+        sessions,
+        closingTabId: "missing",
+        scope: "project",
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/src/lib/workspaceTabGroups.ts
+++ b/src/lib/workspaceTabGroups.ts
@@ -54,6 +54,42 @@ export function filterTabsForProject(
   });
 }
 
+export type WorkspaceTabCloseScope = "project" | "workspace";
+
+export function planWorkspaceTabCloseTarget({
+  tabs,
+  sessions,
+  closingTabId,
+  scope,
+}: {
+  tabs: WorkspaceTab[];
+  sessions: Session[];
+  closingTabId: string;
+  scope: WorkspaceTabCloseScope;
+}): string | undefined {
+  const closingIndex = tabs.findIndex((tab) => tab.id === closingTabId);
+  if (closingIndex < 0) return undefined;
+
+  const remaining = tabs.filter((tab) => tab.id !== closingTabId);
+  const globalTarget = remaining[Math.max(0, closingIndex - 1)] ?? remaining[0];
+  if (scope === "workspace") return globalTarget?.id;
+
+  const closingCwd = workspaceTabCwd(tabs[closingIndex], sessions);
+  if (!closingCwd) return globalTarget?.id;
+
+  for (let index = closingIndex - 1; index >= 0; index -= 1) {
+    const cwd = workspaceTabCwd(tabs[index], sessions);
+    if (cwd && sameProjectPath(cwd, closingCwd)) return tabs[index].id;
+  }
+
+  for (let index = closingIndex + 1; index < tabs.length; index += 1) {
+    const cwd = workspaceTabCwd(tabs[index], sessions);
+    if (cwd && sameProjectPath(cwd, closingCwd)) return tabs[index].id;
+  }
+
+  return globalTarget?.id;
+}
+
 export function isGroupableProject(
   project: string | null,
 ): project is string {


### PR DESCRIPTION
## What changed

When closing tabs now, the next tab is scoped to the tabs in that project rather than to global tabs.

## Why

Say you have two projects, monocode and ruler. Then you create a session: monocode, ruler, then monocode. Closing the tab for the second session in monocode moves the user to the tab in the ruler project. 

## UI

<img width="800" height="569" alt="CleanShot 2026-08-28 at 18 40 41" src="https://github.com/user-attachments/assets/5e144c56-7076-45f2-897f-9e3cc78ca02d" />


## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes
