### PR TITLE
Read model catalogs on demand instead of at launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Model catalogs are read on demand instead of at launch. MonoCode used to start every installed provider CLI on startup just to list its models, so an agent you never opened still showed up in Activity Monitor. Now only the providers your open sessions use are read at launch; the rest are read when you open their tab in the model picker, or when you open Settings → Providers. ([#19](https://github.com/hardbeat920/monocode/issues/19))
+
+### Fixed
+
+- A model-catalog or usage probe left behind by a window reload or close is now killed by the backend instead of living on. One stranded `pi` probe had reached 1 GB and 14 minutes of CPU. ([#19](https://github.com/hardbeat920/monocode/issues/19))
+- Listing Pi's models no longer loads your extensions: 0.8s and 190 MB instead of 2.9s and 357 MB, and one fewer child process.
+
 ## [0.1.16] - 2026-08-28
 
 ### Added

--- a/src-tauri/src/harness.rs
+++ b/src-tauri/src/harness.rs
@@ -107,6 +107,17 @@ impl HarnessHost {
             .remove(session_id)
     }
 
+    /// Shared ids (`monocode-*-probe`, `monocode-*-text`) get respawned under
+    /// the same key, so a dying generation must not evict the child that
+    /// replaced it — that entry is the only handle `kill_all` has left.
+    fn remove_pid(&self, session_id: &str, pid: u32) -> Option<Arc<LiveChild>> {
+        let mut map = self.children.lock().unwrap_or_else(|e| e.into_inner());
+        match map.get(session_id) {
+            Some(live) if live.pid == pid => map.remove(session_id),
+            _ => None,
+        }
+    }
+
     pub(crate) fn kill_all(&self) {
         let kids: Vec<Arc<LiveChild>> = {
             let mut map = self.children.lock().unwrap_or_else(|e| e.into_inner());
@@ -249,6 +260,11 @@ pub fn harness_free_port() -> Result<u16, String> {
         .map_err(|e| format!("Failed to reserve a local port: {e}"))
 }
 
+/// `ttl_ms` is the safety net for one-shot children (catalog and usage probes).
+/// Nothing but the caller's own `finally` used to kill them, so a webview
+/// reload or a closed window stranded a full agent process — one leaked `pi`
+/// probe sat at 1 GB and 14 minutes of CPU. The watchdog only fires when the
+/// entry is still the child it spawned, so a normal kill or a respawn wins.
 #[tauri::command]
 pub fn harness_spawn(
     app: AppHandle,
@@ -257,6 +273,7 @@ pub fn harness_spawn(
     command: String,
     args: Vec<String>,
     cwd: String,
+    ttl_ms: Option<u64>,
 ) -> Result<u32, String> {
     if let Some(prev) = host.remove(&session_id) {
         terminate(prev.pid);
@@ -332,6 +349,20 @@ pub fn harness_spawn(
         }
     });
 
+    if let Some(ttl) = ttl_ms.filter(|ms| *ms > 0) {
+        let ttl_app = app.clone();
+        let ttl_id = session_id.clone();
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(ttl));
+            let Some(host) = ttl_app.try_state::<HarnessHost>() else {
+                return;
+            };
+            if host.remove_pid(&ttl_id, pid).is_some() {
+                terminate(pid);
+            }
+        });
+    }
+
     let wait_app = app.clone();
     let wait_id = session_id;
     let wait_pid = pid;
@@ -339,7 +370,7 @@ pub fn harness_spawn(
         let code = child.wait().ok().and_then(|status| status.code());
         if let Some(host) = wait_app.try_state::<HarnessHost>() {
             host.stop_sse(&wait_id);
-            host.remove(&wait_id);
+            host.remove_pid(&wait_id, wait_pid);
         }
         let _ = wait_app.emit(
             EXIT_EVENT,
@@ -1343,6 +1374,41 @@ mod tests {
             let _ = child.kill();
             panic!("process group survived after its leader exited");
         }
+    }
+
+    /// Real stdin handle, dead process: `remove_pid` only compares pids, and a
+    /// fake pid must never reach `terminate`.
+    fn live_child(pid: u32) -> Arc<LiveChild> {
+        let mut child = Command::new("sh")
+            .args(["-c", "exit 0"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn test process");
+        let stdin = child.stdin.take().expect("stdin");
+        let _ = child.wait();
+        Arc::new(LiveChild {
+            stdin: Mutex::new(stdin),
+            pid,
+        })
+    }
+
+    #[test]
+    fn a_dead_generation_does_not_evict_its_replacement() {
+        let host = HarnessHost::new();
+        host.insert("monocode-pi-probe".into(), live_child(4001));
+        host.insert("monocode-pi-probe".into(), live_child(4002));
+
+        // The replaced child's wait thread lands after the respawn.
+        assert!(host.remove_pid("monocode-pi-probe", 4001).is_none());
+        assert!(
+            host.get("monocode-pi-probe").is_some(),
+            "replacement lost its registry entry, so kill_all can never reach it"
+        );
+
+        assert!(host.remove_pid("monocode-pi-probe", 4002).is_some());
+        assert!(host.get("monocode-pi-probe").is_none());
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -606,7 +606,12 @@ export default function App({
 
   useEffect(() => {
     void probeHarnessAvailability();
-    void refreshHarnessCatalogs().then(() => {
+    // Only the providers already on screen. Probing the rest would spawn a CLI
+    // for an agent the user may never open — see issue #19.
+    const inUse = sessionsRef.current
+      .filter((session) => isLiveHarness(session.harness))
+      .map((session) => session.harness);
+    void refreshHarnessCatalogs(inUse).then(() => {
       setSessions((prev) =>
         prev.map((session) => {
           if (!isLiveHarness(session.harness)) return session;

--- a/src/chrome/ModelPicker.tsx
+++ b/src/chrome/ModelPicker.tsx
@@ -28,7 +28,7 @@ import {
   type AgentModel,
   type ModelPickerTab,
 } from "../lib/models";
-import { refreshCodexCatalog } from "../lib/harness/codexCatalog";
+import { refreshHarnessCatalog } from "../lib/harness/registry";
 import {
   harnessUnavailableHint,
   hasProbedHarnessAvailability,
@@ -159,10 +159,11 @@ export function ModelPicker({
     setQuery("");
   }, [open]);
 
+  // The tab the user is looking at is the one provider they have asked about,
+  // so its catalog probe is the only CLI worth spawning.
   useEffect(() => {
-    if (!open || visibleTab !== "codex") return;
-    if (modelsFor("codex").length > 0) return;
-    void refreshCodexCatalog();
+    if (!open || visibleTab === "favorites") return;
+    void refreshHarnessCatalog(visibleTab);
   }, [open, visibleTab]);
 
   useLayoutEffect(() => {

--- a/src/lib/harness/child.ts
+++ b/src/lib/harness/child.ts
@@ -168,17 +168,25 @@ export function unwatchSse(sessionId: string) {
   sseBuffer.delete(sessionId);
 }
 
+/**
+ * `ttlMs` hands the kill to Rust for one-shot children. Our own cleanup is a
+ * `finally` in the webview, which never runs if the window reloads or closes
+ * mid-probe — that stranded a `pi` catalog probe at 1 GB for a whole session.
+ * Pass it only for children we always expect to kill ourselves.
+ */
 export async function spawnChild(
   sessionId: string,
   command: string,
   args: string[],
   cwd: string,
+  ttlMs?: number,
 ): Promise<void> {
   const pid = await invoke<number>("harness_spawn", {
     sessionId,
     command,
     args,
     cwd,
+    ttlMs,
   });
   if (typeof pid === "number" && pid > 0) livePid.set(sessionId, pid);
 }

--- a/src/lib/harness/codexCatalog.ts
+++ b/src/lib/harness/codexCatalog.ts
@@ -17,6 +17,8 @@ import { JsonRpcClient } from "./jsonRpc";
 
 const PROBE_ID = "monocode-codex-probe";
 const DISCOVERY_TIMEOUT_MS = 15_000;
+/** Rust-side backstop, above the timeout so our own cleanup normally wins. */
+const PROBE_TTL_MS = 30_000;
 const REQUEST_TIMEOUT_MS = 12_000;
 
 const REASONING_LABELS: Record<string, string> = {
@@ -73,7 +75,7 @@ async function discoverCodexModels(): Promise<AgentModel[]> {
   );
 
   try {
-    await spawnChild(PROBE_ID, path, ["app-server"], cwd);
+    await spawnChild(PROBE_ID, path, ["app-server"], cwd, PROBE_TTL_MS);
     return await withTimeout(DISCOVERY_TIMEOUT_MS, async () => {
       await rpc.request(
         "initialize",

--- a/src/lib/harness/cursorCatalog.ts
+++ b/src/lib/harness/cursorCatalog.ts
@@ -17,6 +17,8 @@ import {
 
 const PROBE_ID = "monocode-cursor-probe";
 const DISCOVERY_TIMEOUT_MS = 15_000;
+/** Rust-side backstop, above the timeout so our own cleanup normally wins. */
+const PROBE_TTL_MS = 30_000;
 const REQUEST_TIMEOUT_MS = 12_000;
 
 const CURSOR_CLIENT_CAPABILITIES = {
@@ -76,7 +78,7 @@ async function discoverViaAcp(): Promise<AgentModel[]> {
   );
 
   try {
-    await spawnChild(PROBE_ID, path, ["acp"], cwd);
+    await spawnChild(PROBE_ID, path, ["acp"], cwd, PROBE_TTL_MS);
     return await withTimeout(DISCOVERY_TIMEOUT_MS, async () => {
       await acp.request(
         "initialize",

--- a/src/lib/harness/index.ts
+++ b/src/lib/harness/index.ts
@@ -115,6 +115,7 @@ export {
   stopHarnessSession,
   forgetHarnessSession,
   bindHarnessSession,
+  refreshHarnessCatalog,
   refreshHarnessCatalogs,
   generateHarnessTitle,
   generateHarnessCommitMessage,

--- a/src/lib/harness/piCatalog.ts
+++ b/src/lib/harness/piCatalog.ts
@@ -11,6 +11,8 @@ import { OMP_FLAVOR, PI_FLAVOR, type PiFlavor } from "./piFlavor";
 import { buildPiSpawnArgs, modelsFromRpcData } from "./piProtocol";
 
 const DISCOVERY_TIMEOUT_MS = 45_000;
+/** Rust-side backstop, above the timeout so our own cleanup normally wins. */
+const PROBE_TTL_MS = 60_000;
 
 const inflight = new Map<string, Promise<void>>();
 
@@ -53,8 +55,12 @@ async function discoverModels(flavor: PiFlavor) {
     await spawnChild(
       probeId,
       path,
-      buildPiSpawnArgs(flavor, { noSession: true }),
+      // Listing models needs no extension host. Loading one cost 2.9s and
+      // 357 MB against 0.8s and 190 MB, and it is what pulled in the child
+      // process that kept the leaked probe busy.
+      buildPiSpawnArgs(flavor, { noSession: true, noExtensions: true }),
       cwd,
+      PROBE_TTL_MS,
     );
     const response = await Promise.race([
       rpc.request({ type: "get_available_models" }, DISCOVERY_TIMEOUT_MS),

--- a/src/lib/harness/registry.test.ts
+++ b/src/lib/harness/registry.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   isLiveHarness,
   listHarnesses,
+  refreshHarnessCatalog,
+  refreshHarnessCatalogs,
   registerHarness,
   type HarnessAdapter,
 } from "./registry";
@@ -34,5 +36,39 @@ describe("harness registry", () => {
       "codex",
       "cursor",
     ]);
+  });
+});
+
+describe("catalog refresh", () => {
+  it("probes a provider once, and only the ones asked for", async () => {
+    const calls: string[] = [];
+    const withCatalog = (id: "cursor" | "codex" | "claude") => ({
+      ...stub(id, true),
+      refreshCatalog: async () => {
+        calls.push(id);
+      },
+    });
+    registerHarness(withCatalog("cursor"));
+    registerHarness(withCatalog("codex"));
+
+    await refreshHarnessCatalogs(["cursor", "cursor"]);
+    await refreshHarnessCatalog("cursor");
+    expect(calls).toEqual(["cursor"]);
+  });
+
+  it("lets a failed probe run again", async () => {
+    let attempts = 0;
+    registerHarness({
+      ...stub("claude", true),
+      refreshCatalog: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("cli busy");
+      },
+    });
+
+    await refreshHarnessCatalog("claude");
+    await refreshHarnessCatalog("claude");
+    await refreshHarnessCatalog("claude");
+    expect(attempts).toBe(2);
   });
 });

--- a/src/lib/harness/registry.ts
+++ b/src/lib/harness/registry.ts
@@ -147,14 +147,31 @@ export function bindHarnessSession(
   getHarness(harness)?.bindSession(threadId, providerSessionId, cwd);
 }
 
-export async function refreshHarnessCatalogs(): Promise<void> {
-  await Promise.all(
-    [...adapters.values()].map((adapter) =>
-      adapter.refreshCatalog?.().catch((error: unknown) => {
-        console.debug(`[monocode] ${adapter.id} catalog`, error);
-      }),
-    ),
-  );
+/**
+ * A catalog probe spawns the provider's own CLI, so it has to stay on demand:
+ * refreshing every adapter at launch is what left `pi` running in the
+ * background for people who only use Claude and Codex. Once per run is enough
+ * — a catalog only changes when the CLI is upgraded, which restarts us anyway.
+ */
+const refreshedCatalogs = new Set<HarnessId>();
+
+export async function refreshHarnessCatalog(harness: HarnessId): Promise<void> {
+  const adapter = getHarness(harness);
+  if (!adapter?.refreshCatalog || refreshedCatalogs.has(harness)) return;
+  refreshedCatalogs.add(harness);
+  try {
+    await adapter.refreshCatalog();
+  } catch (error: unknown) {
+    // A CLI that was missing or busy this time gets another chance later.
+    refreshedCatalogs.delete(harness);
+    console.debug(`[monocode] ${harness} catalog`, error);
+  }
+}
+
+export async function refreshHarnessCatalogs(
+  harnesses: Iterable<HarnessId>,
+): Promise<void> {
+  await Promise.all([...new Set(harnesses)].map(refreshHarnessCatalog));
 }
 
 export async function generateHarnessTitle(

--- a/src/lib/rateLimitsFetch.ts
+++ b/src/lib/rateLimitsFetch.ts
@@ -19,6 +19,8 @@ import { JsonRpcClient } from "./harness/jsonRpc";
 
 const USAGE_CHILD_ID = "monocode-codex-usage";
 const DISCOVERY_TIMEOUT_MS = 15_000;
+/** Rust-side backstop, above the timeout so our own cleanup normally wins. */
+const USAGE_TTL_MS = 30_000;
 const REQUEST_TIMEOUT_MS = 12_000;
 
 type ClaudeUsageFetch = {
@@ -91,7 +93,7 @@ export async function fetchCodexRateLimits(): Promise<ProviderRateLimits> {
   );
 
   try {
-    await spawnChild(USAGE_CHILD_ID, path, ["app-server"], cwd);
+    await spawnChild(USAGE_CHILD_ID, path, ["app-server"], cwd, USAGE_TTL_MS);
     return await withTimeout(
       DISCOVERY_TIMEOUT_MS,
       async () => {

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -70,6 +70,7 @@ import {
   probeHarnessAvailability,
   subscribeHarnessAvailability,
 } from "../lib/harness/availability";
+import { refreshHarnessCatalogs } from "../lib/harness/registry";
 import {
   defaultModelId,
   getModelSnapshot,
@@ -785,8 +786,11 @@ function ProvidersPage() {
   const [choice, setChoice] = useState(loadLastModelChoice);
   const [defaultModels, setDefaultModels] = useState(loadDefaultModels);
 
+  // This page lists every provider's model, so the probes belong here rather
+  // than at launch, where they spawned CLIs nobody had asked for.
   useEffect(() => {
     void probeHarnessAvailability();
+    void refreshHarnessCatalogs(HARNESSES);
   }, []);
 
   const onModelChange = (harness: HarnessId, model: string) => {


### PR DESCRIPTION
## What changed

Model catalogs are read on demand instead of at launch, and the one-shot probe children now have an owner on the Rust side that outlives the webview.

Closes #19.

## Why

`refreshHarnessCatalogs()` ran on app mount and called every registered adapter, so each installed provider CLI was started at launch purely to list its models. Someone using only Claude and Codex still got a `pi` process in Activity Monitor, which is exactly what #19 reports.

Catalogs are now read for the providers that open sessions already use. The rest wait until the user asks: their tab in the model picker, or Settings → Providers, which is the one page that lists every provider's models and so is the right place to pay for the probes. This generalises the lazy refresh the codex tab already did for itself, and `refreshHarnessCatalog` keeps a per-run set so a probe does not repeat — while a failed probe is dropped from that set so a CLI that was missing or busy gets another chance.

The probes also had no owner. Cleanup was a `finally` in the webview, which never runs if the window reloads or closes mid-probe; the leaked `pi` probe in #19 had reached 1 GB and 14 minutes of CPU. One-shot children now pass a `ttl_ms` that `harness_spawn` enforces from a watchdog thread. It only fires while the registry entry is still the child it spawned, so a normal kill or a respawn wins the race. The wait thread matches on pid for the same reason: shared ids (`monocode-*-probe`, `monocode-*-text`) get respawned under one key, and a dying generation must not evict the child that replaced it — that entry is the only handle `kill_all` has left.

Listing Pi's models needs no extension host either. Loading one cost 2.9s and 357 MB against 0.8s and 190 MB, and it pulled in the child process that kept the leaked probe busy. The model list is identical either way.

## UI

No visible change. The model picker fills its tab on open the way the codex tab already did; the CLI availability probe still runs at startup, so the installed/not-installed hints are unaffected.

## Notes

`a_dead_generation_does_not_evict_its_replacement` covers the pid-matching rule with a real stdin handle on a dead process, so a fake pid can never reach `terminate`.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes
