### PR TITLE
chore: Implement update check functionality in the sidebar and move t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Check for Updates lives in the app menu — next to Settings on macOS and in the File menu elsewhere — so you can check anytime; Settings → General has it too.
+
 ### Changed
 
 - Launch holds the logo until the restored workspace is ready, then fades to that first paint. The window stays up through the Dock bounce so the mark is visible instead of a blank or shifting chrome.

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -22,7 +22,7 @@ pub fn dispatch(app: &AppHandle, id: &str) {
         | "focus_down" | "toggle_sidebar" | "toggle_zen" | "sidebar_opacity" | "open_project"
         | "go_to_file" | "open_search" | "open_inbox" | "open_notes" | "find_in_project"
         | "find" | "new_terminal" | "new_terminal_tab" | "toggle_terminal"
-        | "open_model_picker" | "open_settings" => {
+        | "open_model_picker" | "open_settings" | "check_for_updates" => {
             let _ = app.emit(id, ());
         }
         _ => {}
@@ -34,6 +34,8 @@ fn build(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     let open_settings = MenuItemBuilder::with_id("open_settings", "Settings…")
         .accelerator("CmdOrCtrl+,")
         .build(app)?;
+    let check_for_updates =
+        MenuItemBuilder::with_id("check_for_updates", "Check for Updates…").build(app)?;
     let new_window = MenuItemBuilder::with_id("new_window", "New Window")
         .accelerator("CmdOrCtrl+Shift+N")
         .build(app)?;
@@ -171,6 +173,7 @@ fn build(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
             .about(Some(AboutMetadata::default()))
             .separator()
             .item(&open_settings)
+            .item(&check_for_updates)
             .separator()
             .hide()
             .hide_others()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
   type SidebarTabId,
 } from "./lib/appearance";
 import { IS_MAC } from "./lib/platform";
+import { runUpdateFlow } from "./lib/updater";
 import { displayAttachments, prepareAttachments } from "./lib/attachments";
 import { basename, notifyGitChanged, pickFolder, restoreSessionCheckout } from "./lib/fs";
 import {
@@ -4092,6 +4093,9 @@ export default function App({
       listen("open_inbox", () => actions.current.onOpenInbox()),
       listen("open_notes", () => actions.current.onOpenNotes()),
       listen("open_settings", () => actions.current.openSettings()),
+      listen("check_for_updates", () => {
+        void runUpdateFlow(true);
+      }),
       listen("sidebar_opacity", () => {
         actions.current.openSettings("appearance");
       }),

--- a/src/chrome/MenuBar.tsx
+++ b/src/chrome/MenuBar.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { ExplorerMenu, type ExplorerMenuItem } from "./ExplorerMenu";
 import { ALT, MOD, SHIFT } from "../lib/platform";
 import { toggleTranscriptZen } from "../lib/appearance";
+import { runUpdateFlow } from "../lib/updater";
 
 type MenuKey = "file" | "view" | "terminal";
 
@@ -142,6 +143,9 @@ export function MenuBar({
         case "toggle_diff":
           onShowSourceControl?.();
           break;
+        case "check_for_updates":
+          void runUpdateFlow(true);
+          break;
       }
     },
     [
@@ -175,6 +179,8 @@ export function MenuBar({
           { kind: "item", id: "find_in_project", label: "Find in Files…", shortcut: `${MOD}${SHIFT}F` },
           { kind: "sep" },
           { kind: "item", id: "close_tab", label: "Close Pane", shortcut: `${MOD}W` },
+          { kind: "sep" },
+          { kind: "item", id: "check_for_updates", label: "Check for Updates…" },
         ];
       case "view":
         return [


### PR DESCRIPTION
## What changed

Moving the permanent "Check for update" banner from side panel to menu. The banner appears in side panel when an update is actually available. The user can still force update check from the menu options.

## Why

Please refer to the tweet here: https://x.com/ayushporwalhq/status/2094340766789185900?s=20

## UI

<img width="1103" height="1440" alt="image" src="https://github.com/user-attachments/assets/561f829a-7746-4943-9028-acb4c7ac61dd" />

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes
