### PR TITLE
Keep package-lock.json in sync on a version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `npm run set-version` left `package-lock.json` behind, so the lockfile still called itself 0.1.0 sixteen releases on. The script now updates both of the version fields it carries, and the lockfile is back in sync.
+
 ## [0.1.16] - 2026-08-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monocode-desktop",
-  "version": "0.1.0",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monocode-desktop",
-      "version": "0.1.0",
+      "version": "0.1.16",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.12",
@@ -15,6 +15,7 @@
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/lang-python": "^6.2.1",
         "@codemirror/lang-rust": "^6.0.2",
+        "@codemirror/lint": "^6.9.7",
         "@codemirror/merge": "^6.12.2",
         "@codemirror/search": "^6.5.11",
         "@lezer/highlight": "^1.2.3",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -26,6 +26,20 @@ replaceFirst(
   /("version": ")[^"]+(")/,
   `$1${version}$2`,
 );
+// The lockfile carries the version twice: once at the top and once on the
+// root package. Missing them left npm's lockfile claiming 0.1.0 sixteen
+// releases later. The second pattern is anchored on `packages` because the
+// top-level object repeats the same name/version pair.
+replaceFirst(
+  join(root, "package-lock.json"),
+  /^(\{\n\s*"name": "monocode-desktop",\n\s*"version": ")[^"]+(")/,
+  `$1${version}$2`,
+);
+replaceFirst(
+  join(root, "package-lock.json"),
+  /("packages": \{\n\s*"": \{\n\s*"name": "monocode-desktop",\n\s*"version": ")[^"]+(")/,
+  `$1${version}$2`,
+);
 replaceFirst(
   join(root, "Cargo.toml"),
   /^(version = ")[^"]+(")/m,


### PR DESCRIPTION
## What changed

`npm run set-version` now updates `package-lock.json`, and the lockfile is brought back in sync.

## Why

The bump script updates `package.json`, `Cargo.toml`, `tauri.conf.json` and `Cargo.lock`, but never `package-lock.json` — so the lockfile has called itself 0.1.0 since the first release, sixteen versions ago, and its root dependency list had drifted from `package.json`.

The lockfile names its version twice, at the top and on the root package entry. The top-level object repeats the same `name`/`version` pair as the root package, so the second pattern is anchored on `packages` to avoid matching the first one again. Verified by bumping to a throwaway version and checking both fields moved, then restoring.

`npm ci` tolerated the drift, so this is housekeeping rather than a broken build.

## UI

None.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes
