### PR TITLE
Scope session changes to the session's own baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The Changes panel has a Project/Session toggle. The session view lists only the files that session touched, each with its own Keep and Undo, and opening one diffs it against the snapshot taken when the session started instead of against the index. A session review tab and a project review tab of the same file are now separate tabs.
+
+### Fixed
+
+- A session's file list took its line counts from git's HEAD numbers, so a file that was already dirty when the session started billed someone else's edits to that session.
+
 ## [0.1.16] - 2026-08-28
 
 ### Added

--- a/src-tauri/src/checkpoint.rs
+++ b/src-tauri/src/checkpoint.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager, State};
 
 use crate::fs::{
-    expand_home, git_checked, git_diff_files_for, resolve_repo_path, GitChangedFile, GitDiffIndex,
-    GitDiffStats, MAX_TEXT_FILE_BYTES,
+    expand_home, git_checked, git_diff_files_for, git_file_diff_for, resolve_repo_path,
+    GitChangedFile, GitDiffIndex, GitDiffStats, GitFileDiff, MAX_TEXT_FILE_BYTES,
 };
 
 const MAX_SNAPSHOT_FILES: usize = 500;
@@ -135,7 +135,10 @@ impl CheckpointStore {
             if manifest.files.contains_key(&relative) {
                 continue;
             }
-            if !file_differs(&dir, &root, &manifest, &relative, &git_dirty) {
+            if matches!(
+                session_change(&dir, &root, &manifest, &relative, &git_dirty),
+                Change::None
+            ) {
                 continue;
             }
             if in_head(&root, &relative) && manifest.tracked.insert(relative.clone()) {
@@ -232,6 +235,30 @@ impl CheckpointStore {
             .insert(relative.clone(), snapshot_file(&dir, &root, &relative)?);
         write_manifest(&dir, &manifest)?;
         self.status(session_id, cwd)
+    }
+
+    /// Diff base for review: the session's snapshot when it has one, else HEAD
+    /// (the path was clean at session start, so HEAD is that same baseline).
+    fn file_diff(
+        &self,
+        session_id: &str,
+        cwd: &str,
+        relative: &str,
+    ) -> Result<GitFileDiff, String> {
+        let root = project_root(cwd)?;
+        let relative = resolve_repo_path(&root, relative)?;
+        let kind = self
+            .load_matching(session_id, cwd)?
+            .and_then(|manifest| manifest.files.get(&relative).copied());
+        match kind {
+            Some(kind) => Ok(checkpoint_file_diff(
+                &self.session_dir(session_id),
+                &root,
+                &relative,
+                kind,
+            )),
+            None => git_file_diff_for(&root, &relative),
+        }
     }
 
     fn load_matching(&self, session_id: &str, cwd: &str) -> Result<Option<Manifest>, String> {
@@ -395,6 +422,20 @@ pub async fn session_checkpoint_stats(
 }
 
 #[tauri::command]
+pub async fn session_checkpoint_file_diff(
+    store: State<'_, CheckpointStore>,
+    session_id: String,
+    cwd: String,
+    relative: String,
+) -> Result<GitFileDiff, String> {
+    validate_id(&session_id, "session")?;
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || store.file_diff(&session_id, &cwd, &relative))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
 pub async fn session_checkpoint_undo(
     store: State<'_, CheckpointStore>,
     session_id: String,
@@ -441,14 +482,17 @@ fn diff_from_manifest_with(
     let mut files = Vec::new();
 
     for relative in &manifest.touched {
-        if !file_differs(dir, root, manifest, relative, &git_dirty) {
-            continue;
+        match session_change(dir, root, manifest, relative, &git_dirty) {
+            Change::None => continue,
+            Change::Snapshot(before, after) => {
+                files.push(describe_snapshot_change(root, relative, &before, &after));
+            }
+            Change::Head => files.push(describe_head_change(
+                root,
+                relative,
+                by_relative.get(relative.as_str()).copied(),
+            )),
         }
-        files.push(describe_change(
-            root,
-            relative,
-            by_relative.get(relative.as_str()).copied(),
-        ));
     }
 
     files.sort_by(|a, b| a.relative.cmp(&b.relative));
@@ -469,31 +513,73 @@ fn stats_from_status(status: &CheckpointStatus) -> GitDiffStats {
     }
 }
 
-fn file_differs(
+/// What this session did to one path, and against which baseline.
+enum Change {
+    None,
+    /// Snapshotted because the path was already dirty at session start, so its
+    /// baseline is the snapshot. Both sides are carried to avoid a second read.
+    Snapshot(FileState, FileState),
+    /// Clean at session start, so HEAD is the baseline and git's counts apply.
+    Head,
+}
+
+fn session_change(
     dir: &Path,
     root: &Path,
     manifest: &Manifest,
     relative: &str,
     git_dirty: &HashSet<&str>,
-) -> bool {
+) -> Change {
     // Once a tracked path is clean against HEAD, its session change was
     // committed (or otherwise resolved) and no longer needs review.
     if !git_dirty.contains(relative)
         && (manifest.tracked.contains(relative) || in_head(root, relative))
     {
-        return false;
+        return Change::None;
     }
     match manifest.files.get(relative) {
-        Some(SnapshotKind::Skipped) => false,
-        Some(kind) => read_worktree(root, relative) != read_snapshot(dir, relative, *kind),
+        Some(SnapshotKind::Skipped) => Change::None,
+        Some(kind) => {
+            let before = read_snapshot(dir, relative, *kind);
+            let after = read_worktree(root, relative);
+            if before == after {
+                return Change::None;
+            }
+            Change::Snapshot(before, after)
+        }
         None => {
-            git_dirty.contains(relative)
-                || (root.join(relative).is_file() && !in_head(root, relative))
+            let changed = git_dirty.contains(relative)
+                || (root.join(relative).is_file() && !in_head(root, relative));
+            if changed {
+                Change::Head
+            } else {
+                Change::None
+            }
         }
     }
 }
 
-fn describe_change(root: &Path, relative: &str, git: Option<&GitChangedFile>) -> CheckpointFile {
+fn describe_snapshot_change(
+    root: &Path,
+    relative: &str,
+    before: &FileState,
+    after: &FileState,
+) -> CheckpointFile {
+    let (additions, deletions) = line_diff_counts(before, after);
+    CheckpointFile {
+        path: root.join(relative).to_string_lossy().into_owned(),
+        relative: relative.to_string(),
+        status: change_status(before, after).into(),
+        additions,
+        deletions,
+    }
+}
+
+fn describe_head_change(
+    root: &Path,
+    relative: &str,
+    git: Option<&GitChangedFile>,
+) -> CheckpointFile {
     if let Some(file) = git {
         return CheckpointFile {
             path: file.path.clone(),
@@ -512,6 +598,125 @@ fn describe_change(root: &Path, relative: &str, git: Option<&GitChangedFile>) ->
         additions: 0,
         deletions: 0,
     }
+}
+
+fn change_status(before: &FileState, after: &FileState) -> &'static str {
+    match (before, after) {
+        (FileState::Missing, _) => "added",
+        (_, FileState::Missing) => "deleted",
+        _ => "modified",
+    }
+}
+
+fn state_bytes(state: &FileState) -> &[u8] {
+    match state {
+        FileState::Contents(bytes) => bytes,
+        FileState::Missing | FileState::Skipped => &[],
+    }
+}
+
+/// Baseline vs worktree contents for one file, shaped like the HEAD diff so the
+/// editor can render either base with the same merge view.
+fn checkpoint_file_diff(
+    dir: &Path,
+    root: &Path,
+    relative: &str,
+    kind: SnapshotKind,
+) -> GitFileDiff {
+    let before = read_snapshot(dir, relative, kind);
+    let after = read_worktree(root, relative);
+    let status = change_status(&before, &after);
+    let too_large = matches!(before, FileState::Skipped) || matches!(after, FileState::Skipped);
+    let binary = state_bytes(&before).contains(&0) || state_bytes(&after).contains(&0);
+    let (original, current) = if binary || too_large {
+        (String::new(), String::new())
+    } else {
+        (
+            String::from_utf8_lossy(state_bytes(&before)).into_owned(),
+            String::from_utf8_lossy(state_bytes(&after)).into_owned(),
+        )
+    };
+    GitFileDiff {
+        path: root.join(relative).to_string_lossy().into_owned(),
+        relative: relative.to_string(),
+        status: status.to_string(),
+        original,
+        current,
+        binary,
+        too_large,
+    }
+}
+
+/// LCS cells we will fill before calling an edit a whole-file rewrite. Keeps a
+/// reformatted 8 MB file from stalling the status poll.
+const MAX_DIFF_CELLS: usize = 4_000_000;
+
+fn line_diff_counts(before: &FileState, after: &FileState) -> (i64, i64) {
+    if matches!(before, FileState::Skipped) || matches!(after, FileState::Skipped) {
+        return (0, 0);
+    }
+    let before = state_bytes(before);
+    let after = state_bytes(after);
+    if before.contains(&0) || after.contains(&0) {
+        return (0, 0);
+    }
+    count_line_changes(&split_lines(before), &split_lines(after))
+}
+
+fn split_lines(bytes: &[u8]) -> Vec<&[u8]> {
+    if bytes.is_empty() {
+        return Vec::new();
+    }
+    let mut lines: Vec<&[u8]> = bytes.split(|byte| *byte == b'\n').collect();
+    if lines.last().is_some_and(|line| line.is_empty()) {
+        lines.pop();
+    }
+    lines
+}
+
+fn count_line_changes(before: &[&[u8]], after: &[&[u8]]) -> (i64, i64) {
+    let mut head = 0;
+    while head < before.len() && head < after.len() && before[head] == after[head] {
+        head += 1;
+    }
+    let mut tail = 0;
+    while tail < before.len() - head
+        && tail < after.len() - head
+        && before[before.len() - 1 - tail] == after[after.len() - 1 - tail]
+    {
+        tail += 1;
+    }
+    let before = &before[head..before.len() - tail];
+    let after = &after[head..after.len() - tail];
+    if before.is_empty()
+        || after.is_empty()
+        || before.len().saturating_mul(after.len()) > MAX_DIFF_CELLS
+    {
+        return (after.len() as i64, before.len() as i64);
+    }
+    let common = lcs_len(before, after);
+    (
+        (after.len() - common) as i64,
+        (before.len() - common) as i64,
+    )
+}
+
+fn lcs_len(a: &[&[u8]], b: &[&[u8]]) -> usize {
+    // Roll over the shorter side so the two rows stay bounded by MAX_DIFF_CELLS.
+    let (long, short) = if a.len() >= b.len() { (a, b) } else { (b, a) };
+    let mut prev = vec![0usize; short.len() + 1];
+    let mut row = vec![0usize; short.len() + 1];
+    for left in long {
+        for (index, right) in short.iter().enumerate() {
+            row[index + 1] = if left == right {
+                prev[index] + 1
+            } else {
+                row[index].max(prev[index + 1])
+            };
+        }
+        std::mem::swap(&mut prev, &mut row);
+    }
+    prev[short.len()]
 }
 
 fn restore_one(dir: &Path, root: &Path, manifest: &Manifest, relative: &str) -> Result<(), String> {
@@ -1222,6 +1427,107 @@ mod tests {
         assert_eq!(s1.additions, 1);
         assert_eq!(s1.deletions, 0);
         assert_eq!(relatives(&store.status("s1", &cwd).unwrap()), vec!["a.txt"]);
+    }
+
+    fn counts(before: &str, after: &str) -> (i64, i64) {
+        count_line_changes(
+            &split_lines(before.as_bytes()),
+            &split_lines(after.as_bytes()),
+        )
+    }
+
+    #[test]
+    fn line_counts_ignore_untouched_head_and_tail() {
+        assert_eq!(counts("a\nb\nc\n", "a\nB\nc\n"), (1, 1));
+        assert_eq!(counts("a\nc\n", "a\nb\nc\n"), (1, 0));
+        assert_eq!(counts("a\nb\nc\n", "a\nc\n"), (0, 1));
+        assert_eq!(counts("a\nb\n", "a\nb\n"), (0, 0));
+    }
+
+    #[test]
+    fn line_counts_handle_empty_sides() {
+        assert_eq!(counts("", "a\nb\n"), (2, 0));
+        assert_eq!(counts("a\nb\n", ""), (0, 2));
+        assert_eq!(counts("", ""), (0, 0));
+    }
+
+    #[test]
+    fn line_counts_reuse_moved_lines() {
+        // A block inserted in the middle must not bill the lines after it.
+        assert_eq!(counts("a\nb\nc\nd\n", "a\nx\ny\nb\nc\nd\n"), (2, 0));
+    }
+
+    #[test]
+    fn trailing_newline_is_not_a_line() {
+        assert_eq!(split_lines(b"a\nb\n").len(), 2);
+        assert_eq!(split_lines(b"a\nb").len(), 2);
+        assert_eq!(split_lines(b"").len(), 0);
+    }
+
+    #[test]
+    fn binary_and_skipped_sides_report_nothing() {
+        let binary = FileState::Contents(vec![b'a', 0, b'b']);
+        let text = FileState::Contents(b"a\n".to_vec());
+        assert_eq!(line_diff_counts(&binary, &text), (0, 0));
+        assert_eq!(line_diff_counts(&FileState::Skipped, &text), (0, 0));
+        assert_eq!(line_diff_counts(&FileState::Missing, &text), (1, 0));
+    }
+
+    /// The pre-existing dirt must stay off the session's tab.
+    #[test]
+    fn counts_exclude_edits_made_before_the_session() {
+        let repo = tmp("counts-baseline");
+        if !init_git_commit(&repo.0, &[("a.txt", "one\n")]) {
+            return;
+        }
+        // Someone edits the file by hand, then the session starts and adds a line.
+        std::fs::write(repo.0.join("a.txt"), "one\nuser\n").unwrap();
+        let cwd = repo.0.to_string_lossy().into_owned();
+        let (_root, store) = store();
+        store.ensure("s1", &cwd).unwrap();
+
+        std::fs::write(repo.0.join("a.txt"), "one\nuser\nagent\n").unwrap();
+        record(&store, "s1", &cwd, &["a.txt"]);
+
+        let status = store.status("s1", &cwd).unwrap();
+        let file = status.files.first().expect("a.txt");
+        assert_eq!((file.additions, file.deletions), (1, 0));
+    }
+
+    #[test]
+    fn file_diff_bases_on_the_session_snapshot() {
+        let repo = tmp("file-diff-base");
+        if !init_git_commit(&repo.0, &[("a.txt", "one\n")]) {
+            return;
+        }
+        std::fs::write(repo.0.join("a.txt"), "one\nuser\n").unwrap();
+        let cwd = repo.0.to_string_lossy().into_owned();
+        let (_root, store) = store();
+        store.ensure("s1", &cwd).unwrap();
+        std::fs::write(repo.0.join("a.txt"), "one\nuser\nagent\n").unwrap();
+        record(&store, "s1", &cwd, &["a.txt"]);
+
+        let diff = store.file_diff("s1", &cwd, "a.txt").unwrap();
+        assert_eq!(diff.original, "one\nuser\n");
+        assert_eq!(diff.current, "one\nuser\nagent\n");
+    }
+
+    /// Files that were clean at session start have no snapshot, so HEAD is the base.
+    #[test]
+    fn file_diff_falls_back_to_head_without_a_snapshot() {
+        let repo = tmp("file-diff-head");
+        if !init_git_commit(&repo.0, &[("a.txt", "one\n")]) {
+            return;
+        }
+        let cwd = repo.0.to_string_lossy().into_owned();
+        let (_root, store) = store();
+        store.ensure("s1", &cwd).unwrap();
+        std::fs::write(repo.0.join("a.txt"), "one\ntwo\n").unwrap();
+        record(&store, "s1", &cwd, &["a.txt"]);
+
+        let diff = store.file_diff("s1", &cwd, "a.txt").unwrap();
+        assert_eq!(diff.original, "one\n");
+        assert_eq!(diff.current, "one\ntwo\n");
     }
 
     #[test]

--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -880,7 +880,7 @@ fn mark_cached_and_unstaged(root: &Path, files: &mut HashMap<String, FileAcc>) {
     }
 }
 
-fn git_file_diff_for(root: &Path, relative: &str) -> Result<GitFileDiff, String> {
+pub(crate) fn git_file_diff_for(root: &Path, relative: &str) -> Result<GitFileDiff, String> {
     let relative = normalize_diff_path(relative);
     if relative.is_empty()
         || relative.starts_with('/')

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -250,6 +250,7 @@ pub fn run() {
             checkpoint::session_checkpoint_sync,
             checkpoint::session_checkpoint_status,
             checkpoint::session_checkpoint_stats,
+            checkpoint::session_checkpoint_file_diff,
             checkpoint::session_checkpoint_undo,
             checkpoint::session_checkpoint_keep,
             set_traffic_lights_visible,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1889,7 +1889,7 @@ export default function App({
   );
 
   const onOpenDiff = useCallback(
-    (path?: string) => {
+    (path?: string, sessionId?: string) => {
       void (async () => {
         const resolved = path
           ? ((await resolveOpenablePath(gitCwdRef.current, path)) ?? path)
@@ -1901,7 +1901,7 @@ export default function App({
             const opened = resolved
               ? openEditorTab(
                   tab,
-                  newFileTab(resolved, sidebarCwdRef.current, true),
+                  newFileTab(resolved, sidebarCwdRef.current, true, sessionId),
                 )
               : tab;
             if (deckLayout) return opened;
@@ -3884,6 +3884,7 @@ export default function App({
                 cwd={gitCwd}
                 textHarness={pickTextHarness(active?.harness)}
                 selectedPath={selectedChangePath(activeTab, gitCwd)}
+                sessionId={active?.id}
                 focused={!!activeTab.diffFocused}
                 onFocus={onFocusDiff}
                 onOpenFile={onOpenDiff}

--- a/src/chrome/GitChangesPanel.tsx
+++ b/src/chrome/GitChangesPanel.tsx
@@ -23,6 +23,14 @@ import {
 } from "react";
 import { FileTypeIcon } from "./FileTypeIcon";
 import {
+  DiffCounts,
+  dirname,
+  IconAction,
+  statusColor,
+  statusLetter,
+} from "./changeParts";
+import { SessionChanges } from "./SessionChanges";
+import {
   basename,
   gitCommit,
   gitDiffIndex,
@@ -51,15 +59,21 @@ import { useLockOverscroll } from "../hooks/useLockOverscroll";
 const GIT_POLL_MS = 2000;
 let stagedOpen = true;
 let changesOpen = true;
+/** Sticky across mounts so switching tabs keeps the scope you were reviewing. */
+let scopeChoice: Scope = "project";
 const indexByCwd = new Map<string, GitDiffIndex>();
 const prByCwd = new Map<string, GitPr | null>();
+
+type Scope = "project" | "session";
 
 type Props = {
   cwd: string;
   enabled: boolean;
   textHarness?: HarnessId;
   selectedPath?: string;
-  onOpenFile: (path: string) => void;
+  /** Active session, when one can scope the list to its own edits. */
+  sessionId?: string;
+  onOpenFile: (path: string, sessionId?: string) => void;
 };
 
 export function GitChangesPanel({
@@ -67,10 +81,18 @@ export function GitChangesPanel({
   enabled,
   textHarness,
   selectedPath,
+  sessionId,
   onOpenFile,
 }: Props) {
-  const { index, reload } = useDiffIndex(cwd, enabled);
+  const [scope, setScope] = useState<Scope>(scopeChoice);
+  const sessionScope = Boolean(sessionId) && scope === "session";
+  const { index, reload } = useDiffIndex(cwd, enabled && !sessionScope);
   const files = index?.files ?? [];
+
+  const pickScope = (next: Scope) => {
+    scopeChoice = next;
+    setScope(next);
+  };
 
   if (!cwd || cwd === "~") {
     return (
@@ -81,7 +103,9 @@ export function GitChangesPanel({
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <header className="flex h-9 shrink-0 items-center gap-2 border-b border-content/10 px-3">
-        {(index?.additions ?? 0) > 0 || (index?.deletions ?? 0) > 0 ? (
+        {sessionId ? (
+          <ScopeToggle scope={scope} onPick={pickScope} />
+        ) : (index?.additions ?? 0) > 0 || (index?.deletions ?? 0) > 0 ? (
           <DiffCounts
             additions={index?.additions ?? 0}
             deletions={index?.deletions ?? 0}
@@ -89,7 +113,7 @@ export function GitChangesPanel({
         ) : (
           <span className="text-[12px] font-medium text-content">Changes</span>
         )}
-        {index?.branch ? (
+        {!sessionScope && index?.branch ? (
           <span className="ml-auto flex min-w-0 items-center gap-1 text-[11px] text-content/50">
             <GitBranch className="size-3 shrink-0" strokeWidth={1.75} />
             <span className="min-w-0 truncate">{index.branch}</span>
@@ -108,21 +132,59 @@ export function GitChangesPanel({
           <span className="ml-auto" />
         )}
       </header>
-      <ChangedFiles
-        cwd={cwd}
-        textHarness={textHarness}
-        index={index}
-        files={files}
-        selected={selectedPath}
-        enabled={enabled}
-        onOpenFile={onOpenFile}
-        onMutated={(paths) => {
-          reload();
-          notifyGitChanged();
-          invalidateWatchedFiles(paths);
-          window.setTimeout(() => invalidateWatchedFiles(paths), 150);
-        }}
-      />
+      {sessionScope && sessionId ? (
+        <SessionChanges
+          sessionId={sessionId}
+          cwd={cwd}
+          enabled={enabled}
+          selectedPath={selectedPath}
+          onOpenFile={(path) => onOpenFile(path, sessionId)}
+        />
+      ) : (
+        <ChangedFiles
+          cwd={cwd}
+          textHarness={textHarness}
+          index={index}
+          files={files}
+          selected={selectedPath}
+          enabled={enabled}
+          onOpenFile={onOpenFile}
+          onMutated={(paths) => {
+            reload();
+            notifyGitChanged();
+            invalidateWatchedFiles(paths);
+            window.setTimeout(() => invalidateWatchedFiles(paths), 150);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function ScopeToggle({
+  scope,
+  onPick,
+}: {
+  scope: Scope;
+  onPick: (scope: Scope) => void;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-px rounded-md bg-content/8 p-px">
+      {(["project", "session"] as const).map((option) => (
+        <button
+          key={option}
+          type="button"
+          aria-pressed={scope === option}
+          onClick={() => onPick(option)}
+          className={`h-5 rounded-[5px] px-2 text-[11px] capitalize ${
+            scope === option
+              ? "bg-content/15 text-content"
+              : "text-content/55 hover:text-content"
+          }`}
+        >
+          {option}
+        </button>
+      ))}
     </div>
   );
 }
@@ -855,70 +917,6 @@ function ChangeRow({
       </div>
     </li>
   );
-}
-
-function IconAction({
-  title,
-  disabled,
-  onClick,
-  children,
-}: {
-  title: string;
-  disabled?: boolean;
-  onClick: () => void;
-  children: ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      title={title}
-      aria-label={title}
-      disabled={disabled}
-      onClick={onClick}
-      className="grid size-5 place-items-center rounded text-content/55 hover:bg-content/10 hover:text-content disabled:opacity-40"
-    >
-      {children}
-    </button>
-  );
-}
-
-function DiffCounts({
-  additions,
-  deletions,
-}: {
-  additions: number;
-  deletions: number;
-}) {
-  if (additions <= 0 && deletions <= 0) return null;
-  return (
-    <span className="flex shrink-0 items-center gap-1.5 font-mono text-[11px] font-semibold tabular-nums">
-      {additions > 0 ? (
-        <span className="text-emerald-400">+{additions}</span>
-      ) : null}
-      {deletions > 0 ? (
-        <span className="text-red-400">-{deletions}</span>
-      ) : null}
-    </span>
-  );
-}
-
-function dirname(relative: string): string {
-  const i = relative.lastIndexOf("/");
-  return i > 0 ? relative.slice(0, i) : "";
-}
-
-function statusLetter(status: string): string {
-  if (status === "untracked") return "U";
-  if (status === "added") return "A";
-  if (status === "deleted") return "D";
-  return "M";
-}
-
-function statusColor(status: string): string {
-  if (status === "untracked") return "text-sky-400";
-  if (status === "added") return "text-emerald-400";
-  if (status === "deleted") return "text-red-400";
-  return "text-amber-400";
 }
 
 function useDiffIndex(

--- a/src/chrome/SessionChanges.tsx
+++ b/src/chrome/SessionChanges.tsx
@@ -1,0 +1,236 @@
+import { Check, RefreshCw, Undo2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  keepSessionChanges,
+  sessionCheckpointStatus,
+  subscribeReviewChanged,
+  undoSessionChanges,
+  type CheckpointFile,
+} from "../lib/checkpoint";
+import { invalidateProjectFiles } from "../lib/fileIndex";
+import { invalidateWatchedFiles } from "../lib/fileWatch";
+import { notifyGitChanged, subscribeGitChanged } from "../lib/fs";
+import { FileTypeIcon } from "./FileTypeIcon";
+import {
+  DiffCounts,
+  dirname,
+  IconAction,
+  statusColor,
+  statusLetter,
+} from "./changeParts";
+
+type Props = {
+  sessionId: string;
+  cwd: string;
+  enabled: boolean;
+  selectedPath?: string;
+  onOpenFile: (path: string) => void;
+};
+
+/**
+ * Files this session changed, measured against the snapshot taken when it
+ * started rather than HEAD, so pre-existing dirt stays out of the list.
+ */
+export function SessionChanges({
+  sessionId,
+  cwd,
+  enabled,
+  selectedPath,
+  onOpenFile,
+}: Props) {
+  const [files, setFiles] = useState<CheckpointFile[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const filesRef = useRef(files);
+  filesRef.current = files;
+
+  const load = useCallback(() => {
+    if (!cwd || cwd === "~") {
+      setFiles([]);
+      return;
+    }
+    void sessionCheckpointStatus(sessionId, cwd)
+      .then((status) => setFiles(status.files))
+      .catch(() => setFiles([]));
+  }, [cwd, sessionId]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    load();
+    let timer: number | null = null;
+    const schedule = () => {
+      if (timer != null) window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        timer = null;
+        load();
+      }, 200);
+    };
+    const unsubReview = subscribeReviewChanged((id) => {
+      if (!id || id === sessionId) schedule();
+    });
+    const unsubGit = subscribeGitChanged(schedule);
+    const onResume = () => {
+      if (!document.hidden) schedule();
+    };
+    window.addEventListener("focus", onResume);
+    document.addEventListener("visibilitychange", onResume);
+    return () => {
+      if (timer != null) window.clearTimeout(timer);
+      window.removeEventListener("focus", onResume);
+      document.removeEventListener("visibilitychange", onResume);
+      unsubReview();
+      unsubGit();
+    };
+  }, [enabled, load, sessionId]);
+
+  const run = useCallback(
+    (action: "keep" | "undo", relative?: string) => {
+      setBusy(relative ?? "*");
+      const touched = relative
+        ? filesRef.current
+            .filter((file) => file.relative === relative)
+            .map((file) => file.path)
+        : filesRef.current.map((file) => file.path);
+      const op =
+        action === "keep"
+          ? keepSessionChanges(sessionId, cwd, relative)
+          : undoSessionChanges(sessionId, cwd, relative);
+      void op
+        .then((status) => {
+          setFiles(status.files);
+          notifyGitChanged();
+          invalidateWatchedFiles(touched);
+          invalidateProjectFiles(cwd);
+        })
+        .catch(() => load())
+        .finally(() => setBusy(null));
+    },
+    [cwd, load, sessionId],
+  );
+
+  const additions = files.reduce((sum, file) => sum + file.additions, 0);
+  const deletions = files.reduce((sum, file) => sum + file.deletions, 0);
+
+  if (files.length === 0) {
+    return (
+      <p className="px-3 py-2 text-[12px] text-content/50">
+        No changes from this session
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="group flex h-7 shrink-0 items-center gap-1 px-2">
+        <span className="min-w-0 truncate text-[10px] font-semibold tracking-[0.04em] text-content/55 uppercase">
+          {files.length} {files.length === 1 ? "File" : "Files"}
+        </span>
+        <span className="ml-auto flex items-center gap-1">
+          <DiffCounts additions={additions} deletions={deletions} />
+          <span className="flex opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
+            <IconAction
+              title="Undo all session changes"
+              disabled={busy != null}
+              onClick={() => run("undo")}
+            >
+              <Undo2 className="size-3.5" strokeWidth={1.75} />
+            </IconAction>
+            <IconAction
+              title="Keep all session changes"
+              disabled={busy != null}
+              onClick={() => run("keep")}
+            >
+              <Check className="size-3.5" strokeWidth={1.75} />
+            </IconAction>
+            <IconAction title="Refresh" onClick={load}>
+              <RefreshCw className="size-3.5" strokeWidth={1.75} />
+            </IconAction>
+          </span>
+        </span>
+      </div>
+      <ul className="scrollbar-thin min-h-0 flex-1 overflow-y-auto">
+        {files.map((file) => (
+          <SessionRow
+            key={file.relative}
+            file={file}
+            active={file.path === selectedPath}
+            busy={busy != null}
+            onOpenFile={onOpenFile}
+            onAction={run}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function SessionRow({
+  file,
+  active,
+  busy,
+  onOpenFile,
+  onAction,
+}: {
+  file: CheckpointFile;
+  active: boolean;
+  busy: boolean;
+  onOpenFile: (path: string) => void;
+  onAction: (action: "keep" | "undo", relative: string) => void;
+}) {
+  const name = file.relative.slice(file.relative.lastIndexOf("/") + 1);
+  const dir = dirname(file.relative);
+  const canOpen = file.status !== "deleted";
+  return (
+    <li>
+      <div
+        className={`group flex h-7 w-full items-center gap-1 px-2 leading-none ${
+          active
+            ? "bg-content/10 text-content"
+            : "text-content hover:bg-content/5"
+        }`}
+      >
+        <button
+          type="button"
+          title={file.relative}
+          onClick={() => {
+            if (canOpen) onOpenFile(file.path);
+          }}
+          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+        >
+          <FileTypeIcon name={name} isDir={false} size={16} />
+          <span className="min-w-0 flex-1 truncate">
+            <span className="text-[13px] font-medium">{name}</span>
+            {dir ? (
+              <span className="ml-1.5 text-[11px] text-content/40">{dir}</span>
+            ) : null}
+          </span>
+        </button>
+        <div
+          className={`shrink-0 items-center ${
+            active ? "flex" : "hidden group-focus-within:flex group-hover:flex"
+          }`}
+        >
+          <IconAction
+            title="Undo this file"
+            disabled={busy}
+            onClick={() => onAction("undo", file.relative)}
+          >
+            <Undo2 className="size-3.5" strokeWidth={1.75} />
+          </IconAction>
+          <IconAction
+            title="Keep this file"
+            disabled={busy}
+            onClick={() => onAction("keep", file.relative)}
+          >
+            <Check className="size-3.5" strokeWidth={1.75} />
+          </IconAction>
+        </div>
+        <DiffCounts additions={file.additions} deletions={file.deletions} />
+        <span
+          className={`w-3.5 shrink-0 text-right font-mono text-[11px] font-semibold ${statusColor(file.status)}`}
+        >
+          {statusLetter(file.status)}
+        </span>
+      </div>
+    </li>
+  );
+}

--- a/src/chrome/SessionReview.tsx
+++ b/src/chrome/SessionReview.tsx
@@ -17,7 +17,7 @@ type Props = {
   cwd: string;
   enabled?: boolean;
   busy?: boolean;
-  onOpenDiff: (path?: string) => void;
+  onOpenDiff: (path?: string, sessionId?: string) => void;
 };
 
 export function SessionReview({
@@ -130,7 +130,10 @@ export function SessionReview({
               <span className="truncate text-[12px]">{files.length} Files</span>
             </button>
           ) : (
-            <FileLabel file={first} onOpenDiff={onOpenDiff} />
+            <FileLabel
+              file={first}
+              onOpenDiff={(path) => onOpenDiff(path, sessionId)}
+            />
           )}
           <div className="flex shrink-0 items-center gap-0.5">
             <button
@@ -165,7 +168,10 @@ export function SessionReview({
           <ul className="scrollbar-none mt-1 max-h-40 overflow-y-auto">
             {files.map((file) => (
               <li key={file.relative}>
-                <FileRow file={file} onOpenDiff={onOpenDiff} />
+                <FileRow
+                  file={file}
+                  onOpenDiff={(path) => onOpenDiff(path, sessionId)}
+                />
               </li>
             ))}
           </ul>

--- a/src/chrome/Sidebar.tsx
+++ b/src/chrome/Sidebar.tsx
@@ -117,7 +117,7 @@ type Props = {
   canGoForward?: boolean;
   onGoBack?: () => void;
   onGoForward?: () => void;
-  onOpenDiff?: (path: string) => void;
+  onOpenDiff?: (path: string, sessionId?: string) => void;
   selectedDiffPath?: string;
   textHarness?: HarnessId;
   onShowSourceControl?: () => void;
@@ -823,6 +823,7 @@ function SidebarComponent({
             enabled={open}
             textHarness={textHarness}
             selectedPath={selectedDiffPath}
+            sessionId={activeSessionId}
             onOpenFile={onOpenDiff ?? onOpenFile}
           />
         </div>

--- a/src/chrome/SourceControl.tsx
+++ b/src/chrome/SourceControl.tsx
@@ -6,7 +6,8 @@ type Props = {
   enabled: boolean;
   textHarness?: HarnessId;
   selectedPath?: string;
-  onOpenFile: (path: string) => void;
+  sessionId?: string;
+  onOpenFile: (path: string, sessionId?: string) => void;
 };
 
 export function SourceControl({
@@ -14,6 +15,7 @@ export function SourceControl({
   enabled,
   textHarness,
   selectedPath,
+  sessionId,
   onOpenFile,
 }: Props) {
   return (
@@ -23,6 +25,7 @@ export function SourceControl({
         enabled={enabled}
         textHarness={textHarness}
         selectedPath={selectedPath}
+        sessionId={sessionId}
         onOpenFile={onOpenFile}
       />
     </div>

--- a/src/chrome/changeParts.tsx
+++ b/src/chrome/changeParts.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from "react";
+
+/** Row chrome shared by the project (git) and session (checkpoint) change lists. */
+
+export function IconAction({
+  title,
+  disabled,
+  onClick,
+  children,
+}: {
+  title: string;
+  disabled?: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      aria-label={title}
+      disabled={disabled}
+      onClick={onClick}
+      className="grid size-5 place-items-center rounded text-content/55 hover:bg-content/10 hover:text-content disabled:opacity-40"
+    >
+      {children}
+    </button>
+  );
+}
+
+export function DiffCounts({
+  additions,
+  deletions,
+}: {
+  additions: number;
+  deletions: number;
+}) {
+  if (additions <= 0 && deletions <= 0) return null;
+  return (
+    <span className="flex shrink-0 items-center gap-1.5 font-mono text-[11px] font-semibold tabular-nums">
+      {additions > 0 ? (
+        <span className="text-emerald-400">+{additions}</span>
+      ) : null}
+      {deletions > 0 ? (
+        <span className="text-red-400">-{deletions}</span>
+      ) : null}
+    </span>
+  );
+}
+
+export function dirname(relative: string): string {
+  const i = relative.lastIndexOf("/");
+  return i > 0 ? relative.slice(0, i) : "";
+}
+
+export function statusLetter(status: string): string {
+  if (status === "untracked") return "U";
+  if (status === "added") return "A";
+  if (status === "deleted") return "D";
+  return "M";
+}
+
+export function statusColor(status: string): string {
+  if (status === "untracked") return "text-sky-400";
+  if (status === "added") return "text-emerald-400";
+  if (status === "deleted") return "text-red-400";
+  return "text-amber-400";
+}

--- a/src/lib/checkpoint.ts
+++ b/src/lib/checkpoint.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { GitDiffStats } from "./fs";
+import type { GitDiffStats, GitFileDiff } from "./fs";
 
 export type CheckpointFile = {
   path: string;
@@ -87,6 +87,19 @@ export function sessionCheckpointStats(
   return invoke<Record<string, GitDiffStats>>("session_checkpoint_stats", {
     cwd,
     sessionIds,
+  });
+}
+
+/** Session baseline vs worktree, so review shows only this session's edits. */
+export function sessionFileDiff(
+  sessionId: string,
+  cwd: string,
+  relative: string,
+): Promise<GitFileDiff> {
+  return invoke<GitFileDiff>("session_checkpoint_file_diff", {
+    sessionId,
+    cwd,
+    relative,
   });
 }
 

--- a/src/lib/layout.test.ts
+++ b/src/lib/layout.test.ts
@@ -85,6 +85,21 @@ describe("editorTabKey", () => {
     expect(isTerminalTab(terminal)).toBe(true);
     expect(isTerminalTab(newFileTab(path, cwd))).toBe(false);
   });
+
+  it("separates a session review from the project review of one file", () => {
+    const cwd = "/repo";
+    const path = "/repo/EventStore.swift";
+    expect(editorTabKey(newFileTab(path, cwd, true, "s1"))).toBe(
+      `review:s1:${path}`,
+    );
+    expect(editorTabKey(newFileTab(path, cwd, true, "s2"))).not.toBe(
+      editorTabKey(newFileTab(path, cwd, true, "s1")),
+    );
+    // A session id without review must not change the plain file tab.
+    expect(editorTabKey(newFileTab(path, cwd, false, "s1"))).toBe(
+      `file:${path}`,
+    );
+  });
 });
 
 describe("openTerminalTab", () => {

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -35,6 +35,8 @@ export type FilePaneTab = {
   cwd: string;
   plan?: PlanTabSource;
   review?: boolean;
+  /** Diff against this session's checkpoint instead of HEAD. */
+  reviewSessionId?: string;
   terminal?: boolean;
 };
 
@@ -80,12 +82,14 @@ export function newFileTab(
   path: string,
   cwd: string,
   review = false,
+  reviewSessionId?: string,
 ): FilePaneTab {
   return {
     id: crypto.randomUUID(),
     path,
     cwd,
     ...(review ? { review: true } : {}),
+    ...(review && reviewSessionId ? { reviewSessionId } : {}),
   };
 }
 
@@ -266,7 +270,11 @@ export function isReviewTab(file: FilePaneTab): boolean {
 export function editorTabKey(file: FilePaneTab): string {
   if (file.terminal) return `terminal:${file.id}`;
   if (file.plan) return `plan:${file.plan.blockId}`;
-  return file.review ? `review:${file.path}` : `file:${file.path}`;
+  if (!file.review) return `file:${file.path}`;
+  // Session and project reviews of one file are different diffs, so different tabs.
+  return file.reviewSessionId
+    ? `review:${file.reviewSessionId}:${file.path}`
+    : `review:${file.path}`;
 }
 
 export function newEditorPane(file: FilePaneTab): EditorPane {

--- a/src/lib/workspaceSnapshot.ts
+++ b/src/lib/workspaceSnapshot.ts
@@ -354,6 +354,11 @@ function sanitizeFile(raw: unknown): FilePaneTab | null {
     cwd: value.cwd,
     ...(plan ? { plan } : {}),
     ...(value.review === true ? { review: true } : {}),
+    ...(value.review === true &&
+    typeof value.reviewSessionId === "string" &&
+    value.reviewSessionId
+      ? { reviewSessionId: value.reviewSessionId }
+      : {}),
     ...(value.terminal === true ? { terminal: true } : {}),
   };
 }

--- a/src/surfaces/DiffPane.tsx
+++ b/src/surfaces/DiffPane.tsx
@@ -19,15 +19,17 @@ type Props = {
   cwd: string;
   textHarness?: HarnessId;
   selectedPath?: string;
+  sessionId?: string;
   focused: boolean;
   onFocus: () => void;
-  onOpenFile: (path: string) => void;
+  onOpenFile: (path: string, sessionId?: string) => void;
 };
 
 export function DiffPane({
   cwd,
   textHarness,
   selectedPath,
+  sessionId,
   focused,
   onFocus,
   onOpenFile,
@@ -145,6 +147,7 @@ export function DiffPane({
         enabled
         textHarness={textHarness}
         selectedPath={selectedPath}
+        sessionId={sessionId}
         onOpenFile={onOpenFile}
       />
     </section>

--- a/src/surfaces/FileEditor.tsx
+++ b/src/surfaces/FileEditor.tsx
@@ -46,6 +46,7 @@ import {
   subscribeGitChanged,
   writeTextFile,
 } from "../lib/fs";
+import { sessionFileDiff, subscribeReviewChanged } from "../lib/checkpoint";
 import { syncWatchedMtime, watchFile } from "../lib/fileWatch";
 import { displayPath } from "../lib/paths";
 import type { EditorNavigation } from "../lib/search";
@@ -74,6 +75,8 @@ type Props = {
   cwd: string;
   active: boolean;
   showDiff?: boolean;
+  /** Diff against this session's checkpoint baseline instead of HEAD. */
+  diffSessionId?: string;
   navigation?: EditorNavigationRequest | null;
   onDirtyChange: (path: string, dirty: boolean) => void;
   onErrorCountChange?: (path: string, count: number) => void;
@@ -94,6 +97,7 @@ export function FileEditor({
   cwd,
   active,
   showDiff = false,
+  diffSessionId,
   navigation,
   onDirtyChange,
   onErrorCountChange,
@@ -194,7 +198,10 @@ export function FileEditor({
     setGitBase({ path, original: null });
 
     const load = () => {
-      void gitFileDiff(cwd, relative)
+      const pending = diffSessionId
+        ? sessionFileDiff(diffSessionId, cwd, relative)
+        : gitFileDiff(cwd, relative);
+      void pending
         .then((diff) => {
           if (cancelled) return;
           if (diff.binary || diff.tooLarge) {
@@ -226,6 +233,11 @@ export function FileEditor({
     window.addEventListener("focus", onFocus);
     document.addEventListener("visibilitychange", onFocus);
     const unsubGit = subscribeGitChanged(onGit);
+    const unsubReview = diffSessionId
+      ? subscribeReviewChanged((id) => {
+          if (!id || id === diffSessionId) load();
+        })
+      : null;
     const unsubWatch = watchFile(path, onDisk);
     return () => {
       cancelled = true;
@@ -233,9 +245,10 @@ export function FileEditor({
       window.removeEventListener("focus", onFocus);
       document.removeEventListener("visibilitychange", onFocus);
       unsubGit();
+      unsubReview?.();
       unsubWatch();
     };
-  }, [cwd, path, reloadFromDisk, showDiff]);
+  }, [cwd, diffSessionId, path, reloadFromDisk, showDiff]);
 
   const gitOriginal = gitBase.path === path ? gitBase.original : null;
 

--- a/src/surfaces/FilePane.tsx
+++ b/src/surfaces/FilePane.tsx
@@ -98,6 +98,7 @@ function FilePaneComponent({
                 path={file.path}
                 cwd={file.cwd}
                 showDiff={!!file.review}
+                diffSessionId={file.reviewSessionId}
                 active={focused && file.id === pane.activeFileId}
                 navigation={
                   editorNavigation &&

--- a/src/surfaces/PaneTree.tsx
+++ b/src/surfaces/PaneTree.tsx
@@ -70,7 +70,7 @@ type Shared = {
   ) => void;
   onOpenFile: (path: string) => void;
   editorNavigation?: EditorNavigationTarget | null;
-  onOpenDiff: (path?: string) => void;
+  onOpenDiff: (path?: string, sessionId?: string) => void;
   onOpenPlan: (sessionId: string, blockId: string) => void;
   onMovePane: (fromId: string, toId: string, edge: PaneEdge) => void;
   onNewTerminal: (sessionId: string) => void;

--- a/src/surfaces/SessionPane.tsx
+++ b/src/surfaces/SessionPane.tsx
@@ -54,7 +54,7 @@ type Props = {
     decision: ApprovalDecision,
   ) => void;
   onOpenFile: (path: string) => void;
-  onOpenDiff: (path?: string) => void;
+  onOpenDiff: (path?: string, sessionId?: string) => void;
   onOpenPlan: (sessionId: string, blockId: string) => void;
   onNewTerminal: (sessionId: string) => void;
   onPaneDragStart?: (event: ReactPointerEvent<HTMLElement>) => void;


### PR DESCRIPTION
## What changed

The Changes panel gains a Project/Session toggle, and the session view now measures a file against the snapshot taken when the session started rather than against git's HEAD.

## Why

The session file list took its line counts from git's HEAD numbers. A file that was already dirty when the session started therefore billed someone else's edits to that session, and opening it diffed against the index instead of the snapshot. The number and the diff both described the working tree, not the session.

`session_change()` now decides in one place whether a path changed and which baseline applies, and carries the contents it read, so a status poll reads each file once instead of twice. A file with a snapshot gets its counts from a bounded line diff against that snapshot; a file that was clean at session start keeps git's numbers, since HEAD is its baseline.

`session_checkpoint_file_diff` is the command behind the editor diffing a file against the session snapshot. Session review tabs are keyed separately from project review tabs so the two views of one file are two tabs rather than one that flips meaning.

## UI

The Changes panel gains a Project/Session toggle and a session-scoped file list with per-file Keep and Undo.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes
