### PR TITLE
Carry the composer's model pick to new sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The model you pick in the composer now carries to new sessions. Previously only the Providers settings page wrote the default, so a session started from the built-in default no matter what you had switched to while working. Reported in #30.
 - Unused provider CLIs no longer start at launch. Catalog probes run only for harnesses in the restored workspace, or when you open that provider in the model picker. Pi/omp probes skip extensions so a leftover `pi` process cannot sit at ~1GB while you work in Codex or Claude. Diagnosed in #19.
 
 ## [0.1.16] - 2026-08-28

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,6 +157,7 @@ import {
   mergeModelSettings,
   preferredModelSettings,
   resolveModel,
+  saveLastModelChoice,
   saveLastModelSettings,
 } from "./lib/models";
 import { planTitle } from "./lib/plan";
@@ -2780,6 +2781,9 @@ export default function App({
       if (!current) return;
       if (isPreparingHandoff(current)) return;
       const resolved = resolveModel(harness, model);
+      // Picking in the composer is the same intent as picking in Settings, so
+      // new sessions start here too instead of on the built-in default.
+      saveLastModelChoice(harness, resolved.id);
       if (current.modelSettings) {
         saveLastModelSettings(current.modelSettings, "fill");
       }


### PR DESCRIPTION
## What changed

`onModelChange` now calls `saveLastModelChoice(harness, resolved.id)`, so switching model from the composer's picker also updates the default new sessions start with.

## Why

Fixes #30.

`monocode.lastModel` was written only by Settings → Providers (`SettingsView.tsx`). The composer picker updated just the session it was opened from, so `defaultSessionChoice()` kept reading a stale (or absent) choice and fell back to the hardcoded `"cursor"` provider — every new session started on Composer regardless of what the user had actually been working in.

The effort/thinking chips sitting next to the picker already do the analogous thing (`onModelSettingsChange` → `saveLastModelSettings`), which is why effort was sticky and model was not. This just closes that gap. `saveLastModelChoice` also writes through to `defaultModels[harness]`, so the per-provider default in Settings tracks the picker too.

## UI

No visual change.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes