### PR TITLE
Drag the window from any empty spot in the header

### DIFF
--- a/src/chrome/ProjectRail.tsx
+++ b/src/chrome/ProjectRail.tsx
@@ -350,7 +350,7 @@ export function ProjectRail({
       className="sidebar-glass relative flex shrink-0 flex-col border-r border-content/10"
     >
       <div
-        className="flex h-10 shrink-0 items-center pr-1.5"
+        className="flex h-10 shrink-0 select-none items-center pr-1.5"
         data-tauri-drag-region="deep"
       >
         {IS_MAC ? <div className="w-[78px] shrink-0" /> : null}

--- a/src/chrome/ProjectRail.tsx
+++ b/src/chrome/ProjectRail.tsx
@@ -351,12 +351,10 @@ export function ProjectRail({
     >
       <div
         className="flex h-10 shrink-0 items-center pr-1.5"
-        data-tauri-drag-region
+        data-tauri-drag-region="deep"
       >
-        {IS_MAC ? (
-          <div className="w-[78px] shrink-0" data-tauri-drag-region />
-        ) : null}
-        <div className="min-w-0 flex-1" data-tauri-drag-region />
+        {IS_MAC ? <div className="w-[78px] shrink-0" /> : null}
+        <div className="min-w-0 flex-1" />
         <TabVisitNav
           canGoBack={canGoBack}
           canGoForward={canGoForward}

--- a/src/chrome/Sidebar.tsx
+++ b/src/chrome/Sidebar.tsx
@@ -566,7 +566,7 @@ function SidebarComponent({
       {deckLayout && railVisible ? (
         <>
           <div
-            className="flex h-10 shrink-0 items-center gap-1 border-b border-content/10 pl-3 pr-1.5"
+            className="flex h-10 shrink-0 select-none items-center gap-1 border-b border-content/10 pl-3 pr-1.5"
             data-tauri-drag-region="deep"
           >
             <span className="min-w-0 flex-1 truncate text-sm font-medium leading-tight">
@@ -586,7 +586,7 @@ function SidebarComponent({
         <>
           {deckLayout ? (
             <div
-              className="flex h-10 shrink-0 items-center border-b border-content/10 pr-1.5"
+              className="flex h-10 shrink-0 select-none items-center border-b border-content/10 pr-1.5"
               data-tauri-drag-region="deep"
             >
               {IS_MAC ? <div className="w-[78px] shrink-0" /> : null}
@@ -602,7 +602,7 @@ function SidebarComponent({
             </div>
           ) : (
             <div
-              className="flex h-9.75 shrink-0 items-center justify-end pr-1.5"
+              className="flex h-9.75 shrink-0 select-none items-center justify-end pr-1.5"
               data-tauri-drag-region="deep"
             >
               <TabVisitNav

--- a/src/chrome/Sidebar.tsx
+++ b/src/chrome/Sidebar.tsx
@@ -567,7 +567,7 @@ function SidebarComponent({
         <>
           <div
             className="flex h-10 shrink-0 items-center gap-1 border-b border-content/10 pl-3 pr-1.5"
-            data-tauri-drag-region
+            data-tauri-drag-region="deep"
           >
             <span className="min-w-0 flex-1 truncate text-sm font-medium leading-tight">
               Workspace
@@ -587,12 +587,10 @@ function SidebarComponent({
           {deckLayout ? (
             <div
               className="flex h-10 shrink-0 items-center border-b border-content/10 pr-1.5"
-              data-tauri-drag-region
+              data-tauri-drag-region="deep"
             >
-              {IS_MAC ? (
-                <div className="w-[78px] shrink-0" data-tauri-drag-region />
-              ) : null}
-              <div className="min-w-0 flex-1" data-tauri-drag-region />
+              {IS_MAC ? <div className="w-[78px] shrink-0" /> : null}
+              <div className="min-w-0 flex-1" />
               <TabVisitNav
                 canGoBack={canGoBack}
                 canGoForward={canGoForward}
@@ -605,7 +603,7 @@ function SidebarComponent({
           ) : (
             <div
               className="flex h-9.75 shrink-0 items-center justify-end pr-1.5"
-              data-tauri-drag-region
+              data-tauri-drag-region="deep"
             >
               <TabVisitNav
                 canGoBack={canGoBack}

--- a/src/chrome/TitleBar.tsx
+++ b/src/chrome/TitleBar.tsx
@@ -1220,7 +1220,7 @@ function TitleBarComponent({
   // exempts buttons, links and inputs on its own.
   return (
     <header
-      className="flex h-10 shrink-0 items-stretch border-b border-content/10"
+      className="flex h-10 shrink-0 select-none items-stretch border-b border-content/10"
       data-tauri-drag-region="deep"
     >
       {/* Both the rail and the sidebar step aside without a project, so the

--- a/src/chrome/TitleBar.tsx
+++ b/src/chrome/TitleBar.tsx
@@ -1106,17 +1106,6 @@ function TitleBarComponent({
     syncTabOverflow();
   }, [activeId, collapsedGroups, syncTabOverflow, tabs]);
 
-  const onTitleBarDoubleClick = useCallback((e: ReactMouseEvent) => {
-    if (
-      e.target instanceof HTMLElement &&
-      e.target.hasAttribute("data-tauri-drag-region")
-    ) {
-      try {
-        void getCurrentWindow().toggleMaximize();
-      } catch {}
-    }
-  }, []);
-
   const activeTab = useMemo(
     () => tabs.find((t) => t.id === activeId),
     [activeId, tabs],
@@ -1226,16 +1215,18 @@ function TitleBarComponent({
     </div>
   );
 
+  // "deep" drags from anywhere in the subtree. The bare attribute only drags
+  // on a direct hit, which left every label and spacer dead. Tauri still
+  // exempts buttons, links and inputs on its own.
   return (
     <header
       className="flex h-10 shrink-0 items-stretch border-b border-content/10"
-      data-tauri-drag-region
-      onDoubleClick={onTitleBarDoubleClick}
+      data-tauri-drag-region="deep"
     >
       {/* Both the rail and the sidebar step aside without a project, so the
           title bar takes over the traffic lights and the rail toggle. */}
       {(projectless && railClosed) || (!sidebarOpen && IS_MAC) ? (
-        <div className="w-[78px] shrink-0" data-tauri-drag-region />
+        <div className="w-[78px] shrink-0" />
       ) : null}
       {projectless && railClosed ? (
         <div className="flex shrink-0 items-center px-1.5">
@@ -1317,7 +1308,6 @@ function TitleBarComponent({
           className={`relative h-full min-w-0 overflow-hidden ${
             deckLayout ? "flex-1" : "shrink"
           }`}
-          data-tauri-drag-region="false"
           onWheel={(event) => {
             const el = tabStripRef.current;
             if (!el || el.scrollWidth <= el.clientWidth) return;
@@ -1520,15 +1510,9 @@ function TitleBarComponent({
         )}
 
         {deckLayout && IS_MAC ? null : (
-          <div
-            className="flex min-w-0 flex-1 items-center justify-center px-4"
-            data-tauri-drag-region
-          >
+          <div className="flex min-w-0 flex-1 items-center justify-center px-4">
             {!IS_MAC ? (
-              <span
-                className="pointer-events-none truncate text-[11.5px] font-medium text-content/40 select-none"
-                data-tauri-drag-region
-              >
+              <span className="pointer-events-none truncate text-[11.5px] font-medium text-content/40 select-none">
                 {systemTitle}
               </span>
             ) : null}

--- a/src/surfaces/InboxView.tsx
+++ b/src/surfaces/InboxView.tsx
@@ -606,16 +606,11 @@ export function InboxView({
       className="flex min-h-0 min-w-0 flex-1 flex-col text-content"
     >
       <div
-        className="flex h-10 shrink-0 items-center border-b border-content/10"
-        data-tauri-drag-region
+        className="flex h-10 shrink-0 select-none items-center border-b border-content/10"
+        data-tauri-drag-region="deep"
       >
-        {IS_MAC && !besideRail ? (
-          <div className="w-[78px] shrink-0" data-tauri-drag-region />
-        ) : null}
-        <div
-          className="flex min-w-0 flex-1 items-center gap-2 px-3 text-[13px]"
-          data-tauri-drag-region
-        >
+        {IS_MAC && !besideRail ? <div className="w-[78px] shrink-0" /> : null}
+        <div className="flex min-w-0 flex-1 items-center gap-2 px-3 text-[13px]">
           <Inbox
             className="size-3.5 shrink-0 text-content/45"
             strokeWidth={1.75}

--- a/src/surfaces/NotesView.tsx
+++ b/src/surfaces/NotesView.tsx
@@ -272,16 +272,11 @@ export function NotesView({ besideRail = false, cwd, onClose }: Props) {
       className="flex min-h-0 min-w-0 flex-1 flex-col text-content"
     >
       <div
-        className="flex h-10 shrink-0 items-center border-b border-content/10"
-        data-tauri-drag-region
+        className="flex h-10 shrink-0 select-none items-center border-b border-content/10"
+        data-tauri-drag-region="deep"
       >
-        {IS_MAC && !besideRail ? (
-          <div className="w-[78px] shrink-0" data-tauri-drag-region />
-        ) : null}
-        <div
-          className="flex min-w-0 flex-1 items-center gap-2 px-3 text-[13px]"
-          data-tauri-drag-region
-        >
+        {IS_MAC && !besideRail ? <div className="w-[78px] shrink-0" /> : null}
+        <div className="flex min-w-0 flex-1 items-center gap-2 px-3 text-[13px]">
           <File
             className="size-3.5 shrink-0 text-content/45"
             strokeWidth={1.75}

--- a/src/surfaces/SearchView.tsx
+++ b/src/surfaces/SearchView.tsx
@@ -317,12 +317,10 @@ export function SearchView({
       className="flex min-h-0 min-w-0 flex-1 flex-col text-content"
     >
       <div
-        className="flex h-10 shrink-0 items-center border-b border-content/10"
-        data-tauri-drag-region
+        className="flex h-10 shrink-0 select-none items-center border-b border-content/10"
+        data-tauri-drag-region="deep"
       >
-        {IS_MAC && !besideRail ? (
-          <div className="w-[78px] shrink-0" data-tauri-drag-region />
-        ) : null}
+        {IS_MAC && !besideRail ? <div className="w-[78px] shrink-0" /> : null}
         <label className="flex min-w-0 flex-1 items-center gap-2 px-3 text-content/50">
           <Search className="size-3.5 shrink-0" strokeWidth={1.75} />
           <input
@@ -337,7 +335,7 @@ export function SearchView({
             autoCorrect="off"
             autoCapitalize="off"
             data-tauri-drag-region="false"
-            className="min-w-0 flex-1 bg-transparent text-[13px] text-content outline-none placeholder:text-content/40"
+            className="min-w-0 flex-1 bg-transparent text-[13px] text-content outline-none select-text placeholder:text-content/40"
           />
           {loading ? (
             <LoaderCircle

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -190,16 +190,11 @@ export function SettingsView({
       className="flex min-h-0 min-w-0 flex-1 flex-col text-content"
     >
       <div
-        className="flex h-10 shrink-0 items-center border-b border-content/10"
-        data-tauri-drag-region
+        className="flex h-10 shrink-0 select-none items-center border-b border-content/10"
+        data-tauri-drag-region="deep"
       >
-        {IS_MAC && !besideRail ? (
-          <div className="w-[78px] shrink-0" data-tauri-drag-region />
-        ) : null}
-        <div
-          className="flex min-w-0 flex-1 items-center gap-2 px-3 text-[13px]"
-          data-tauri-drag-region
-        >
+        {IS_MAC && !besideRail ? <div className="w-[78px] shrink-0" /> : null}
+        <div className="flex min-w-0 flex-1 items-center gap-2 px-3 text-[13px]">
           <span className="shrink-0 text-content/45">Settings</span>
           <span aria-hidden className="shrink-0 text-content/25">
             /


### PR DESCRIPTION
Moving the window only worked from a few spots next to the window controls. With a project open the Workspace header — "Workspace" on the left, search and plus on the right, empty in between — could not be grabbed at all, and neither could the gaps in the tab strip.

The cause is the value of the attribute, not where it sits. Every header used the bare `data-tauri-drag-region`, and Tauri only starts a drag when the mousedown target *is* that element. The `Workspace` label is `flex-1`, so it covers the whole middle of that row: the area that looks empty is the label's own box, and it swallowed the gesture. The title bar's tab strip went further and set `data-tauri-drag-region="false"`, so its padding and the gaps between tabs never dragged either.

Tauri supports `"deep"`, which drags from anywhere in the subtree while still exempting buttons, links, inputs and anything marked `"false"`. That matches what a title bar should do, so every header row now uses it — the title bar, the sidebar, the project rail, and the inbox, notes, search and settings surfaces, which render their own title bar row and had the same dead spots on their icon and label.

- every gap, label and spacer in those rows drags the window
- the tab strip's gaps drag; tabs stay clickable and re-orderable, since Tauri exempts them as buttons
- the existing `data-tauri-drag-region="false"` opt-outs (pickers, window controls, drag handles, the search field) keep working untouched
- the per-child attributes on spacers and title spans are redundant under `"deep"` and were removed

The rows are also `select-none` now. Tauri's drag script skips `preventDefault` on a macOS double click, because it defers maximize to mouseup, and nothing then suppressed the browser's own word selection — double clicking the header highlighted the tab labels. The search field keeps `select-text`, since `select-none` on its row would otherwise reach into the input.

Also dropped the title bar's own double-click-to-maximize handler. Tauri's drag script already toggles maximize on a double click inside a drag region, so the local handler was a second toggle on the same gesture, and it keyed off the exact target, which no longer matches the area that now drags.

`npm run check:web` and `npm run build` pass. The drag itself needs a real window, so it wants a hands-on check on macOS, and on Windows/Linux for the double-click path.
