### PR TITLE
Add a System theme option that follows the OS appearance

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,13 @@
             var o = Math.max(0.15, Math.min(1, Number(opacity) || 0.85));
             root.style.setProperty("--sidebar-opacity", String(o));
           }
-          if (localStorage.getItem("monocode.colorScheme") === "light") {
+          var scheme = localStorage.getItem("monocode.colorScheme");
+          if (scheme === "system") {
+            scheme = window.matchMedia("(prefers-color-scheme: light)").matches
+              ? "light"
+              : "dark";
+          }
+          if (scheme === "light") {
             root.classList.add("theme-light");
           }
           var bodyGlass = localStorage.getItem("monocode.bodyGlass");

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -1,13 +1,16 @@
 import { useEffect, useState } from "react";
 import {
-  loadColorScheme,
+  loadThemePreference,
+  resolveColorScheme,
   SCHEME_CHANGE_EVENT,
   type ColorScheme,
 } from "../lib/appearance";
 
-/** Subscribes to color scheme changes triggered by applyColorScheme(). */
+/** Subscribes to color scheme changes triggered by applyThemePreference(). */
 export function useColorScheme(): ColorScheme {
-  const [scheme, setScheme] = useState<ColorScheme>(loadColorScheme);
+  const [scheme, setScheme] = useState<ColorScheme>(() =>
+    resolveColorScheme(loadThemePreference()),
+  );
   useEffect(() => {
     const onChange = (event: Event) => {
       const detail = (event as CustomEvent<ColorScheme>).detail;

--- a/src/lib/appearance.test.ts
+++ b/src/lib/appearance.test.ts
@@ -10,9 +10,14 @@ import {
   loadTranscriptAnchor,
   saveTranscriptAnchor,
   TRANSCRIPT_ANCHOR_DEFAULT,
+  loadThemePreference,
+  saveThemePreference,
+  resolveColorScheme,
+  THEME_PREFERENCE_DEFAULT,
 } from "./appearance";
 
 const KEY = "monocode.transcriptLayout";
+const SCHEME_KEY = "monocode.colorScheme";
 const ZEN_KEY = "monocode.transcriptZen";
 const ANCHOR_KEY = "monocode.transcriptAnchor";
 
@@ -107,5 +112,60 @@ describe("transcript prompt-to-top setting", () => {
     expect(loadTranscriptAnchor()).toBe(true);
     saveTranscriptAnchor(false);
     expect(loadTranscriptAnchor()).toBe(false);
+  });
+});
+
+function mockSystemScheme(scheme: "dark" | "light") {
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      matchMedia: (query: string) => ({
+        matches: query.includes("light") && scheme === "light",
+      }),
+    },
+    configurable: true,
+  });
+}
+
+describe("theme preference setting", () => {
+  beforeEach(mockLocalStorage);
+  afterEach(() => {
+    localStorage.removeItem(SCHEME_KEY);
+    Reflect.deleteProperty(globalThis, "window");
+  });
+
+  it("defaults to dark", () => {
+    expect(THEME_PREFERENCE_DEFAULT).toBe("dark");
+    expect(loadThemePreference()).toBe("dark");
+  });
+
+  it("persists each preference", () => {
+    for (const value of ["system", "light", "dark"] as const) {
+      saveThemePreference(value);
+      expect(localStorage.getItem(SCHEME_KEY)).toBe(value);
+      expect(loadThemePreference()).toBe(value);
+    }
+  });
+
+  it("ignores unknown stored values", () => {
+    localStorage.setItem(SCHEME_KEY, "solarized");
+    expect(loadThemePreference()).toBe(THEME_PREFERENCE_DEFAULT);
+  });
+
+  it("resolves system against the OS appearance", () => {
+    mockSystemScheme("light");
+    expect(resolveColorScheme("system")).toBe("light");
+    mockSystemScheme("dark");
+    expect(resolveColorScheme("system")).toBe("dark");
+  });
+
+  it("keeps explicit picks regardless of the OS appearance", () => {
+    mockSystemScheme("light");
+    expect(resolveColorScheme("dark")).toBe("dark");
+    mockSystemScheme("dark");
+    expect(resolveColorScheme("light")).toBe("light");
+  });
+
+  it("falls back to dark without matchMedia", () => {
+    expect(resolveColorScheme("system")).toBe("dark");
   });
 });

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -17,10 +17,11 @@ const TRANSCRIPT_ZEN_KEY = "monocode.transcriptZen";
 const TRANSCRIPT_ANCHOR_KEY = "monocode.transcriptAnchor";
 
 export type ColorScheme = "dark" | "light";
+export type ThemePreference = ColorScheme | "system";
 export type SidebarLayout = "classic" | "deck";
 export type TranscriptLayout = "full" | "chat";
 
-export const COLOR_SCHEME_DEFAULT: ColorScheme = "dark";
+export const THEME_PREFERENCE_DEFAULT: ThemePreference = "dark";
 
 /** Fired on `window` whenever the color scheme flips (detail: ColorScheme). */
 export const SCHEME_CHANGE_EVENT = "monocode:schemechange";
@@ -169,21 +170,27 @@ export function applyThemeTint(hue: number, saturation: number) {
 export function initAppearance() {
   document.documentElement.classList.toggle("is-mac", IS_MAC);
   applyThemeTint(loadThemeHue(), loadThemeSaturation());
-  applyColorScheme(loadColorScheme());
+  applyThemePreference(loadThemePreference());
+  watchSystemColorScheme();
   applySidebarOpacity(loadSidebarOpacity());
   applySidebarBlur(loadSidebarBlur());
   applyBodyGlass(loadBodyGlass());
 }
 
-export function loadColorScheme(): ColorScheme {
+function isThemePreference(value: unknown): value is ThemePreference {
+  return value === "dark" || value === "light" || value === "system";
+}
+
+export function loadThemePreference(): ThemePreference {
   try {
-    return localStorage.getItem(SCHEME_KEY) === "light" ? "light" : "dark";
+    const raw = localStorage.getItem(SCHEME_KEY);
+    return isThemePreference(raw) ? raw : THEME_PREFERENCE_DEFAULT;
   } catch {
-    return COLOR_SCHEME_DEFAULT;
+    return THEME_PREFERENCE_DEFAULT;
   }
 }
 
-export function saveColorScheme(value: ColorScheme) {
+export function saveThemePreference(value: ThemePreference) {
   try {
     localStorage.setItem(SCHEME_KEY, value);
   } catch {
@@ -191,17 +198,40 @@ export function saveColorScheme(value: ColorScheme) {
   }
 }
 
+function systemQuery(): MediaQueryList | null {
+  if (typeof window === "undefined" || !window.matchMedia) return null;
+  return window.matchMedia("(prefers-color-scheme: light)");
+}
+
+function systemColorScheme(): ColorScheme {
+  return systemQuery()?.matches ? "light" : "dark";
+}
+
+export function resolveColorScheme(value: ThemePreference): ColorScheme {
+  return value === "system" ? systemColorScheme() : value;
+}
+
 export function isLightScheme(): boolean {
   return document.documentElement.classList.contains("theme-light");
 }
 
-export function applyColorScheme(value: ColorScheme): ColorScheme {
-  const next = value === "light" ? "light" : "dark";
+export function applyThemePreference(value: ThemePreference): ColorScheme {
+  const next = resolveColorScheme(value);
   document.documentElement.classList.toggle("theme-light", next === "light");
   window.dispatchEvent(
     new CustomEvent<ColorScheme>(SCHEME_CHANGE_EVENT, { detail: next }),
   );
   return next;
+}
+
+/** Keeps the "system" preference in sync when the OS flips appearance. */
+export function watchSystemColorScheme() {
+  const query = systemQuery();
+  if (!query) return;
+  query.addEventListener("change", () => {
+    const preference = loadThemePreference();
+    if (preference === "system") applyThemePreference(preference);
+  });
 }
 
 export function loadSidebarOpacity(): number {

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -22,14 +22,14 @@ import { WindowControls } from "../chrome/WindowControls";
 import { useLockOverscroll } from "../hooks/useLockOverscroll";
 import {
   applyBodyGlass,
-  applyColorScheme,
+  applyThemePreference,
   applySidebarBlur,
   applySidebarOpacity,
   applyThemeTint,
   BODY_GLASS_DEFAULT,
-  COLOR_SCHEME_DEFAULT,
+  THEME_PREFERENCE_DEFAULT,
   loadBodyGlass,
-  loadColorScheme,
+  loadThemePreference,
   loadSidebarBlur,
   loadSidebarLayout,
   loadSidebarOpacity,
@@ -39,7 +39,7 @@ import {
   loadTranscriptZen,
   loadTranscriptAnchor,
   saveBodyGlass,
-  saveColorScheme,
+  saveThemePreference,
   saveSidebarBlur,
   saveSidebarLayout,
   saveSidebarOpacity,
@@ -62,7 +62,7 @@ import {
   THEME_SATURATION_DEFAULT,
   THEME_SATURATION_MAX,
   THEME_SATURATION_MIN,
-  type ColorScheme,
+  type ThemePreference,
   type SidebarLayout,
   type TranscriptLayout,
 } from "../lib/appearance";
@@ -669,17 +669,18 @@ function UpdateRow() {
 type AppearanceSettings = ReturnType<typeof useAppearanceSettings>;
 
 function useAppearanceSettings() {
-  const [colorScheme, setColorScheme] = useState<ColorScheme>(loadColorScheme);
+  const [themePreference, setThemePreference] =
+    useState<ThemePreference>(loadThemePreference);
   const [opacity, setOpacity] = useState(loadSidebarOpacity);
   const [blur, setBlur] = useState(loadSidebarBlur);
   const [themeHue, setThemeHue] = useState(loadThemeHue);
   const [themeSaturation, setThemeSaturation] = useState(loadThemeSaturation);
   const [bodyGlass, setBodyGlass] = useState(loadBodyGlass);
 
-  const onColorScheme = useCallback((next: ColorScheme) => {
-    applyColorScheme(next);
-    saveColorScheme(next);
-    setColorScheme(next);
+  const onThemePreference = useCallback((next: ThemePreference) => {
+    applyThemePreference(next);
+    saveThemePreference(next);
+    setThemePreference(next);
   }, []);
 
   const onOpacity = useCallback((percent: number) => {
@@ -709,21 +710,21 @@ function useAppearanceSettings() {
   }, []);
 
   const restoreDefaults = useCallback(() => {
-    onColorScheme(COLOR_SCHEME_DEFAULT);
+    onThemePreference(THEME_PREFERENCE_DEFAULT);
     onOpacity(Math.round(SIDEBAR_OPACITY_DEFAULT * 100));
     onBlur(SIDEBAR_BLUR_DEFAULT);
     onTint(THEME_HUE_DEFAULT, THEME_SATURATION_DEFAULT);
     onBodyGlass(BODY_GLASS_DEFAULT);
-  }, [onBlur, onBodyGlass, onColorScheme, onOpacity, onTint]);
+  }, [onBlur, onBodyGlass, onThemePreference, onOpacity, onTint]);
 
   return {
-    colorScheme,
+    themePreference,
     opacity,
     blur,
     themeHue,
     themeSaturation,
     bodyGlass,
-    onColorScheme,
+    onThemePreference,
     onOpacity,
     onBlur,
     onTint,
@@ -739,16 +740,17 @@ function AppearancePage({ appearance }: { appearance: AppearanceSettings }) {
     <>
       <Row
         label="Theme"
-        description="Dark and light share the same tint, so the hue below applies to both."
+        description="System follows the OS appearance. Dark and light share the same tint, so the hue below applies to both."
       >
         <Segmented
           label="Theme"
-          value={appearance.colorScheme}
+          value={appearance.themePreference}
           options={[
+            { value: "system", label: "System" },
             { value: "dark", label: "Dark" },
             { value: "light", label: "Light" },
           ]}
-          onChange={appearance.onColorScheme}
+          onChange={appearance.onThemePreference}
         />
       </Row>
       <Row


### PR DESCRIPTION
The theme picker only offered Dark and Light, so the app never followed the OS appearance. This adds a third choice, System, which resolves through `prefers-color-scheme` and keeps tracking it while the app is open.

- `ColorScheme` stays the resolved value (`dark` | `light`); a new `ThemePreference` adds `system` and is what gets stored and shown in Settings.
- `applyThemePreference()` resolves the preference before toggling `theme-light`, so every existing consumer of `SCHEME_CHANGE_EVENT` (transcript, terminal, editor, mermaid) keeps receiving a concrete scheme and needs no change.
- `watchSystemColorScheme()` re-applies on OS flips, but only while the preference is `system`.
- The pre-paint script in `index.html` resolves `system` the same way, so the boot splash does not flash the wrong scheme before the bundle loads.
- The stored key is unchanged, so existing `dark`/`light` values keep working; unknown values fall back to the default. Default stays Dark, so nobody's current appearance changes.

Tests cover persistence of all three values, unknown-value fallback, system resolution in both directions, and the no-`matchMedia` fallback.

`npm run check:web` passes.
