### PR TITLE
Portal the model picker menu out of the composer

### DIFF
--- a/src/chrome/ModelPicker.tsx
+++ b/src/chrome/ModelPicker.tsx
@@ -10,6 +10,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import {
   coerceModelPickerTab,
   findModel,
@@ -69,7 +70,7 @@ function menuStyle(anchor: DOMRect): CSSProperties {
     bottom: window.innerHeight - anchor.top + 6,
     width,
     height: Math.max(180, Math.min(340, anchor.top - 12)),
-    zIndex: 50,
+    zIndex: 80,
   };
 }
 
@@ -102,6 +103,7 @@ export function ModelPicker({
   const [favorites, setFavorites] = useState(loadFavoriteModels);
   const [menu, setMenu] = useState<CSSProperties>();
   const root = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const search = useRef<HTMLInputElement>(null);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
@@ -178,7 +180,11 @@ export function ModelPicker({
   useEffect(() => {
     if (!open) return;
     const onPointerDown = (e: PointerEvent) => {
-      if (!root.current?.contains(e.target as Node)) dismiss(false);
+      const target = e.target as Node;
+      if (root.current?.contains(target) || menuRef.current?.contains(target)) {
+        return;
+      }
+      dismiss(false);
     };
     window.addEventListener("pointerdown", onPointerDown);
     return () => window.removeEventListener("pointerdown", onPointerDown);
@@ -361,81 +367,89 @@ export function ModelPicker({
           strokeWidth={1.75}
         />
       </button>
-      {open && menu ? (
-        <div
-          role="dialog"
-          aria-label="Model picker"
-          data-model-picker
-          style={menu}
-          className="flex flex-col overflow-hidden rounded-lg border border-content/10 bg-content/10 shadow-xl backdrop-blur-xl"
-        >
-          <nav
-            role="tablist"
-            aria-label="Providers"
-            aria-keyshortcuts="ArrowLeft ArrowRight"
-            aria-orientation="horizontal"
-            className="flex w-full shrink-0 items-stretch border-b border-content/10"
-          >
-            <ProviderTabButton
-              title="Favorites"
-              selected={visibleTab === "favorites"}
-              onSelect={() => selectTab("favorites")}
+      {/* Portalled: the composer box is a `z-10` stacking context, so an inline
+          fixed menu loses to anything painted above it — in a split pane the
+          arcade backdrop swallowed the list (#29). */}
+      {open && menu
+        ? createPortal(
+            <div
+              ref={menuRef}
+              role="dialog"
+              aria-label="Model picker"
+              data-model-picker
+              style={menu}
+              className="flex flex-col overflow-hidden rounded-lg border border-content/10 bg-content/10 shadow-xl backdrop-blur-xl"
             >
-              <Star
-                className="size-4"
-                strokeWidth={1.75}
-                fill={visibleTab === "favorites" ? "currentColor" : "none"}
-              />
-            </ProviderTabButton>
-            {pickerHarnesses.map((id) => (
-              <ProviderTabButton
-                key={id}
-                title={HARNESS_TITLE[id]}
-                selected={visibleTab === id}
-                onSelect={() => selectTab(id)}
+              <nav
+                role="tablist"
+                aria-label="Providers"
+                aria-keyshortcuts="ArrowLeft ArrowRight"
+                aria-orientation="horizontal"
+                className="flex w-full shrink-0 items-stretch border-b border-content/10"
               >
-                <HarnessIcon harness={id} className="size-4" />
-              </ProviderTabButton>
-            ))}
-          </nav>
+                <ProviderTabButton
+                  title="Favorites"
+                  selected={visibleTab === "favorites"}
+                  onSelect={() => selectTab("favorites")}
+                >
+                  <Star
+                    className="size-4"
+                    strokeWidth={1.75}
+                    fill={visibleTab === "favorites" ? "currentColor" : "none"}
+                  />
+                </ProviderTabButton>
+                {pickerHarnesses.map((id) => (
+                  <ProviderTabButton
+                    key={id}
+                    title={HARNESS_TITLE[id]}
+                    selected={visibleTab === id}
+                    onSelect={() => selectTab(id)}
+                  >
+                    <HarnessIcon harness={id} className="size-4" />
+                  </ProviderTabButton>
+                ))}
+              </nav>
 
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-            <div className="pb-1.5">
-              <label className="flex items-center gap-2 border-b border-content/10 px-2 py-2.5 text-content/50">
-                <Search className="size-3.5 shrink-0" strokeWidth={1.75} />
-                <input
-                  ref={search}
-                  type="text"
-                  value={query}
-                  placeholder="Search models..."
-                  aria-label="Search models"
-                  className="min-w-0 flex-1 bg-transparent text-[12px] text-content outline-none placeholder:text-content/40"
-                  onChange={(e) => setQuery(e.target.value)}
-                  onKeyDown={onSearchKey}
+              <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+                <div className="pb-1.5">
+                  <label className="flex items-center gap-2 border-b border-content/10 px-2 py-2.5 text-content/50">
+                    <Search className="size-3.5 shrink-0" strokeWidth={1.75} />
+                    <input
+                      ref={search}
+                      type="text"
+                      value={query}
+                      placeholder="Search models..."
+                      aria-label="Search models"
+                      className="min-w-0 flex-1 bg-transparent text-[12px] text-content outline-none placeholder:text-content/40"
+                      onChange={(e) => setQuery(e.target.value)}
+                      onKeyDown={onSearchKey}
+                    />
+                  </label>
+                </div>
+                <ModelList
+                  models={visible}
+                  active={active}
+                  currentId={current.id}
+                  favorites={favorites}
+                  emptyLabel={
+                    visibleTab === "favorites" && !query.trim()
+                      ? "No favorite models"
+                      : visibleTab !== "favorites" &&
+                          !isHarnessAvailable(visibleTab)
+                        ? harnessUnavailableHint(visibleTab)
+                        : visibleTab === "codex" && !query.trim()
+                          ? "Loading Codex models…"
+                          : "No matching models"
+                  }
+                  onActive={setActive}
+                  onPick={pick}
+                  onToggleFavorite={toggleFavorite}
                 />
-              </label>
-            </div>
-            <ModelList
-              models={visible}
-              active={active}
-              currentId={current.id}
-              favorites={favorites}
-              emptyLabel={
-                visibleTab === "favorites" && !query.trim()
-                  ? "No favorite models"
-                  : visibleTab !== "favorites" && !isHarnessAvailable(visibleTab)
-                    ? harnessUnavailableHint(visibleTab)
-                    : visibleTab === "codex" && !query.trim()
-                      ? "Loading Codex models…"
-                      : "No matching models"
-              }
-              onActive={setActive}
-              onPick={pick}
-              onToggleFavorite={toggleFavorite}
-            />
-          </div>
-        </div>
-      ) : null}
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
     </div>
   );
 }


### PR DESCRIPTION
## What changed

The model picker's dropdown is now rendered through a `createPortal` onto `document.body` at the same `zIndex: 80` tier the other popups in the app use, instead of inline inside the composer.

## Why

Fixes #29.

`data-composer-box` in `Composer.tsx` carries `relative z-10`, which makes it a **stacking context**. The picker's menu is `position: fixed`, but it was rendered as a DOM descendant of that box, so its `zIndex: 50` resolved *inside* the box — against everything outside the composer the menu painted as if it were `z-10`.

Anything layered above that covered it. The case in the issue: an empty session in a split pane docks its composer outside `EmptySession`, while the arcade backdrop goes to `absolute inset-0 z-20` with an opaque `bg-background-base` (`TerminalGridBackground.tsx:350-356`). z-20 beats the menu's effective z-10, so the list was swallowed and no model could be selected.

Raising the inline z-index would not have helped — the menu has to leave the stacking context. The portal follows the pattern already used by `ExplorerMenu`, `TabGroupMenu`, `SessionFiltersMenu`, `SecondOpinionButton` and `TranscriptSelectionMenu`.

One adjustment came with it: the outside-click handler compared against the trigger's `root` ref, which no longer contains the portalled menu, so clicking inside the menu would have dismissed it. It now treats the menu node as inside too.

Positioning is unchanged — `menuStyle` is viewport-relative `position: fixed`, and nothing on `html`/`body`/`#root` creates a containing block for fixed elements.

## UI

Before: https://github.com/user-attachments/assets/9ba54eb8-48cf-4bfd-b1f2-702997d0804e

## Checklist

- [x] I ran `npm run check` (`check:web` — 694 tests, `tsc --noEmit` clean; the change is frontend-only and does not touch Rust)
- [x] This PR is small and focused
- [x] I did not mix unrelated changes

## Note on scope

`ModelSettings`, `AccessPicker`, `BranchPicker` and `CwdPicker` sit in the same composer box with the same inline `position: fixed` + `zIndex: 50` and are hidden the same way. I kept this PR to the picker in the issue — happy to send the rest as a follow-up, or drop `z-10` from `data-composer-box` instead if you'd rather fix all five at the source.