### PR TITLE
Allow monocode to fetch skills directly from pi

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -229,10 +229,10 @@ import {
   tabVisitForward,
   type TabVisitHistory,
 } from "./lib/tabVisitHistory";
-import { applySkillsToTurn } from "./lib/skills";
-import { applyFileMentionsToTurn } from "./lib/fileMentions";
+import { preparePrompt } from "./lib/promptPreparation";
+import { warmPiSkills } from "./lib/skills";
+import { piSkillContextForSession } from "./lib/sessionSkills";
 import {
-  applyNotesToTurn,
   ADD_NOTE_TO_CHAT_EVENT,
   composeNoteMessage,
   noteCardMeta,
@@ -323,14 +323,6 @@ function scheduleHarnessFlush(run: () => void): ScheduledFlush {
     return { kind: "timeout", id: window.setTimeout(run, 32) };
   }
   return { kind: "raf", id: requestAnimationFrame(run) };
-}
-
-/** Expand the composer's `@file`, `@note`, and `/skill` tokens for the harness. */
-async function preparePrompt(text: string, cwd: string): Promise<string> {
-  return applySkillsToTurn(
-    await applyNotesToTurn(await applyFileMentionsToTurn(text, cwd)),
-    cwd,
-  );
 }
 
 function userTurnCards(
@@ -694,6 +686,16 @@ export default function App({
       (session) => activeTab && leafIds(activeTab.layout).includes(session.id),
     );
   const sessionDefaults = active ?? sessions[0];
+  const activeSkillContext = active
+    ? piSkillContextForSession(active)
+    : null;
+  const activeSkillCwd = activeSkillContext?.cwd;
+
+  useEffect(() => {
+    if (!activeSkillContext || !activeSkillCwd) return;
+    warmPiSkills(activeSkillContext);
+  }, [activeSkillCwd]);
+
   const sidebarCwd =
     active?.cwd ??
     (activeTab ? focusedFileTab(activeTab)?.cwd : undefined) ??
@@ -3022,7 +3024,10 @@ export default function App({
         void (async () => {
           try {
             const prepared = await prepareAttachments(attachments);
-            const prompt = await preparePrompt(harnessText, workCwd);
+            const prompt = await preparePrompt(harnessText, {
+              harness: current.harness,
+              cwd: workCwd,
+            });
             await steerHarnessTurn({
               harness: current.harness,
               sessionId,
@@ -3194,7 +3199,10 @@ export default function App({
         if (turnGen.current.get(sessionId) !== gen) return;
         try {
           const prepared = await prepareAttachments(attachments);
-          const prompt = await preparePrompt(harnessText, workCwd);
+          const prompt = await preparePrompt(harnessText, {
+            harness: current.harness,
+            cwd: workCwd,
+          });
           const earlier = queuedHandoff
             ? userMessagesAfterHandoff(current)
             : [];

--- a/src/chrome/Composer.tsx
+++ b/src/chrome/Composer.tsx
@@ -46,9 +46,6 @@ import type { Attachment, HarnessId, RuntimeMode } from "../lib/session";
 import { harnessSupportsAttachments } from "../lib/session";
 import {
   createBlankSkill,
-  loadSkills,
-  mergeCatalog,
-  peekSkills,
   rankSkills,
   replaceSlashToken,
   skillTextParts,
@@ -88,6 +85,7 @@ import {
   type NoteComposerCard,
 } from "../lib/notes";
 import { resolveTabGroupLogo } from "../lib/tabGroups";
+import { useComposerSkills } from "./useComposerSkills";
 
 type Props = {
   enabled?: boolean;
@@ -98,6 +96,7 @@ type Props = {
   modelSettings?: Record<string, string>;
   runtimeMode: RuntimeMode;
   cwd?: string;
+  executionCwd: string;
   branch?: string;
   recents?: RecentProject[];
   hideProjectPicker?: boolean;
@@ -165,6 +164,7 @@ export function Composer({
   modelSettings = {},
   runtimeMode,
   cwd = "~",
+  executionCwd,
   branch,
   recents = [],
   hideProjectPicker = false,
@@ -202,9 +202,6 @@ export function Composer({
   );
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [fileDrag, setFileDrag] = useState(false);
-  const [skills, setSkills] = useState<Skill[]>(
-    () => peekSkills(cwd) ?? mergeCatalog([]),
-  );
   const [slash, setSlash] = useState<SlashToken | null>(null);
   const [skillActive, setSkillActive] = useState(0);
   const [creatingSkill, setCreatingSkill] = useState(false);
@@ -233,13 +230,25 @@ export function Composer({
 
   attachmentsRef.current = attachments;
 
-  const rankedSkills = rankSkills(skills, slash?.query ?? "");
   const mentionOpen =
     mention !== null && (looksLikeProject(cwd) || notesEnabled);
   const pickerOpen = creatingSkill || slash !== null;
+  const skillCatalog = useComposerSkills({
+    harness,
+    executionCwd,
+    pickerOpen,
+  });
+  const skills = skillCatalog.skills;
+  const skillLimit =
+    harness === "pi" ? Number.POSITIVE_INFINITY : undefined;
+  const rankedSkills = rankSkills(
+    skills,
+    slash?.query ?? "",
+    skillLimit,
+  );
   const attachmentsSupported = harnessSupportsAttachments(harness);
   const skillNames = useMemo(
-    () => new Set(skills.map((skill) => skill.name)),
+    () => new Set(skills.map((skill) => skill.invocation)),
     [skills],
   );
   const mentionFiles = useMemo(
@@ -335,16 +344,6 @@ export function Composer({
     }
     if (busy) setRunnerLive(true);
   }, [busy, runnerEnabled]);
-
-  useEffect(() => {
-    let cancelled = false;
-    void loadSkills(cwd, pickerOpen).then((next) => {
-      if (!cancelled) setSkills(next);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [cwd, pickerOpen]);
 
   useEffect(() => {
     setSkillActive(0);
@@ -450,10 +449,10 @@ export function Composer({
         setCreatingSkill(false);
         return;
       }
-      const next = replaceSlashToken(el.value, token, skill.name);
+      const next = replaceSlashToken(el.value, token, skill.invocation);
       el.value = next;
       resizeTextarea(el);
-      let cursor = token.start + skill.name.length + 1;
+      let cursor = token.start + skill.invocation.length + 1;
       if (next[cursor] === " ") cursor += 1;
       el.setSelectionRange(cursor, cursor);
       setDraft(next);
@@ -770,7 +769,9 @@ export function Composer({
                     setCreatingSkill(false);
                     setSlash(null);
                     setCreateError(null);
-                    void loadSkills(cwd, true).then(setSkills);
+                    void skillCatalog
+                      .refresh({ refresh: true })
+                      .catch(() => undefined);
                     onOpenFile?.(path);
                     el?.focus();
                   })

--- a/src/chrome/SkillPicker.tsx
+++ b/src/chrome/SkillPicker.tsx
@@ -145,7 +145,7 @@ function SkillList({
         const highlighted = index === active;
         return (
           <button
-            key={`${skill.source}:${skill.path || skill.name}`}
+            key={`${skill.kind}:${skill.source}:${skill.invocation}`}
             ref={highlighted ? activeRef : undefined}
             type="button"
             role="option"
@@ -163,7 +163,7 @@ function SkillList({
                   highlighted ? "font-medium text-skill" : ""
                 }`}
               >
-                /{skill.name}
+                /{skill.invocation}
               </span>
               <span className="shrink-0 text-[10px] uppercase tracking-wide text-content/40">
                 {scopeLabel(skill)}
@@ -312,7 +312,8 @@ function ScopeButton({
 }
 
 function scopeLabel(skill: Skill): string {
-  if (skill.scope === "builtin") return "monocode";
+  if (skill.kind === "native") return skill.source;
+  if (skill.kind === "builtin") return "monocode";
   if (skill.scope === "user") return "personal";
   if (skill.source !== "agents" && skill.source !== "monocode") return skill.source;
   return "project";

--- a/src/chrome/useComposerSkills.test.ts
+++ b/src/chrome/useComposerSkills.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { Skill } from "../lib/skills";
+import {
+  nextComposerSkillContextToken,
+  pickerSkillLoadOptions,
+  visibleComposerSkills,
+} from "./useComposerSkills";
+
+const piSkill: Skill = {
+  kind: "native",
+  name: "architect",
+  description: "Design first.",
+  invocation: "skill:architect",
+  source: "pi",
+};
+
+const cachedSkill: Skill = {
+  kind: "native",
+  name: "cached",
+  description: "Cached current context.",
+  invocation: "skill:cached",
+  source: "pi",
+};
+
+describe("composer skill catalog policies", () => {
+  it("uses loaded rows only for their owning context", () => {
+    expect(
+      visibleComposerSkills(
+        { key: "pi\0/a", skills: [piSkill] },
+        "pi\0/a",
+        null,
+        [],
+      ),
+    ).toEqual([piSkill]);
+    expect(
+      visibleComposerSkills(
+        { key: "pi\0/a", skills: [piSkill] },
+        "pi\0/b",
+        [cachedSkill],
+        [],
+      ),
+    ).toEqual([cachedSkill]);
+  });
+
+  it("preserves filesystem refresh while Pi uses its TTL", () => {
+    expect(pickerSkillLoadOptions("pi")).toBeUndefined();
+    expect(pickerSkillLoadOptions("claude")).toEqual({ refresh: true });
+  });
+
+  it("does not reuse a context token after A to B to A", () => {
+    const firstA = nextComposerSkillContextToken(null, "pi\0/a");
+    const sameA = nextComposerSkillContextToken(firstA, "pi\0/a");
+    const b = nextComposerSkillContextToken(sameA, "pi\0/b");
+    const secondA = nextComposerSkillContextToken(b, "pi\0/a");
+
+    expect(sameA).toBe(firstA);
+    expect(secondA.key).toBe(firstA.key);
+    expect(secondA).not.toBe(firstA);
+    expect(secondA.generation).toBeGreaterThan(firstA.generation);
+  });
+});

--- a/src/chrome/useComposerSkills.ts
+++ b/src/chrome/useComposerSkills.ts
@@ -1,0 +1,120 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  loadSkills,
+  mergeCatalog,
+  peekSkills,
+  skillCatalogKey,
+  type Skill,
+  type SkillCatalogContext,
+} from "../lib/skills";
+import type { HarnessId } from "../lib/session";
+
+export type ComposerSkillContextToken = {
+  key: string;
+  generation: number;
+};
+
+type ComposerSkillState = {
+  key: string;
+  skills: Skill[];
+};
+
+export function nextComposerSkillContextToken(
+  current: ComposerSkillContextToken | null,
+  key: string,
+): ComposerSkillContextToken {
+  if (current?.key === key) return current;
+  return { key, generation: (current?.generation ?? -1) + 1 };
+}
+
+export function pickerSkillLoadOptions(
+  harness: HarnessId,
+): { refresh: true } | undefined {
+  return harness === "pi" ? undefined : { refresh: true };
+}
+
+export function visibleComposerSkills(
+  state: ComposerSkillState,
+  currentKey: string,
+  cached: Skill[] | null,
+  fallback: Skill[],
+): Skill[] {
+  return state.key === currentKey ? state.skills : cached ?? fallback;
+}
+
+export function useComposerSkills(input: {
+  harness: HarnessId;
+  executionCwd: string;
+  pickerOpen: boolean;
+}) {
+  const context = useMemo<SkillCatalogContext>(
+    () => ({ harness: input.harness, cwd: input.executionCwd }),
+    [input.executionCwd, input.harness],
+  );
+  const contextKey = skillCatalogKey(context);
+  const fallback = useMemo<Skill[]>(
+    () => (input.harness === "pi" ? [] : mergeCatalog([])),
+    [input.harness],
+  );
+  const currentToken = useRef<ComposerSkillContextToken | null>(null);
+  currentToken.current = nextComposerSkillContextToken(
+    currentToken.current,
+    contextKey,
+  );
+  const contextToken = currentToken.current;
+  const [state, setState] = useState<ComposerSkillState>(() => ({
+    key: contextKey,
+    skills: peekSkills(context) ?? fallback,
+  }));
+
+  const isCurrent = useCallback(
+    (token: ComposerSkillContextToken) => currentToken.current === token,
+    [],
+  );
+  const commit = useCallback(
+    (token: ComposerSkillContextToken, skills: Skill[]) => {
+      if (!isCurrent(token)) return false;
+      setState({ key: token.key, skills });
+      return true;
+    },
+    [isCurrent],
+  );
+  const refresh = useCallback(
+    async (options?: { refresh?: boolean }) => {
+      const token = contextToken;
+      const next = await loadSkills(context, options);
+      return commit(token, next);
+    },
+    [commit, context, contextToken],
+  );
+
+  useEffect(() => {
+    const cached = peekSkills(context);
+    if (cached) commit(contextToken, cached);
+    void refresh().catch(() => undefined);
+  }, [commit, context, contextToken, refresh]);
+
+  useEffect(() => {
+    if (!input.pickerOpen) return;
+    void refresh(pickerSkillLoadOptions(input.harness)).catch(() => undefined);
+  }, [input.harness, input.pickerOpen, refresh]);
+
+  return {
+    contextKey,
+    contextToken,
+    isCurrent,
+    refresh,
+    skills: visibleComposerSkills(
+      state,
+      contextKey,
+      peekSkills(context),
+      fallback,
+    ),
+  };
+}

--- a/src/lib/harness/child.test.ts
+++ b/src/lib/harness/child.test.ts
@@ -1,16 +1,141 @@
-import { describe, expect, it } from "vitest";
-import { isCurrentChildExit } from "./child";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+
+const mocks = vi.hoisted(() => ({
+  handlers: new Map<string, (event: { payload: never }) => void>(),
+  invoke: vi.fn(),
+  listen: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: mocks.listen }));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function installResolvedListeners() {
+  mocks.listen.mockImplementation(
+    async (name: string, handler: (event: { payload: never }) => void) => {
+      mocks.handlers.set(name, handler);
+      return vi.fn();
+    },
+  );
+}
+
+async function loadChild() {
+  vi.resetModules();
+  return import("./child");
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+afterEach(() => {
+  mocks.handlers.clear();
+  mocks.invoke.mockReset();
+  mocks.listen.mockReset();
+  vi.useRealTimers();
+});
 
 describe("isCurrentChildExit", () => {
-  it("ignores an exit before this session has a live pid", () => {
+  it("matches only the live child's pid", async () => {
+    installResolvedListeners();
+    const { isCurrentChildExit } = await loadChild();
     expect(isCurrentChildExit(undefined, 41)).toBe(false);
-  });
-
-  it("ignores the previous child's exit after a handoff spawn", () => {
     expect(isCurrentChildExit(42, 41)).toBe(false);
+    expect(isCurrentChildExit(42, 42)).toBe(true);
+  });
+});
+
+describe("child bridge", () => {
+  it("waits until every listener is installed", async () => {
+    const pending = deferred<UnlistenFn>();
+    mocks.listen.mockImplementation(
+      (name: string, handler: (event: { payload: never }) => void) => {
+        mocks.handlers.set(name, handler);
+        return name === "harness-stdout" ? pending.promise : Promise.resolve(vi.fn());
+      },
+    );
+    const child = await loadChild();
+    let acquired = false;
+    const lease = child.acquireHarnessBridge().then((release) => {
+      acquired = true;
+      return release;
+    });
+
+    await flush();
+    expect(acquired).toBe(false);
+
+    pending.resolve(vi.fn());
+    const release = await lease;
+    expect(acquired).toBe(true);
+    release();
   });
 
-  it("accepts the live child's own exit", () => {
-    expect(isCurrentChildExit(42, 42)).toBe(true);
+  it("cleans a failed installation and allows retry", async () => {
+    vi.useFakeTimers();
+    const late = deferred<UnlistenFn>();
+    const firstUnlisten = vi.fn();
+    const lateUnlisten = vi.fn();
+    mocks.listen
+      .mockResolvedValueOnce(firstUnlisten)
+      .mockRejectedValueOnce(new Error("listen failed"))
+      .mockReturnValueOnce(late.promise)
+      .mockResolvedValueOnce(vi.fn())
+      .mockResolvedValueOnce(vi.fn());
+    const child = await loadChild();
+    const releaseApp = child.startHarnessBridge();
+
+    await expect(child.acquireHarnessBridge()).rejects.toThrow("listen failed");
+    expect(firstUnlisten).toHaveBeenCalledOnce();
+
+    late.resolve(lateUnlisten);
+    await flush();
+    expect(lateUnlisten).toHaveBeenCalledOnce();
+
+    installResolvedListeners();
+    const releaseProbe = await child.acquireHarnessBridge();
+    releaseProbe();
+    releaseApp();
+    await vi.runAllTimersAsync();
+  });
+
+  it("reconciles an exit that arrives before spawn returns its pid", async () => {
+    installResolvedListeners();
+    const spawned = deferred<number>();
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "harness_spawn") return spawned.promise;
+      return Promise.resolve();
+    });
+    const child = await loadChild();
+    const release = await child.acquireHarnessBridge();
+    const onExit = vi.fn();
+    child.watchChild("probe", vi.fn(), onExit);
+
+    const spawning = child.spawnChild("probe", "pi", ["--mode", "rpc"], "/repo");
+    mocks.handlers.get("harness-exit")?.({
+      payload: { sessionId: "probe", code: 1, pid: 42 } as never,
+    });
+    expect(onExit).not.toHaveBeenCalled();
+
+    spawned.resolve(42);
+    await spawning;
+    expect(onExit).toHaveBeenCalledWith(1);
+    release();
   });
 });

--- a/src/lib/harness/child.ts
+++ b/src/lib/harness/child.ts
@@ -19,6 +19,10 @@ const sseHandlers = new Map<string, SseHandler>();
 const sseEndHandlers = new Map<string, SseEndHandler>();
 const sseBuffer = new Map<string, string[]>();
 const livePid = new Map<string, number>();
+const pendingExit = new Map<
+  string,
+  Array<{ code: number | null; pid: number }>
+>();
 
 /** True when this exit belongs to the child we currently have spawned. */
 export function isCurrentChildExit(
@@ -32,6 +36,7 @@ export function isCurrentChildExit(
 
 const MAX_BUFFERED = 1000;
 let bridge: Promise<UnlistenFn[]> | null = null;
+let bridgeAttempt: symbol | null = null;
 let users = 0;
 let teardownTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -50,45 +55,89 @@ function pushBounded(
 
 function ensureBridge() {
   if (bridge) return;
-  bridge = Promise.all([
-    listen<LinePayload>("harness-stdout", (event) => {
-      const { sessionId, line } = event.payload;
-      const handler = lineHandlers.get(sessionId);
-      if (handler) {
-        handler(line);
-        return;
+  let failed = false;
+  const installed: UnlistenFn[] = [];
+  const register = (pending: Promise<UnlistenFn>) =>
+    pending.then((unlisten) => {
+      if (failed) {
+        unlisten();
+        return () => undefined;
       }
-      pushBounded(lineBuffer, sessionId, line);
-    }),
-    listen<LinePayload>("harness-stderr", (event) => {
-      const { sessionId, line } = event.payload;
-      stderrHandlers.get(sessionId)?.(line);
-    }),
-    listen<ExitPayload>("harness-exit", (event) => {
-      const { sessionId, code, pid } = event.payload;
-      if (!isCurrentChildExit(livePid.get(sessionId), pid)) return;
-      livePid.delete(sessionId);
-      exitHandlers.get(sessionId)?.(code);
-    }),
-    listen<SsePayload>("harness-sse", (event) => {
-      const { sessionId, data } = event.payload;
-      const handler = sseHandlers.get(sessionId);
-      if (handler) {
-        handler(data);
-        return;
-      }
-      pushBounded(sseBuffer, sessionId, data);
-    }),
-    listen<SseEndPayload>("harness-sse-end", (event) => {
-      const { sessionId, error } = event.payload;
-      sseEndHandlers.get(sessionId)?.(error ?? undefined);
-    }),
-  ]);
+      installed.push(unlisten);
+      return unlisten;
+    });
+  const attempt = Symbol("bridge-installation");
+  bridgeAttempt = attempt;
+  const installation = Promise.all([
+    register(
+      listen<LinePayload>("harness-stdout", (event) => {
+        const { sessionId, line } = event.payload;
+        const handler = lineHandlers.get(sessionId);
+        if (handler) {
+          handler(line);
+          return;
+        }
+        pushBounded(lineBuffer, sessionId, line);
+      }),
+    ),
+    register(
+      listen<LinePayload>("harness-stderr", (event) => {
+        const { sessionId, line } = event.payload;
+        stderrHandlers.get(sessionId)?.(line);
+      }),
+    ),
+    register(
+      listen<ExitPayload>("harness-exit", (event) => {
+        const { sessionId, code, pid } = event.payload;
+        const handler = exitHandlers.get(sessionId);
+        if (!handler || pid == null || pid <= 0) return;
+        const currentPid = livePid.get(sessionId);
+        if (isCurrentChildExit(currentPid, pid)) {
+          livePid.delete(sessionId);
+          handler(code);
+          return;
+        }
+        if (currentPid != null) return;
+        const exits = pendingExit.get(sessionId) ?? [];
+        exits.push({ code, pid });
+        if (exits.length > 8) exits.splice(0, exits.length - 8);
+        pendingExit.set(sessionId, exits);
+      }),
+    ),
+    register(
+      listen<SsePayload>("harness-sse", (event) => {
+        const { sessionId, data } = event.payload;
+        const handler = sseHandlers.get(sessionId);
+        if (handler) {
+          handler(data);
+          return;
+        }
+        pushBounded(sseBuffer, sessionId, data);
+      }),
+    ),
+    register(
+      listen<SseEndPayload>("harness-sse-end", (event) => {
+        const { sessionId, error } = event.payload;
+        sseEndHandlers.get(sessionId)?.(error ?? undefined);
+      }),
+    ),
+  ]).catch((error: unknown) => {
+    failed = true;
+    installed.splice(0).forEach((unlisten) => unlisten());
+    if (bridgeAttempt === attempt) {
+      bridge = null;
+      bridgeAttempt = null;
+    }
+    throw error;
+  });
+  void installation.catch(() => undefined);
+  bridge = installation;
 }
 
 function teardownBridge() {
   const pending = bridge;
   bridge = null;
+  bridgeAttempt = null;
   lineHandlers.clear();
   exitHandlers.clear();
   lineBuffer.clear();
@@ -97,7 +146,10 @@ function teardownBridge() {
   sseEndHandlers.clear();
   sseBuffer.clear();
   livePid.clear();
-  void pending?.then((fns) => fns.forEach((fn) => fn()));
+  pendingExit.clear();
+  void pending
+    ?.then((fns) => fns.forEach((fn) => fn()))
+    .catch(() => undefined);
 }
 
 export function startHarnessBridge(): () => void {
@@ -116,6 +168,18 @@ export function startHarnessBridge(): () => void {
       if (users === 0) teardownBridge();
     }, 0);
   };
+}
+
+export async function acquireHarnessBridge(): Promise<() => void> {
+  const release = startHarnessBridge();
+  const installation = bridge;
+  try {
+    await installation;
+    return release;
+  } catch (error) {
+    release();
+    throw error;
+  }
 }
 
 if (import.meta.hot) {
@@ -148,6 +212,7 @@ export function unwatchChild(sessionId: string) {
   exitHandlers.delete(sessionId);
   lineBuffer.delete(sessionId);
   stderrHandlers.delete(sessionId);
+  pendingExit.delete(sessionId);
 }
 
 export function watchSse(
@@ -174,13 +239,22 @@ export async function spawnChild(
   args: string[],
   cwd: string,
 ): Promise<void> {
+  livePid.delete(sessionId);
+  pendingExit.delete(sessionId);
   const pid = await invoke<number>("harness_spawn", {
     sessionId,
     command,
     args,
     cwd,
   });
-  if (typeof pid === "number" && pid > 0) livePid.set(sessionId, pid);
+  if (typeof pid !== "number" || pid <= 0) return;
+  livePid.set(sessionId, pid);
+  const exits = pendingExit.get(sessionId);
+  pendingExit.delete(sessionId);
+  const exited = exits?.find((event) => event.pid === pid);
+  if (!exited) return;
+  livePid.delete(sessionId);
+  exitHandlers.get(sessionId)?.(exited.code);
 }
 
 export function writeChild(sessionId: string, line: string): Promise<void> {
@@ -189,6 +263,7 @@ export function writeChild(sessionId: string, line: string): Promise<void> {
 
 export function killChild(sessionId: string): Promise<void> {
   livePid.delete(sessionId);
+  pendingExit.delete(sessionId);
   unwatchChild(sessionId);
   return invoke("harness_kill", { sessionId });
 }
@@ -202,6 +277,7 @@ export function killAllChildren(): Promise<void> {
   sseEndHandlers.clear();
   sseBuffer.clear();
   livePid.clear();
+  pendingExit.clear();
   return invoke("harness_kill_all");
 }
 

--- a/src/lib/harness/piClient.test.ts
+++ b/src/lib/harness/piClient.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ writeChild: vi.fn() }));
+
+vi.mock("./child", () => ({ writeChild: mocks.writeChild }));
+
+import { PiRpc } from "./piClient";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  mocks.writeChild.mockReset();
+  vi.useRealTimers();
+});
+
+describe("PiRpc.request", () => {
+  it("rejects when the transport write fails", async () => {
+    mocks.writeChild.mockRejectedValue(new Error("write failed"));
+    const rpc = new PiRpc("probe", vi.fn());
+
+    await expect(rpc.request({ type: "get_commands" })).rejects.toThrow(
+      "write failed",
+    );
+    rpc.close();
+  });
+
+  it("times out even when the transport write stalls", async () => {
+    vi.useFakeTimers();
+    const write = deferred<void>();
+    mocks.writeChild.mockReturnValue(write.promise);
+    const rpc = new PiRpc("probe", vi.fn());
+    const request = rpc.request({ type: "get_commands" }, 100);
+    const rejected = expect(request).rejects.toThrow(
+      "Pi get_commands timed out",
+    );
+
+    await vi.advanceTimersByTimeAsync(100);
+    await rejected;
+
+    write.resolve();
+    rpc.close();
+  });
+});

--- a/src/lib/harness/piClient.ts
+++ b/src/lib/harness/piClient.ts
@@ -65,7 +65,13 @@ export class PiRpc {
         },
       });
     });
-    await writeChild(this.sessionId, JSON.stringify(payload));
+    void writeChild(this.sessionId, JSON.stringify(payload)).catch((error) => {
+      const message =
+        error instanceof Error ? error : new Error(String(error));
+      const request = this.pending.get(id);
+      this.pending.delete(id);
+      request?.reject(message);
+    });
     return pending;
   }
 

--- a/src/lib/harness/piSkills.test.ts
+++ b/src/lib/harness/piSkills.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  acquireHarnessBridge: vi.fn(),
+  close: vi.fn(),
+  frames: [] as Array<(record: Record<string, unknown>) => void>,
+  killChild: vi.fn(),
+  onExit: undefined as ((code: number | null) => void) | undefined,
+  pushLine: vi.fn(),
+  releaseBridge: vi.fn(),
+  request: vi.fn(),
+  resolveBinary: vi.fn(),
+  spawnChild: vi.fn(),
+  unwatchChild: vi.fn(),
+  watchChild: vi.fn(),
+  writeChild: vi.fn(),
+}));
+
+vi.mock("./child", () => ({
+  acquireHarnessBridge: mocks.acquireHarnessBridge,
+  killChild: mocks.killChild,
+  resolveOmpBinary: vi.fn(),
+  resolvePiBinary: mocks.resolveBinary,
+  spawnChild: mocks.spawnChild,
+  unwatchChild: mocks.unwatchChild,
+  watchChild: mocks.watchChild,
+  writeChild: mocks.writeChild,
+}));
+
+vi.mock("./piClient", () => ({
+  PiRpc: class {
+    pushLine = mocks.pushLine;
+    request = mocks.request;
+    close = mocks.close;
+
+    constructor(
+      _sessionId: string,
+      onFrame: (record: Record<string, unknown>) => void,
+    ) {
+      mocks.frames.push(onFrame);
+    }
+  },
+}));
+
+import {
+  discoverPiSkills,
+  piSkillsFromRpcData,
+} from "./piSkills";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  for (const value of Object.values(mocks)) {
+    if (typeof value === "function" && "mockReset" in value) {
+      value.mockReset();
+    }
+  }
+  mocks.frames.length = 0;
+  mocks.onExit = undefined;
+  mocks.acquireHarnessBridge.mockResolvedValue(mocks.releaseBridge);
+  mocks.resolveBinary.mockResolvedValue({ path: "/bin/pi" });
+  mocks.spawnChild.mockResolvedValue(undefined);
+  mocks.killChild.mockResolvedValue(undefined);
+  mocks.writeChild.mockResolvedValue(undefined);
+  mocks.request.mockResolvedValue({ data: { commands: [] } });
+  mocks.watchChild.mockImplementation(
+    (
+      _id: string,
+      _onLine: (line: string) => void,
+      onExit: (code: number | null) => void,
+    ) => {
+      mocks.onExit = onExit;
+    },
+  );
+});
+
+describe("piSkillsFromRpcData", () => {
+  it("keeps the first valid row for each Pi skill invocation", () => {
+    expect(
+      piSkillsFromRpcData({
+        commands: [
+          { name: "help", description: "Help", source: "builtin" },
+          {
+            name: "skill:architect",
+            description: "Design before implementation.",
+            source: "skill",
+            sourceInfo: { path: "/tmp/architect/SKILL.md" },
+          },
+          {
+            name: "skill:architect",
+            description: "Duplicate",
+            source: "skill",
+          },
+          { name: "skill:", source: "skill" },
+          { name: 42, source: "skill" },
+        ],
+      }),
+    ).toEqual([
+      {
+        name: "architect",
+        description: "Design before implementation.",
+        invocation: "skill:architect",
+        source: "pi",
+      },
+    ]);
+  });
+
+  it.each([undefined, null, {}, { commands: null }])(
+    "rejects a malformed commands envelope: %j",
+    (data) => expect(() => piSkillsFromRpcData(data)).toThrow(/commands/),
+  );
+});
+
+describe("discoverPiSkills", () => {
+  it("loads skills through an isolated sessionless Pi probe", async () => {
+    mocks.request.mockResolvedValue({
+      data: {
+        commands: [
+          {
+            name: "skill:architect",
+            description: "Design first.",
+            source: "skill",
+          },
+        ],
+      },
+    });
+
+    await expect(discoverPiSkills("/repo")).resolves.toEqual([
+      {
+        name: "architect",
+        description: "Design first.",
+        invocation: "skill:architect",
+        source: "pi",
+      },
+    ]);
+
+    expect(mocks.acquireHarnessBridge).toHaveBeenCalledOnce();
+    const [childId, command, args, cwd] = mocks.spawnChild.mock.calls[0]!;
+    expect(childId).toMatch(/^monocode-pi-skills-/);
+    expect(command).toBe("/bin/pi");
+    expect(args).toEqual(["--mode", "rpc", "--no-session"]);
+    expect(cwd).toBe("/repo");
+    expect(mocks.request).toHaveBeenCalledWith(
+      { type: "get_commands" },
+      45_000,
+    );
+    expect(mocks.close).toHaveBeenCalledOnce();
+    expect(mocks.unwatchChild).toHaveBeenCalledWith(childId);
+    expect(mocks.killChild).toHaveBeenCalledWith(childId);
+    expect(mocks.releaseBridge).toHaveBeenCalledOnce();
+  });
+
+  it("denies extension UI requests that require a reply", async () => {
+    const response = deferred<Record<string, unknown>>();
+    mocks.request.mockReturnValue(response.promise);
+    const discovery = discoverPiSkills("/repo");
+    await vi.waitFor(() => expect(mocks.frames).toHaveLength(1));
+    const childId = mocks.spawnChild.mock.calls[0]![0] as string;
+
+    mocks.frames[0]!({
+      type: "extension_ui_request",
+      id: "ui-1",
+      method: "confirm",
+      title: "Continue?",
+    });
+    await vi.waitFor(() => expect(mocks.writeChild).toHaveBeenCalledOnce());
+    expect(mocks.writeChild).toHaveBeenCalledWith(
+      childId,
+      JSON.stringify({
+        type: "extension_ui_response",
+        id: "ui-1",
+        cancelled: true,
+      }),
+    );
+
+    response.resolve({ data: { commands: [] } });
+    await discovery;
+  });
+
+  it("cleans up after request and response failures", async () => {
+    mocks.request.mockRejectedValueOnce(new Error("rpc failed"));
+    await expect(discoverPiSkills("/repo")).rejects.toThrow("rpc failed");
+    expect(mocks.killChild).toHaveBeenCalledOnce();
+    expect(mocks.releaseBridge).toHaveBeenCalledOnce();
+
+    mocks.request.mockResolvedValueOnce({ data: {} });
+    await expect(discoverPiSkills("/repo")).rejects.toThrow(/commands/);
+    expect(mocks.killChild).toHaveBeenCalledTimes(2);
+    expect(mocks.releaseBridge).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses a unique child id for each probe", async () => {
+    await discoverPiSkills("/repo");
+    await discoverPiSkills("/repo");
+    expect(mocks.spawnChild.mock.calls[0]![0]).not.toBe(
+      mocks.spawnChild.mock.calls[1]![0],
+    );
+  });
+});

--- a/src/lib/harness/piSkills.ts
+++ b/src/lib/harness/piSkills.ts
@@ -1,0 +1,100 @@
+import {
+  acquireHarnessBridge,
+  killChild,
+  spawnChild,
+  unwatchChild,
+  watchChild,
+  writeChild,
+} from "./child";
+import { PiRpc } from "./piClient";
+import { PI_FLAVOR } from "./piFlavor";
+import {
+  asRecord,
+  buildPiSpawnArgs,
+  extensionUiResponse,
+  needsExtensionUiReply,
+  parseExtensionUiRequest,
+} from "./piProtocol";
+
+const REQUEST_TIMEOUT_MS = 45_000;
+
+export type PiSkillCommand = {
+  name: string;
+  description: string;
+  invocation: string;
+  source: "pi";
+};
+
+export async function discoverPiSkills(
+  cwd: string,
+): Promise<PiSkillCommand[]> {
+  const { path } = await PI_FLAVOR.resolveBinary();
+  const releaseBridge = await acquireHarnessBridge();
+  const childId = `monocode-pi-skills-${crypto.randomUUID()}`;
+  const replyToUi = (record: Record<string, unknown>) => {
+    const request = parseExtensionUiRequest(record);
+    if (!request || !needsExtensionUiReply(request)) return;
+    void writeChild(
+      childId,
+      JSON.stringify(extensionUiResponse(request, "deny")),
+    ).catch(() => undefined);
+  };
+  const rpc = new PiRpc(childId, replyToUi, PI_FLAVOR.label);
+
+  try {
+    watchChild(
+      childId,
+      (line) => rpc.pushLine(line),
+      () => rpc.close(new Error(`${PI_FLAVOR.label} skill probe exited`)),
+    );
+    await spawnChild(
+      childId,
+      path,
+      buildPiSpawnArgs(PI_FLAVOR, { noSession: true }),
+      cwd,
+    );
+    const response = await rpc.request(
+      { type: "get_commands" },
+      REQUEST_TIMEOUT_MS,
+    );
+    return piSkillsFromRpcData(asRecord(response)?.data);
+  } finally {
+    rpc.close();
+    unwatchChild(childId);
+    await killChild(childId).catch(() => undefined);
+    releaseBridge();
+  }
+}
+
+export function piSkillsFromRpcData(data: unknown): PiSkillCommand[] {
+  const commands = asRecord(data)?.commands;
+  if (!Array.isArray(commands)) {
+    throw new Error("Pi get_commands returned no commands array");
+  }
+
+  const seen = new Set<string>();
+  const skills: PiSkillCommand[] = [];
+  for (const value of commands) {
+    const command = asRecord(value);
+    const invocation = command?.name;
+    if (
+      command?.source !== "skill" ||
+      typeof invocation !== "string" ||
+      !invocation.startsWith("skill:") ||
+      seen.has(invocation)
+    ) {
+      continue;
+    }
+    const name = invocation.slice("skill:".length);
+    if (!name) continue;
+    seen.add(invocation);
+    skills.push({
+      name,
+      description:
+        typeof command.description === "string" ? command.description : "",
+      invocation,
+      source: "pi",
+    });
+  }
+  return skills;
+}

--- a/src/lib/promptPreparation.test.ts
+++ b/src/lib/promptPreparation.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  applyFileMentionsToTurn: vi.fn(),
+  applyNotesToTurn: vi.fn(),
+  applySkillsToTurn: vi.fn(),
+  events: [] as string[],
+  warmPiSkills: vi.fn(),
+}));
+
+vi.mock("./fileMentions", () => ({
+  applyFileMentionsToTurn: mocks.applyFileMentionsToTurn,
+}));
+
+vi.mock("./notes", () => ({
+  applyNotesToTurn: mocks.applyNotesToTurn,
+}));
+
+vi.mock("./skills", () => ({
+  applySkillsToTurn: mocks.applySkillsToTurn,
+  warmPiSkills: mocks.warmPiSkills,
+}));
+
+import { preparePrompt } from "./promptPreparation";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  mocks.events.length = 0;
+  mocks.applyFileMentionsToTurn.mockReset();
+  mocks.applyNotesToTurn.mockReset();
+  mocks.applyNotesToTurn.mockImplementation(async (text: string) => text);
+  mocks.applySkillsToTurn.mockReset();
+  mocks.warmPiSkills.mockReset();
+  mocks.warmPiSkills.mockImplementation(() => {
+    mocks.events.push("warm");
+  });
+});
+
+describe("preparePrompt", () => {
+  it("starts warmup before awaiting file mentions", async () => {
+    const files = deferred<string>();
+    mocks.applyFileMentionsToTurn.mockImplementation(() => {
+      mocks.events.push("files");
+      return files.promise;
+    });
+    mocks.applySkillsToTurn.mockResolvedValue("prepared");
+
+    const preparation = preparePrompt("hello", {
+      harness: "pi",
+      cwd: "/repo",
+    });
+    expect(mocks.events).toEqual(["warm", "files"]);
+
+    files.resolve("with files");
+    await expect(preparation).resolves.toBe("prepared");
+    expect(mocks.applyNotesToTurn).toHaveBeenCalledWith("with files");
+    expect(mocks.applySkillsToTurn).toHaveBeenCalledWith("with files", {
+      harness: "pi",
+      cwd: "/repo",
+    });
+  });
+});

--- a/src/lib/promptPreparation.ts
+++ b/src/lib/promptPreparation.ts
@@ -1,0 +1,17 @@
+import { applyFileMentionsToTurn } from "./fileMentions";
+import { applyNotesToTurn } from "./notes";
+import {
+  applySkillsToTurn,
+  warmPiSkills,
+  type SkillCatalogContext,
+} from "./skills";
+
+export async function preparePrompt(
+  text: string,
+  context: SkillCatalogContext,
+): Promise<string> {
+  warmPiSkills(context);
+  const withFiles = await applyFileMentionsToTurn(text, context.cwd);
+  const withNotes = await applyNotesToTurn(withFiles);
+  return applySkillsToTurn(withNotes, context);
+}

--- a/src/lib/sessionSkills.test.ts
+++ b/src/lib/sessionSkills.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { piSkillContextForSession } from "./sessionSkills";
+
+describe("piSkillContextForSession", () => {
+  it("uses a Pi session worktree", () => {
+    expect(
+      piSkillContextForSession({
+        harness: "pi",
+        cwd: "/repo",
+        worktreeCwd: "/repo-worktree",
+      }),
+    ).toEqual({ harness: "pi", cwd: "/repo-worktree" });
+  });
+
+  it("ignores a non-Pi session", () => {
+    expect(
+      piSkillContextForSession({ harness: "claude", cwd: "/repo" }),
+    ).toBeNull();
+  });
+});

--- a/src/lib/sessionSkills.ts
+++ b/src/lib/sessionSkills.ts
@@ -1,0 +1,18 @@
+import {
+  sessionWorkCwd,
+  type HarnessId,
+} from "./session";
+import type { SkillCatalogContext } from "./skills";
+
+type SkillWarmupSession = {
+  harness: HarnessId;
+  cwd: string;
+  worktreeCwd?: string;
+};
+
+export function piSkillContextForSession(
+  session: SkillWarmupSession,
+): SkillCatalogContext | null {
+  if (session.harness !== "pi") return null;
+  return { harness: "pi", cwd: sessionWorkCwd(session) };
+}

--- a/src/lib/skillCatalog.test.ts
+++ b/src/lib/skillCatalog.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  discoverPiSkills: vi.fn(),
+  listSkills: vi.fn(),
+}));
+
+vi.mock("./harness/piSkills", () => ({
+  discoverPiSkills: mocks.discoverPiSkills,
+}));
+
+vi.mock("./fs", () => ({
+  createPath: vi.fn(),
+  homeDir: vi.fn(),
+  listSkills: mocks.listSkills,
+  readTextFile: vi.fn(),
+  writeTextFile: vi.fn(),
+}));
+
+import {
+  BUILTIN_CREATE_SKILL,
+  invalidateSkills,
+  loadSkills,
+  peekSkills,
+  skillCatalogKey,
+} from "./skills";
+import type { PiSkillCommand } from "./harness/piSkills";
+
+function piSkill(name: string): PiSkillCommand {
+  return {
+    name,
+    description: `${name} description`,
+    invocation: `skill:${name}`,
+    source: "pi",
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-29T12:00:00Z"));
+  invalidateSkills();
+  mocks.discoverPiSkills.mockReset();
+  mocks.listSkills.mockReset();
+  mocks.discoverPiSkills.mockResolvedValue([piSkill("architect")]);
+  mocks.listSkills.mockResolvedValue([]);
+});
+
+describe("provider-aware skill catalog", () => {
+  it("uses Pi discovery without adding MonoCode's built-in row", async () => {
+    const catalog = await loadSkills({ harness: "pi", cwd: "/repo/" });
+
+    expect(mocks.discoverPiSkills).toHaveBeenCalledWith("/repo");
+    expect(catalog).toEqual([
+      {
+        kind: "native",
+        ...piSkill("architect"),
+      },
+    ]);
+    expect(catalog).not.toContainEqual(BUILTIN_CREATE_SKILL);
+  });
+
+  it("keeps filesystem discovery and the built-in row for non-Pi providers", async () => {
+    const catalog = await loadSkills({ harness: "claude", cwd: "/repo" });
+
+    expect(mocks.listSkills).toHaveBeenCalledWith("/repo");
+    expect(catalog).toContainEqual(BUILTIN_CREATE_SKILL);
+    expect(mocks.discoverPiSkills).not.toHaveBeenCalled();
+  });
+
+  it("separates providers and coalesces equivalent Pi directories", async () => {
+    const pending = deferred<PiSkillCommand[]>();
+    mocks.discoverPiSkills.mockReturnValue(pending.promise);
+
+    const first = loadSkills({ harness: "pi", cwd: "/repo/" });
+    const second = loadSkills({ harness: "pi", cwd: "/repo" });
+    const claude = loadSkills({ harness: "claude", cwd: "/repo" });
+
+    expect(mocks.discoverPiSkills).toHaveBeenCalledTimes(1);
+    expect(skillCatalogKey({ harness: "pi", cwd: "/repo/" })).toBe(
+      skillCatalogKey({ harness: "pi", cwd: "/repo" }),
+    );
+    expect(skillCatalogKey({ harness: "pi", cwd: "/repo" })).not.toBe(
+      skillCatalogKey({ harness: "claude", cwd: "/repo" }),
+    );
+
+    pending.resolve([piSkill("architect")]);
+    await expect(first).resolves.toEqual(await second);
+    await claude;
+  });
+
+  it("refreshes stale Pi data and retains it after a failed refresh", async () => {
+    await loadSkills({ harness: "pi", cwd: "/repo" });
+    vi.advanceTimersByTime(30_001);
+    const refresh = deferred<PiSkillCommand[]>();
+    mocks.discoverPiSkills.mockReturnValueOnce(refresh.promise);
+
+    const loading = loadSkills({ harness: "pi", cwd: "/repo" });
+    expect(peekSkills({ harness: "pi", cwd: "/repo" })?.[0]?.name).toBe(
+      "architect",
+    );
+    refresh.resolve([piSkill("new-skill")]);
+    await expect(loading).resolves.toMatchObject([{ name: "new-skill" }]);
+
+    vi.advanceTimersByTime(30_001);
+    mocks.discoverPiSkills.mockRejectedValueOnce(new Error("offline"));
+    await expect(
+      loadSkills({ harness: "pi", cwd: "/repo" }),
+    ).resolves.toMatchObject([{ name: "new-skill" }]);
+    await loadSkills({ harness: "pi", cwd: "/repo" });
+    expect(mocks.discoverPiSkills).toHaveBeenCalledTimes(3);
+
+    vi.advanceTimersByTime(5_001);
+    await loadSkills({ harness: "pi", cwd: "/repo" });
+    expect(mocks.discoverPiSkills).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not let an invalidated request replace a newer generation", async () => {
+    const old = deferred<PiSkillCommand[]>();
+    const current = deferred<PiSkillCommand[]>();
+    mocks.discoverPiSkills
+      .mockReturnValueOnce(old.promise)
+      .mockReturnValueOnce(current.promise);
+
+    const oldLoad = loadSkills({ harness: "pi", cwd: "/repo" });
+    invalidateSkills({ cwd: "/repo" });
+    const currentLoad = loadSkills(
+      { harness: "pi", cwd: "/repo" },
+      { refresh: true },
+    );
+    current.resolve([piSkill("current")]);
+    await currentLoad;
+    old.resolve([piSkill("old")]);
+
+    await expect(oldLoad).resolves.toMatchObject([{ name: "current" }]);
+    expect(peekSkills({ harness: "pi", cwd: "/repo" })).toMatchObject([
+      { name: "current" },
+    ]);
+  });
+
+  it("rejects completions captured before a global reset", async () => {
+    const old = deferred<PiSkillCommand[]>();
+    mocks.discoverPiSkills.mockReturnValueOnce(old.promise);
+    const oldLoad = loadSkills({ harness: "pi", cwd: "/repo" });
+
+    invalidateSkills();
+    mocks.discoverPiSkills.mockResolvedValueOnce([piSkill("current")]);
+    await loadSkills({ harness: "pi", cwd: "/repo" });
+    old.resolve([piSkill("old")]);
+
+    await expect(oldLoad).resolves.toMatchObject([{ name: "current" }]);
+    expect(peekSkills({ harness: "pi", cwd: "/repo" })).toMatchObject([
+      { name: "current" },
+    ]);
+  });
+});

--- a/src/lib/skills.test.ts
+++ b/src/lib/skills.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   BUILTIN_CREATE_SKILL,
+  applySkillsToTurn,
   blankSkillMarkdown,
   injectSkillPrompt,
   isValidSkillName,
@@ -15,19 +16,41 @@ import {
 } from "./skills";
 
 const review: Skill = {
+  kind: "file",
   name: "review-pr",
   description: "Review pull requests against team standards.",
+  invocation: "review-pr",
   path: "/tmp/.agents/skills/review-pr/SKILL.md",
   scope: "project",
   source: "agents",
 };
 
 const native: Skill = {
+  kind: "file",
   name: "cursor-only",
   description: "Cursor native helper",
+  invocation: "cursor-only",
   path: "/tmp/.cursor/skills/cursor-only/SKILL.md",
   scope: "project",
   source: "cursor",
+};
+
+const piNative: Skill = {
+  kind: "native",
+  name: "architect",
+  description: "Design before implementation.",
+  invocation: "skill:architect",
+  source: "pi",
+};
+
+const piFile: Skill = {
+  kind: "file",
+  name: "pi-file",
+  description: "A file discovered by the existing scanner.",
+  invocation: "pi-file",
+  path: "/tmp/.pi/skills/pi-file/SKILL.md",
+  scope: "project",
+  source: "pi",
 };
 
 describe("slashTokenAt", () => {
@@ -56,13 +79,16 @@ describe("slashTokenAt", () => {
 });
 
 describe("replaceSlashToken", () => {
-  it("inserts /name and a trailing space", () => {
+  it("inserts an exact invocation and a trailing space", () => {
     expect(replaceSlashToken("/cre", { start: 0, end: 4, query: "cre" }, "create-skill")).toBe(
       "/create-skill ",
     );
     expect(
       replaceSlashToken("x /r y", { start: 2, end: 4, query: "r" }, "review-pr"),
     ).toBe("x /review-pr y");
+    expect(
+      replaceSlashToken("/arch", { start: 0, end: 5, query: "arch" }, "skill:architect"),
+    ).toBe("/skill:architect ");
   });
 });
 
@@ -80,12 +106,19 @@ describe("skillNamesInText", () => {
 });
 
 describe("skillTextParts", () => {
-  const names = new Set(["review-pr", "create-skill"]);
+  const names = new Set(["review-pr", "create-skill", "skill:architect"]);
 
   it("marks known /skill tokens", () => {
     expect(skillTextParts("/review-pr look at auth", names)).toEqual([
       { text: "/review-pr", skill: true },
       { text: " look at auth", skill: false },
+    ]);
+  });
+
+  it("marks a known namespaced invocation", () => {
+    expect(skillTextParts("/skill:architect inspect this", names)).toEqual([
+      { text: "/skill:architect", skill: true },
+      { text: " inspect this", skill: false },
     ]);
   });
 
@@ -112,6 +145,17 @@ describe("skillTextParts", () => {
         .filter((part) => part.skill)
         .map((part) => part.text),
     ).toEqual(["/review-pr"]);
+  });
+});
+
+describe("applySkillsToTurn", () => {
+  it("leaves Pi-native skill commands unchanged", async () => {
+    await expect(
+      applySkillsToTurn("/skill:architect inspect this", {
+        harness: "pi",
+        cwd: "/repo",
+      }),
+    ).resolves.toBe("/skill:architect inspect this");
   });
 });
 
@@ -187,6 +231,35 @@ describe("rankSkills", () => {
   it("fuzzy-matches names ahead of descriptions", () => {
     const ranked = rankSkills([native, review, BUILTIN_CREATE_SKILL], "rev");
     expect(ranked[0]?.name).toBe("review-pr");
+  });
+
+  it("ranks native Pi rows with project skills", () => {
+    const ranked = rankSkills([review, piNative, piFile], "");
+    expect(ranked.map((skill) => skill.name)).toEqual([
+      "architect",
+      "pi-file",
+      "review-pr",
+    ]);
+  });
+
+  it("gives the built-in row its exact invocation", () => {
+    expect(BUILTIN_CREATE_SKILL.invocation).toBe("create-skill");
+  });
+
+  it("keeps every Pi result when the composer removes the default cap", () => {
+    const rows: Skill[] = Array.from({ length: 75 }, (_, index) => ({
+      kind: "native",
+      name: `skill-${String(index).padStart(2, "0")}`,
+      description: "Pi skill",
+      invocation: `skill:skill-${String(index).padStart(2, "0")}`,
+      source: "pi",
+    }));
+
+    expect(rankSkills(rows, "")).toHaveLength(50);
+    expect(rankSkills(rows, "", Number.POSITIVE_INFINITY)).toHaveLength(75);
+    expect(rankSkills(rows, "skill-74", Number.POSITIVE_INFINITY)[0]?.name).toBe(
+      "skill-74",
+    );
   });
 });
 

--- a/src/lib/skills.test.ts
+++ b/src/lib/skills.test.ts
@@ -65,6 +65,11 @@ describe("slashTokenAt", () => {
       end: 11,
       query: "rev",
     });
+    expect(slashTokenAt("/skill:arch", 11)).toEqual({
+      start: 0,
+      end: 11,
+      query: "skill:arch",
+    });
   });
 
   it("ignores URLs and paths", () => {
@@ -240,6 +245,11 @@ describe("rankSkills", () => {
       "pi-file",
       "review-pr",
     ]);
+  });
+
+  it("matches the displayed invocation", () => {
+    expect(rankSkills([review, piNative], "skill")).toEqual([piNative]);
+    expect(rankSkills([review, piNative], "skill:arch")).toEqual([piNative]);
   });
 
   it("gives the built-in row its exact invocation", () => {

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -9,8 +9,10 @@ import {
 import { invalidateProjectFiles } from "./fileIndex";
 import { fuzzyMatch } from "./fuzzy";
 import { joinPath } from "./paths";
-import { looksLikeProject } from "./recents";
+import { looksLikeProject, normalizeProjectPath } from "./recents";
 import { isMarkdownBlockquotePosition } from "./quoteDraft";
+import type { HarnessId } from "./session";
+import { discoverPiSkills } from "./harness/piSkills";
 import {
   CREATE_SKILL_BODY,
   CREATE_SKILL_DESCRIPTION,
@@ -29,13 +31,31 @@ export type SkillSource =
   | "fx"
   | "monocode";
 
-export type Skill = {
+type SkillCommon = {
   name: string;
   description: string;
+  invocation: string;
+};
+
+export type FileSkill = SkillCommon & {
+  kind: "file";
   path: string;
-  scope: SkillScope;
+  scope: Exclude<SkillScope, "builtin">;
   source: SkillSource;
 };
+
+export type BuiltinSkill = SkillCommon & {
+  kind: "builtin";
+  scope: "builtin";
+  source: "monocode";
+};
+
+export type NativeSkill = SkillCommon & {
+  kind: "native";
+  source: "pi";
+};
+
+export type Skill = FileSkill | BuiltinSkill | NativeSkill;
 
 export type SlashToken = {
   start: number;
@@ -43,48 +63,174 @@ export type SlashToken = {
   query: string;
 };
 
-export const BUILTIN_CREATE_SKILL: Skill = {
+export const BUILTIN_CREATE_SKILL: BuiltinSkill = {
+  kind: "builtin",
   name: CREATE_SKILL_NAME,
   description: CREATE_SKILL_DESCRIPTION,
-  path: "",
+  invocation: CREATE_SKILL_NAME,
   scope: "builtin",
   source: "monocode",
 };
 
 const SKILL_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-const SKILL_TOKEN_RE = /(^|\s)\/([a-z0-9]+(?:-[a-z0-9]+)*)(?=\s|$)/g;
+const SKILL_TOKEN_RE =
+  /(^|\s)\/([a-z0-9]+(?:-[a-z0-9]+)*(?::[a-z0-9]+(?:-[a-z0-9]+)*)?)(?=\s|$)/g;
 const MAX_PICKER = 50;
+const PI_SKILL_TTL_MS = 30_000;
+const PI_SKILL_RETRY_MS = 5_000;
 
-let cache: { cwd: string; skills: Skill[] } | null = null;
-let inflight: { cwd: string; promise: Promise<Skill[]> } | null = null;
+export type SkillCatalogContext = {
+  harness: HarnessId;
+  cwd: string;
+};
 
-export function peekSkills(cwd: string): Skill[] | null {
-  return cache?.cwd === cwd ? cache.skills : null;
+type CatalogRequest = {
+  generation: number;
+  promise: Promise<Skill[]>;
+};
+
+type CatalogEntry = {
+  cwd: string;
+  skills: Skill[] | null;
+  loadedAt: number;
+  retryAt: number;
+  generation: number;
+  inFlight: CatalogRequest | null;
+};
+
+const catalogEntries = new Map<string, CatalogEntry>();
+
+export function skillCatalogKey(context: SkillCatalogContext): string {
+  return `${context.harness}\0${normalizeProjectPath(context.cwd)}`;
 }
 
-export function invalidateSkills(cwd?: string) {
-  if (!cwd || cache?.cwd === cwd) cache = null;
+export function peekSkills(context: SkillCatalogContext): Skill[] | null {
+  return catalogEntries.get(skillCatalogKey(context))?.skills ?? null;
 }
 
-export async function loadSkills(
-  cwd: string,
-  refresh = false,
+export function invalidateSkills(context?: { cwd: string }) {
+  if (!context) {
+    catalogEntries.clear();
+    return;
+  }
+  const cwd = normalizeProjectPath(context.cwd);
+  for (const entry of catalogEntries.values()) {
+    if (entry.cwd !== cwd) continue;
+    entry.generation += 1;
+    entry.loadedAt = 0;
+    entry.retryAt = 0;
+    entry.inFlight = null;
+  }
+}
+
+export function loadSkills(
+  context: SkillCatalogContext,
+  options?: { refresh?: boolean },
 ): Promise<Skill[]> {
-  if (!refresh && cache?.cwd === cwd) return cache.skills;
-  if (!refresh && inflight?.cwd === cwd) return inflight.promise;
+  const normalized = {
+    harness: context.harness,
+    cwd: normalizeProjectPath(context.cwd),
+  } satisfies SkillCatalogContext;
+  const key = skillCatalogKey(normalized);
+  let entry = catalogEntries.get(key);
+  if (!entry) {
+    entry = {
+      cwd: normalized.cwd,
+      skills: null,
+      loadedAt: 0,
+      retryAt: 0,
+      generation: 0,
+      inFlight: null,
+    };
+    catalogEntries.set(key, entry);
+  }
 
-  const promise = listSkills(cwd)
-    .then((discovered) => mergeCatalog(discovered))
-    .catch(() => mergeCatalog([]))
+  const now = Date.now();
+  if (options?.refresh) {
+    if (entry.inFlight?.generation === entry.generation) {
+      return entry.inFlight.promise;
+    }
+    entry.generation += 1;
+    entry.retryAt = 0;
+    return startCatalogLoad(key, entry, normalized);
+  }
+
+  if (entry.inFlight?.generation === entry.generation) {
+    return entry.inFlight.promise;
+  }
+  if (normalized.harness !== "pi" && entry.skills) {
+    return Promise.resolve(entry.skills);
+  }
+  if (
+    normalized.harness === "pi" &&
+    entry.skills &&
+    now - entry.loadedAt < PI_SKILL_TTL_MS
+  ) {
+    return Promise.resolve(entry.skills);
+  }
+  if (normalized.harness === "pi" && now < entry.retryAt) {
+    return Promise.resolve(entry.skills ?? []);
+  }
+  return startCatalogLoad(key, entry, normalized);
+}
+
+function startCatalogLoad(
+  key: string,
+  entry: CatalogEntry,
+  context: SkillCatalogContext,
+): Promise<Skill[]> {
+  const generation = entry.generation;
+  const promise = loadCatalog(context)
     .then((skills) => {
-      cache = { cwd, skills };
+      if (
+        catalogEntries.get(key) !== entry ||
+        entry.generation !== generation
+      ) {
+        return catalogEntries.get(key)?.skills ?? [];
+      }
+      entry.skills = skills;
+      entry.loadedAt = Date.now();
+      entry.retryAt = 0;
       return skills;
     })
+    .catch(() => {
+      if (
+        catalogEntries.get(key) !== entry ||
+        entry.generation !== generation
+      ) {
+        return catalogEntries.get(key)?.skills ?? [];
+      }
+      if (context.harness === "pi") {
+        entry.retryAt = Date.now() + PI_SKILL_RETRY_MS;
+        return entry.skills ?? [];
+      }
+      const fallback = mergeCatalog([]);
+      entry.skills = fallback;
+      entry.loadedAt = Date.now();
+      return fallback;
+    })
     .finally(() => {
-      if (inflight?.promise === promise) inflight = null;
+      if (
+        catalogEntries.get(key) === entry &&
+        entry.generation === generation &&
+        entry.inFlight?.promise === promise
+      ) {
+        entry.inFlight = null;
+      }
     });
-  inflight = { cwd, promise };
+  entry.inFlight = { generation, promise };
   return promise;
+}
+
+async function loadCatalog(context: SkillCatalogContext): Promise<Skill[]> {
+  if (context.harness === "pi") {
+    const commands = await discoverPiSkills(context.cwd);
+    return commands.map((command): NativeSkill => ({
+      kind: "native",
+      ...command,
+    }));
+  }
+  return mergeCatalog(await listSkills(context.cwd));
 }
 
 export function mergeCatalog(discovered: DiscoveredSkill[]): Skill[] {
@@ -103,10 +249,12 @@ export function mergeCatalog(discovered: DiscoveredSkill[]): Skill[] {
   return [...out.values()];
 }
 
-function asSkill(skill: DiscoveredSkill): Skill {
+function asSkill(skill: DiscoveredSkill): FileSkill {
   return {
+    kind: "file",
     name: skill.name,
     description: skill.description,
+    invocation: skill.name,
     path: skill.path,
     scope: skill.scope === "user" ? "user" : "project",
     source: skill.source === "monocode" ? "monocode" : skill.source,
@@ -142,8 +290,8 @@ export function rankSkills(skills: Skill[], query: string, limit = MAX_PICKER): 
 }
 
 function scopeRank(skill: Skill): number {
-  if (skill.scope === "builtin") return 0;
-  if (skill.scope === "project") return 1;
+  if (skill.kind === "builtin") return 0;
+  if (skill.kind === "native" || skill.scope === "project") return 1;
   return 2;
 }
 
@@ -269,15 +417,18 @@ export function injectSkillPrompt(
 
 export async function applySkillsToTurn(
   text: string,
-  cwd: string,
+  context: SkillCatalogContext,
 ): Promise<string> {
+  if (context.harness === "pi") return text;
   const names = skillNamesInText(text);
   if (names.length === 0) return text;
-  const catalog = await loadSkills(cwd);
-  const picked: Skill[] = [];
+  const catalog = await loadSkills(context);
+  const picked: Array<FileSkill | BuiltinSkill> = [];
   for (const name of names) {
     const skill = catalog.find((item) => item.name === name);
-    if (skill) picked.push(skill);
+    if (skill?.kind === "file" || skill?.kind === "builtin") {
+      picked.push(skill);
+    }
   }
   if (picked.length === 0) return text;
   const bodies: Record<string, string> = {};
@@ -289,8 +440,20 @@ export async function applySkillsToTurn(
   return injectSkillPrompt(text, picked, bodies);
 }
 
-export async function readSkillBody(skill: Skill): Promise<string> {
-  if (!skill.path) return CREATE_SKILL_BODY;
+type SkillLoader = typeof loadSkills;
+
+export function warmPiSkills(
+  context: SkillCatalogContext,
+  load: SkillLoader = loadSkills,
+): void {
+  if (context.harness !== "pi") return;
+  void load(context).catch(() => undefined);
+}
+
+export async function readSkillBody(
+  skill: FileSkill | BuiltinSkill,
+): Promise<string> {
+  if (skill.kind === "builtin") return CREATE_SKILL_BODY;
   try {
     return await readTextFile(skill.path);
   } catch {
@@ -352,7 +515,7 @@ export async function createBlankSkill(input: {
   await createPath(root, relative, true);
   const path = joinPath(root, `${relative}/SKILL.md`);
   await writeTextFile(path, blankSkillMarkdown(name));
-  invalidateSkills(input.cwd);
+  invalidateSkills({ cwd: input.cwd });
   invalidateProjectFiles(input.cwd);
   return path;
 }

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -276,10 +276,16 @@ export function rankSkills(skills: Skill[], query: string, limit = MAX_PICKER): 
   const scored: { skill: Skill; score: number }[] = [];
   for (const skill of skills) {
     const nameHit = fuzzyMatch(needle, skill.name);
-    const descHit = nameHit ? null : fuzzyMatch(needle, skill.description);
-    const hit = nameHit ?? descHit;
+    const invocationHit = nameHit
+      ? null
+      : fuzzyMatch(needle, skill.invocation);
+    const descHit =
+      nameHit || invocationHit
+        ? null
+        : fuzzyMatch(needle, skill.description);
+    const hit = nameHit ?? invocationHit ?? descHit;
     if (!hit) continue;
-    const score = nameHit ? hit.score + 400 : hit.score;
+    const score = nameHit || invocationHit ? hit.score + 400 : hit.score;
     scored.push({ skill, score });
   }
   scored.sort((a, b) => {
@@ -310,7 +316,7 @@ export function slashTokenAt(text: string, cursor: number): SlashToken | null {
   const typed = text.slice(start + 1, i);
   if (typed.includes("/") || typed.includes("\\")) return null;
   if (/[A-Z]/.test(typed)) return null;
-  if (!/^[a-z0-9-]*$/.test(typed)) return null;
+  if (!/^(?:[a-z0-9-]+(?::[a-z0-9-]*)?)?$/.test(typed)) return null;
 
   return { start, end, query: typed };
 }

--- a/src/surfaces/SessionPane.tsx
+++ b/src/surfaces/SessionPane.tsx
@@ -172,6 +172,7 @@ export const SessionPane = memo(function SessionPane({
       modelSettings={session.modelSettings}
       runtimeMode={session.runtimeMode}
       cwd={session.cwd}
+      executionCwd={workCwd}
       recents={recents}
       hideProjectPicker={hideProjectPicker ? !showDeckProjectPicker : false}
       context={session.context}


### PR DESCRIPTION
## What changed

This allows monocode to load skills directly from pi

## Why

<img width="1246" height="814" alt="CleanShot 2026-08-29 at 14 32 46@2x" src="https://github.com/user-attachments/assets/8cf2291a-b6e4-4f90-9546-5b385165c084" />


## UI

<img width="1124" height="816" alt="CleanShot 2026-08-29 at 14 33 40@2x" src="https://github.com/user-attachments/assets/712f5a87-953d-4a3d-9757-564665fcad60" />


## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes
