### PR TITLE
Report failed Pi turns and meter their context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A Pi or omp turn that fails now says why. Pi reports a failure inside the assistant message rather than as an error, so an expired provider token ended the turn with no reply and no explanation — it looked like the agent was ignoring you.
+- The context meter stayed at zero for the whole of a Pi or omp turn. Usage was only read from the top of a frame, where Pi never puts it; the meter now follows the turn instead of catching up once it ends.
+
 ## [0.1.16] - 2026-08-28
 
 ### Added

--- a/src/lib/harness/piFamily.ts
+++ b/src/lib/harness/piFamily.ts
@@ -40,6 +40,7 @@ import {
   toolKindFromName,
   toolTitle,
   tryParseJsonRecord,
+  turnErrorFromEvent,
   type PiExtensionUiRequest,
 } from "./piProtocol";
 import type { ApprovalDecision, HarnessEvent, SendTurnInput, SteerTurnInput } from "./types";
@@ -82,6 +83,8 @@ type Live = {
   activeTurn: boolean;
   emittedAssistant: string;
   emittedReasoning: string;
+  /** Reason the turn failed, held until we know it is not being retried. */
+  turnError: string | null;
 };
 
 type Resume = {
@@ -302,7 +305,7 @@ async function startLive(
   const rpc = new PiRpc(input.sessionId, (rec) => {
     const current = liveRef.current;
     if (!current) return;
-    handleFrame(input.sessionId, current, rec);
+    handleFrame(flavor, input.sessionId, current, rec);
   }, flavor.label);
 
   const live: Live = {
@@ -329,6 +332,7 @@ async function startLive(
     activeTurn: false,
     emittedAssistant: "",
     emittedReasoning: "",
+    turnError: null,
   };
   liveRef.current = live;
 
@@ -388,6 +392,7 @@ async function runTurn(live: Live, input: SendTurnInput): Promise<void> {
   await applyModel(live, input);
   live.emittedAssistant = "";
   live.emittedReasoning = "";
+  live.turnError = null;
   live.toolsByIndex.clear();
   live.toolsById.clear();
   live.compacting = false;
@@ -423,6 +428,7 @@ async function runTurn(live: Live, input: SendTurnInput): Promise<void> {
 }
 
 function handleFrame(
+  flavor: PiFlavor,
   sessionId: string,
   live: Live,
   rec: Record<string, unknown>,
@@ -442,6 +448,9 @@ function handleFrame(
 
   const status = statusFromPiEvent(rec);
   if (status) live.onEvent({ type: "status", text: status });
+
+  const turnError = turnErrorFromEvent(rec);
+  if (turnError !== null) live.turnError = turnError;
 
   const context = contextFromUsage(rec, live.contextWindow);
   if (context) live.onEvent({ type: "context", ...context });
@@ -526,13 +535,27 @@ function handleFrame(
   }
 
   if (isAgentSettled(rec)) {
+    flushTurnError(flavor, live);
     void settleTurn(live);
     return;
   }
   const willRetry = agentEndWillRetry(rec);
+  // The retry carries the real answer, so the attempt it replaces stays quiet.
+  if (willRetry === true) live.turnError = null;
   if (willRetry === false && !live.compacting && !live.retrying) {
+    flushTurnError(flavor, live);
     void settleTurn(live);
   }
+}
+
+function flushTurnError(flavor: PiFlavor, live: Live): void {
+  const message = live.turnError;
+  if (message === null) return;
+  live.turnError = null;
+  live.onEvent({
+    type: "session.error",
+    message: message || `${flavor.label} turn failed`,
+  });
 }
 
 async function settleTurn(live: Live): Promise<void> {

--- a/src/lib/harness/piProtocol.test.ts
+++ b/src/lib/harness/piProtocol.test.ts
@@ -23,6 +23,7 @@ import {
   toolExecutionEndFromEvent,
   toolKindFromName,
   toolTitle,
+  turnErrorFromEvent,
 } from "./piProtocol";
 import { OMP_FLAVOR, PI_FLAVOR } from "./piFlavor";
 
@@ -314,10 +315,78 @@ describe("tools and models", () => {
         usage: { totalTokens: 120 },
       }, 200),
     ).toEqual({ used: 120, window: 200 });
+    // The two shapes a live turn actually sends.
+    expect(
+      contextFromUsage(
+        {
+          type: "message_end",
+          message: { role: "assistant", usage: { totalTokens: 18014 } },
+        },
+        200000,
+      ),
+    ).toEqual({ used: 18014, window: 200000 });
+    expect(
+      contextFromUsage(
+        {
+          type: "message_update",
+          assistantMessageEvent: {
+            type: "text_delta",
+            partial: { usage: { input: 3, output: 1, cacheWrite: 18007 } },
+          },
+        },
+        200000,
+      ),
+    ).toEqual({ used: 18011, window: 200000 });
+    expect(
+      contextFromUsage(
+        { type: "message_end", message: { role: "user" } },
+        200000,
+      ),
+    ).toBeNull();
     expect(
       contextFromSessionStats({
         contextUsage: { tokens: 60, contextWindow: 200000, percent: 30 },
       }),
     ).toEqual({ used: 60, window: 200000 });
+  });
+});
+
+describe("turnErrorFromEvent", () => {
+  it("reads the reason a turn failed with no content", () => {
+    expect(
+      turnErrorFromEvent({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: "No API key for provider: openai-codex",
+        },
+      }),
+    ).toBe("No API key for provider: openai-codex");
+  });
+
+  it("still reports a failure that carries no reason", () => {
+    expect(
+      turnErrorFromEvent({
+        type: "message_end",
+        message: { stopReason: "error" },
+      }),
+    ).toBe("");
+  });
+
+  it("ignores healthy messages and other frames", () => {
+    expect(
+      turnErrorFromEvent({
+        type: "message_end",
+        message: { stopReason: "end_turn", content: [{ type: "text", text: "hi" }] },
+      }),
+    ).toBeNull();
+    expect(
+      turnErrorFromEvent({
+        type: "turn_end",
+        message: { stopReason: "error", errorMessage: "boom" },
+      }),
+    ).toBeNull();
   });
 });

--- a/src/lib/harness/piProtocol.ts
+++ b/src/lib/harness/piProtocol.ts
@@ -316,11 +316,20 @@ export function providerSessionIdFromState(data: unknown): string | undefined {
   return sessionId;
 }
 
+/**
+ * Pi never puts usage at the top of a frame: a finished message carries it on
+ * `message`, a streaming one on the partial inside `assistantMessageEvent`.
+ * Reading only the top level meant the meter sat still for the whole turn and
+ * caught up from `get_session_stats` after it ended.
+ */
 export function contextFromUsage(
   rec: Record<string, unknown>,
   window?: number,
 ): { used?: number; window?: number } | null {
-  const usage = asRecord(rec.usage);
+  const usage =
+    asRecord(rec.usage) ??
+    asRecord(asRecord(rec.message)?.usage) ??
+    asRecord(asRecord(asRecord(rec.assistantMessageEvent)?.partial)?.usage);
   if (!usage) return null;
   const used =
     numberField(usage, "totalTokens") ||
@@ -451,6 +460,19 @@ export function toolExecutionEndFromEvent(
     detail: textFromContent(result?.content) || undefined,
     isError: rec.isError === true,
   };
+}
+
+/**
+ * A failed turn is reported inside the assistant message, not as an error
+ * frame: `stopReason: "error"` with the reason in `errorMessage`. Nothing else
+ * marks it, so an expired provider token ended the turn with empty content and
+ * looked like the agent ignoring you. Empty string means "failed, no reason".
+ */
+export function turnErrorFromEvent(rec: Record<string, unknown>): string | null {
+  if (stringField(rec, "type") !== "message_end") return null;
+  const message = asRecord(rec.message);
+  if (stringField(message, "stopReason") !== "error") return null;
+  return stringField(message, "errorMessage") ?? "";
 }
 
 export function isAgentSettled(rec: Record<string, unknown>): boolean {


### PR DESCRIPTION
## What changed

A Pi or omp turn that fails now reports the reason instead of ending silently, and the context meter follows the turn instead of sitting at zero until it is over.

## Why

Pi does not send an error frame when a turn fails. It ends the assistant message with `stopReason: "error"` and the reason in `errorMessage`, and the adapter read neither field, so `settleTurn` closed the turn with no text and no error. On a machine whose provider token had expired, every Pi turn came back empty and it looked like the agent was ignoring the prompt — the CLI had been saying `No API key for provider: openai-codex` the whole time.

The failure is held until `agent_end` reports the turn is not being retried, so an auto-retry does not surface the attempt it replaces.

`contextFromUsage` had the same shape problem in reverse: it only looked at `rec.usage`, the top of a frame, which Pi never populates. A finished message carries usage on `message`, a streaming one on the partial inside `assistantMessageEvent`. The meter therefore stayed at zero for the whole turn and only caught up from `get_session_stats` once it settled.

Codex already maps a failed turn to `session.error`; this brings Pi in line.

## UI

No layout change. A failed turn now renders the harness error the transcript already has a place for, where it previously rendered nothing.

## Notes

Frame shapes were captured from a live `pi --mode rpc` turn on `claude-sonnet-4-6` (pi 0.80.2) and the new tests assert against those exact shapes, including the `message_end` / `message_update` split and the user-message frame that must stay `null`.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes
