### PR TITLE
Run Claude Code hooks in interactive sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Claude Code hooks now run. MonoCode used to launch the CLI with `disableAllHooks`, so every hook in your `settings.json` — command rewrites, blocks, notifications — was silently skipped. Settings → General has a "Claude Code hooks" toggle (on by default) to turn them back off if one misbehaves. MonoCode's own helper spawns, like title generation, stay hook-free.
+
+### Changed
+
+- A permission prompt that a `PermissionRequest` hook resolves before you do is no longer labelled "Rejected" in the transcript.
+
 ## [0.1.16] - 2026-08-28
 
 ### Added

--- a/src/lib/harness/claude.ts
+++ b/src/lib/harness/claude.ts
@@ -1,5 +1,6 @@
 import { nativeModelId } from "../models";
 import type { RuntimeMode } from "../session";
+import { loadClaudeHooks } from "../settings";
 import {
   killChild,
   resolveClaudeBinary,
@@ -51,11 +52,18 @@ import {
 import { joinStreamText, snapshotRemainder } from "./streamText";
 import type { ApprovalDecision, HarnessEvent, SendTurnInput, SteerTurnInput } from "./types";
 
+/**
+ * A PermissionRequest hook can decide before the user touches the prompt; Claude
+ * then cancels the control request out from under us. That is not a rejection,
+ * so it gets its own outcome instead of being folded into "deny".
+ */
+type ApprovalOutcome = ApprovalDecision | "cancelled";
+
 type PendingApproval = {
   requestId: string;
   input: Record<string, unknown>;
   kind: "permission" | "question";
-  resolve: (decision: ApprovalDecision) => void;
+  resolve: (decision: ApprovalOutcome) => void;
 };
 
 type InFlightTool = {
@@ -370,7 +378,7 @@ function handleLine(sessionId: string, live: Live, line: string): void {
   if (cancelId) {
     for (const [uiId, pending] of live.approvals) {
       if (pending.requestId === cancelId) {
-        pending.resolve("deny");
+        pending.resolve("cancelled");
         live.approvals.delete(uiId);
       }
     }
@@ -600,6 +608,7 @@ async function handleControlRequest(
     });
     const decision = await waitApproval(live, uiId, control.requestId, input, "question");
     live.onEvent({ type: "approval.resolved", requestId: uiId, decision });
+    if (decision === "cancelled") return;
     const response =
       decision === "allow"
         ? { behavior: "allow", updatedInput: askUserQuestionAllowInput(input) }
@@ -652,6 +661,7 @@ async function handleControlRequest(
   });
   const decision = await waitApproval(live, uiId, control.requestId, input, "permission");
   live.onEvent({ type: "approval.resolved", requestId: uiId, decision });
+  if (decision === "cancelled") return;
   await writeJson(
     sessionId,
     buildControlResponse(
@@ -689,7 +699,7 @@ function waitApproval(
   requestId: string,
   input: Record<string, unknown>,
   kind: "permission" | "question",
-): Promise<ApprovalDecision> {
+): Promise<ApprovalOutcome> {
   return new Promise((resolve) => {
     live.approvals.set(uiId, { requestId, input, kind, resolve });
   });
@@ -766,6 +776,7 @@ function settingsKeyFor(input: SendTurnInput): string {
     thinking: input.modelSettings?.thinking,
     context: input.modelSettings?.context,
     runtimeMode: input.runtimeMode,
+    hooks: loadClaudeHooks(),
   });
 }
 
@@ -793,6 +804,9 @@ function launchOptions(
   }
   if (isClaudeUltracodeEffort(effortRaw)) {
     settings.ultracode = true;
+  }
+  if (!loadClaudeHooks()) {
+    settings.disableAllHooks = true;
   }
   return {
     model: resolveClaudeApiModelId(native, context),

--- a/src/lib/harness/claudeProtocol.test.ts
+++ b/src/lib/harness/claudeProtocol.test.ts
@@ -87,6 +87,12 @@ describe("buildClaudeSpawnArgs", () => {
     );
     expect(args).toEqual(expect.arrayContaining(["--session-id", "sess-1"]));
     const settings = args[args.indexOf("--settings") + 1];
+    expect(JSON.parse(settings).disableAllHooks).toBeUndefined();
+  });
+
+  it("only disables hooks for interactive sessions when asked", () => {
+    const args = buildClaudeSpawnArgs({ settings: { disableAllHooks: true } });
+    const settings = args[args.indexOf("--settings") + 1];
     expect(JSON.parse(settings)).toMatchObject({ disableAllHooks: true });
   });
 

--- a/src/lib/harness/claudeProtocol.ts
+++ b/src/lib/harness/claudeProtocol.ts
@@ -217,11 +217,12 @@ export function buildClaudeSpawnArgs(input: {
   if (input.includePartialMessages !== false) {
     args.push("--include-partial-messages");
   }
-  // PermissionRequest hooks run in parallel with the stdio prompt and dismiss
-  // it when they return allow/deny. MonoCode is the approval UI, so hooks
-  const settings = {
-    disableAllHooks: true,
+  // Isolated spawns are MonoCode's own helper calls (titles, summaries); the
+  // user's hooks have no business firing there. Interactive sessions inherit
+  // whatever the caller decided so `~/.claude` hooks keep working.
+  const settings: ClaudeCliSettings = {
     ...input.settings,
+    ...(input.isolated ? { disableAllHooks: true } : {}),
   };
   if (input.isolated) {
     args.push("--no-session-persistence");
@@ -711,6 +712,7 @@ export function claudeSettingsKey(input: {
   thinking?: string;
   context?: string;
   runtimeMode: RuntimeMode;
+  hooks?: boolean;
 }): string {
   return [
     input.model,
@@ -719,6 +721,7 @@ export function claudeSettingsKey(input: {
     input.thinking ?? "",
     input.context ?? "",
     input.runtimeMode,
+    input.hooks === false ? "nohooks" : "hooks",
   ].join("|");
 }
 

--- a/src/lib/harness/types.ts
+++ b/src/lib/harness/types.ts
@@ -38,7 +38,8 @@ export type HarnessEvent =
   | {
       type: "approval.resolved";
       requestId: number;
-      decision: "allow" | "deny";
+      /** "cancelled" = a PermissionRequest hook decided before the user could. */
+      decision: "allow" | "deny" | "cancelled";
     }
   | { type: "plan"; text: string }
   /** Context-window level after the harness's latest request. */

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -105,7 +105,7 @@ export type Block = {
   };
   approval?: {
     requestId: number;
-    decided?: "allow" | "deny";
+    decided?: "allow" | "deny" | "cancelled";
   };
   handoff?: HandoffMeta;
 };

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -109,6 +109,28 @@ export function saveComposerRunner(value: boolean) {
   );
 }
 
+const CLAUDE_HOOKS_KEY = "monocode.claudeHooks";
+
+export const CLAUDE_HOOKS_DEFAULT = true;
+
+export function loadClaudeHooks(): boolean {
+  try {
+    const raw = localStorage.getItem(CLAUDE_HOOKS_KEY);
+    if (raw == null) return CLAUDE_HOOKS_DEFAULT;
+    return raw === "1" || raw === "true";
+  } catch {
+    return CLAUDE_HOOKS_DEFAULT;
+  }
+}
+
+export function saveClaudeHooks(value: boolean) {
+  try {
+    localStorage.setItem(CLAUDE_HOOKS_KEY, value ? "1" : "0");
+  } catch {
+    // private mode / quota
+  }
+}
+
 const CTRL = IS_MAC ? "⌃" : "Ctrl+";
 
 export type KeybindingRow = {

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -117,7 +117,9 @@ import { loadTabGroupLabels, resolveTabGroupLabel } from "../lib/tabGroups";
 import {
   filterKeybindings,
   KEYBINDINGS,
+  loadClaudeHooks,
   loadComposerRunner,
+  saveClaudeHooks,
   saveComposerRunner,
   settingsSectionDescription,
   settingsSectionLabel,
@@ -250,6 +252,7 @@ function GeneralPage() {
   );
   const [transcriptZen, setTranscriptZen] = useState(loadTranscriptZen);
   const [composerRunner, setComposerRunner] = useState(loadComposerRunner);
+  const [claudeHooks, setClaudeHooks] = useState(loadClaudeHooks);
 
   useEffect(() => {
     const onChange = (event: Event) => {
@@ -278,6 +281,11 @@ function GeneralPage() {
   const onComposerRunner = (next: boolean) => {
     saveComposerRunner(next);
     setComposerRunner(next);
+  };
+
+  const onClaudeHooks = (next: boolean) => {
+    saveClaudeHooks(next);
+    setClaudeHooks(next);
   };
 
   return (
@@ -328,6 +336,16 @@ function GeneralPage() {
           label="Composer mascot"
           on={composerRunner}
           onChange={onComposerRunner}
+        />
+      </Row>
+      <Row
+        label="Claude Code hooks"
+        description="Run the hooks configured in your settings.json files — PreToolUse command rewrites, blocks, notifications, and the rest — just as the Claude Code CLI would. Turn this off if a hook is misbehaving and you need the session back. Takes effect on the next turn."
+      >
+        <Toggle
+          label="Claude Code hooks"
+          on={claudeHooks}
+          onChange={onClaudeHooks}
         />
       </Row>
 

--- a/src/surfaces/transcriptActivity.ts
+++ b/src/surfaces/transcriptActivity.ts
@@ -38,7 +38,9 @@ export function toolCallState(block: Block): ToolCallState {
   ) {
     return "pending";
   }
-  if (decided === "allow" || !status) return "accepted";
+  if (decided === "allow" || decided === "cancelled" || !status) {
+    return "accepted";
+  }
   return "pending";
 }
 


### PR DESCRIPTION
## What changed

Claude Code hooks configured in the user's `settings.json` now run in interactive sessions, with a Settings → General toggle to turn them back off.

## Why

MonoCode launched the CLI with `disableAllHooks`, so every hook a user had configured — `PreToolUse` command rewrites, blocks, notifications — was silently skipped. Nothing surfaced that they had been dropped, so a hook that worked in the terminal simply did nothing in MonoCode.

Hooks are now disabled only for isolated spawns, which are MonoCode's own helper calls such as title and summary generation. Those should not fire a user's hooks, and they still do not.

The toggle (on by default) is the escape hatch for a hook that misbehaves badly enough to need the session back without editing `settings.json`.

Turning hooks on exposed a second bug: a `PermissionRequest` hook can resolve a prompt before the user does, and the transcript labelled that "Rejected". The approval decision gains a `cancelled` state so the transcript stops blaming the user for a decision a hook made.

## UI

Settings → General gains a "Claude Code hooks" row. A permission prompt resolved by a hook no longer shows "Rejected".

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes
