### PR TITLE
Show user friendly changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,19 @@ jobs:
             echo "Tag v$TAG does not match package.json ($PKG), Cargo.toml ($CARGO), or tauri.conf.json ($CONF)"
             exit 1
           fi
+          node - "$TAG" <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const version = process.argv[2];
+          const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+          const heading = new RegExp(
+            `^## \\[${escaped}\\](?: - \\d{4}-\\d{2}-\\d{2})?$`,
+            "m",
+          );
+          if (!heading.test(readFileSync("CHANGELOG.md", "utf8"))) {
+            console.error(`CHANGELOG.md has no valid release section for ${version}`);
+            process.exit(1);
+          }
+          NODE
 
       - name: Write release config
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- After an in-app update, MonoCode shows a notification with a **What's new** action. It opens the bundled notes in a read-only tab only when requested. The notes remain available under Settings → General → About.
 - Inbox pull request and issue details load the conversation (comments, reviews, and review threads) in the background, so the description still appears first.
 - Grok Build joins the provider list. Install it with `curl -fsSL https://x.ai/cli/install.sh | bash` and run `grok login` (or set `XAI_API_KEY`). MonoCode runs `grok agent stdio` like the other ACP harnesses: live turns, supervised approvals, model catalog, reasoning effort, context usage, skills from `.grok/skills`, and titles / commit / PR text.
 - Search sits next to Inbox and Notes in the sidebar project picker, with the same ⌘K / Ctrl+K hint.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { message } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { Sidebar } from "./chrome/Sidebar";
 import { ApprovalToasts } from "./chrome/ApprovalToasts";
+import { UpdateToast } from "./chrome/UpdateToast";
 import { TitleBar, type Tab as TitleTab } from "./chrome/TitleBar";
 import { MenuBar } from "./chrome/MenuBar";
 import { FilePicker } from "./chrome/FilePicker";
@@ -37,7 +39,7 @@ import {
   firstLeafId,
   focusedFileTab,
   isolateTerminalPanes,
-  isPlanTab,
+  isFilesystemTab,
   isTerminalTab,
   leaf,
   leafIds,
@@ -45,6 +47,7 @@ import {
   neighborLeafId,
   newFileTab,
   newPlanTab,
+  newReleaseNotesWorkspaceTab,
   newTab,
   newTerminalFile,
   newTerminalWorkspaceTab,
@@ -66,6 +69,14 @@ import {
   type SplitDir,
   type WorkspaceTab,
 } from "./lib/layout";
+import {
+  releaseNotesForVersion,
+  releaseNotesTitle,
+} from "./lib/releaseNotes";
+import {
+  focusReleaseNotesTarget,
+  planReleaseNotesOpen,
+} from "./lib/releaseNotesWorkspace";
 import { orderByIds } from "./lib/reorder";
 import {
   addTerminalToDock,
@@ -304,6 +315,7 @@ import {
   collectWorkspaceSnapshot,
   workspaceSnapshotKey,
 } from "./lib/workspaceSnapshot";
+import type { InstalledUpdate } from "./lib/updateNotice";
 import {
   bindResumedSessions,
   hasInFlightSessions,
@@ -410,9 +422,11 @@ function titleTabsEqual(a: TitleTab[], b: TitleTab[]): boolean {
 export default function App({
   windowTransfer = null,
   resumed = null,
+  installedUpdate = null,
 }: {
   windowTransfer?: WindowTransferPayload | null;
   resumed?: ResumedWorkspace | null;
+  installedUpdate?: InstalledUpdate | null;
 }) {
   const [projectCwd, setProjectCwd] = useState(
     () =>
@@ -494,6 +508,7 @@ export default function App({
     () => true,
   );
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [updateNotice, setUpdateNotice] = useState(installedUpdate);
   const [settingsSection, setSettingsSection] =
     useState<SettingsSectionId>(loadSettingsSection);
   const [editorNavigation, setEditorNavigation] =
@@ -1161,6 +1176,38 @@ export default function App({
     [projectOfTab],
   );
 
+  const onOpenWhatsNew = useCallback(
+    (version: string) => {
+      const document = releaseNotesForVersion(version);
+      if (!document) {
+        void message(
+          "Release notes for this version are not available in this build.",
+          { title: "MonoCode" },
+        );
+        return;
+      }
+
+      setFilePickerOpen(false);
+      setSearchViewOpen(false);
+      setInboxViewOpen(false);
+      setNotesViewOpen(false);
+      setSettingsOpen(false);
+
+      const plan = planReleaseNotesOpen(tabsRef.current, version);
+      if (plan.kind === "focus") {
+        setTabs((current) => focusReleaseNotesTarget(current, plan));
+        setActiveTabId(plan.tabId);
+      } else {
+        const tab = newReleaseNotesWorkspaceTab(document.source);
+        appendTab(tab);
+        setActiveTabId(tab.id);
+      }
+      setComposerFocused(false);
+      setUpdateNotice(null);
+    },
+    [appendTab],
+  );
+
   const onNew = useCallback(() => {
     setSearchViewOpen(false);
     setInboxViewOpen(false);
@@ -1649,7 +1696,9 @@ export default function App({
         ...closing.editorPanes.flatMap((pane) => pane.files),
         ...(closing.terminalPanes ?? []).flatMap((pane) => pane.files),
       ];
-      const unsaved = closingFiles.filter((file) => dirtyFiles.has(file.id));
+      const unsaved = closingFiles.filter(
+        (file) => isFilesystemTab(file) && dirtyFiles.has(file.id),
+      );
       if (
         unsaved.length > 0 &&
         !window.confirm("Close this tab with unsaved files?")
@@ -1824,8 +1873,7 @@ export default function App({
       if (index < 0) return;
       const file = pane.files[index];
       if (
-        !file.plan &&
-        !file.terminal &&
+        isFilesystemTab(file) &&
         dirtyFiles.has(fileId) &&
         !window.confirm(`Close ${basename(file.path)} without saving?`)
       ) {
@@ -1948,7 +1996,9 @@ export default function App({
         ...tab.editorPanes.flatMap((pane) => pane.files),
         ...(tab.terminalPanes ?? []).flatMap((pane) => pane.files),
       ];
-      const unsaved = closingFiles.filter((file) => dirtyFiles.has(file.id));
+      const unsaved = closingFiles.filter(
+        (file) => isFilesystemTab(file) && dirtyFiles.has(file.id),
+      );
       if (
         unsaved.length > 0 &&
         !window.confirm("Close this conversation with unsaved files?")
@@ -2951,12 +3001,9 @@ export default function App({
           editorPanes: tab.editorPanes.map((pane) => ({
             ...pane,
             files: pane.files.map((file) =>
-              file.plan || file.terminal
-                ? file
-                : {
-                    ...file,
-                    path: rebasePath(file.path, from, to),
-                  },
+              isFilesystemTab(file)
+                ? { ...file, path: rebasePath(file.path, from, to) }
+                : file,
             ),
           })),
         };
@@ -2970,7 +3017,9 @@ export default function App({
     for (const tab of tabsRef.current) {
       for (const pane of tab.editorPanes) {
         for (const file of pane.files) {
-          if (isEqualOrInside(file.path, path)) dropped.add(file.id);
+          if (isFilesystemTab(file) && isEqualOrInside(file.path, path)) {
+            dropped.add(file.id);
+          }
         }
       }
     }
@@ -3896,7 +3945,7 @@ export default function App({
     for (const tab of tabs) {
       for (const pane of tab.editorPanes) {
         for (const file of pane.files) {
-          if (file.plan || file.terminal || seen.has(file.path)) continue;
+          if (!isFilesystemTab(file) || seen.has(file.path)) continue;
           seen.add(file.path);
           paths.push(file.path);
         }
@@ -4493,6 +4542,7 @@ export default function App({
             onDeleteProject={(path) =>
               onRemoveProject(path, { purgeData: true })
             }
+            onOpenWhatsNew={onOpenWhatsNew}
           />
         ) : null}
         {searchViewOpen || inboxViewOpen || notesViewOpen || settingsOpen ? null : (
@@ -4521,6 +4571,11 @@ export default function App({
         onFocusSession={onOpenApprovalSession}
         onApproval={onApproval}
       />
+      <UpdateToast
+        update={updateNotice}
+        onOpen={onOpenWhatsNew}
+        onDismiss={() => setUpdateNotice(null)}
+      />
     </div>
   );
 }
@@ -4547,8 +4602,7 @@ function selectedChangePath(
   gitCwd?: string,
 ): string | undefined {
   const file = focusedFileTab(tab);
-  if (!file || isPlanTab(file) || isTerminalTab(file) || !file.review)
-    return undefined;
+  if (!file || !isFilesystemTab(file) || !file.review) return undefined;
   return displayPath(file.path, gitCwd || file.cwd);
 }
 
@@ -4609,12 +4663,18 @@ function toTitleTab(
       ? `terminal:${file.id}`
       : file.plan
         ? `plan:${file.plan.blockId}`
-        : file.path;
+        : file.releaseNotes
+          ? `release-notes:${file.releaseNotes.version}`
+          : file.path;
     if (seenKeys.has(key)) return;
     seenKeys.add(key);
     files.push(
       file.plan?.title?.trim() ||
-        (file.terminal ? terminalTabLabel(file) : basename(file.path)),
+        (file.releaseNotes
+          ? releaseNotesTitle(file.releaseNotes.version)
+          : file.terminal
+            ? terminalTabLabel(file)
+            : basename(file.path)),
     );
   };
   const focusedPane =
@@ -4659,7 +4719,9 @@ function toTitleTab(
     multiPane,
     fileFocused,
     dirty: tab.editorPanes.some((pane) =>
-      pane.files.some((file) => dirtyFiles.has(file.id)),
+      pane.files.some(
+        (file) => isFilesystemTab(file) && dirtyFiles.has(file.id),
+      ),
     ),
     terminal: hasTerminal && harnesses.length === 0,
     groupId: tab.groupId,
@@ -4674,7 +4736,9 @@ function dropOpenFiles(
   let focusedId = tab.focusedId;
   const editorPanes: EditorPane[] = [];
   for (const pane of tab.editorPanes) {
-    const files = pane.files.filter((file) => !shouldDrop(file.path));
+    const files = pane.files.filter(
+      (file) => !isFilesystemTab(file) || !shouldDrop(file.path),
+    );
     if (files.length === 0) {
       const sibling = siblingLeafId(layout, pane.id);
       const withoutPane = removePane(layout, pane.id);

--- a/src/chrome/SurfaceTabs.test.ts
+++ b/src/chrome/SurfaceTabs.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { appendProblems } from "./SurfaceTabs";
+import { newReleaseNotesWorkspaceTab } from "../lib/layout";
+import { releaseNotesTitle } from "../lib/releaseNotes";
+import { appendProblems, surfaceTabPresentation } from "./SurfaceTabs";
+
+describe("surfaceTabPresentation", () => {
+  it("labels release notes from their version", () => {
+    const file = newReleaseNotesWorkspaceTab({ version: "0.1.23" })
+      .editorPanes[0]?.files[0];
+    if (!file) throw new Error("expected release-note file");
+
+    expect(surfaceTabPresentation(file)).toEqual({
+      name: releaseNotesTitle("0.1.23"),
+      label: releaseNotesTitle("0.1.23"),
+      iconName: "CHANGELOG.md",
+      tooltip: releaseNotesTitle("0.1.23"),
+    });
+  });
+});
 
 describe("appendProblems", () => {
   it("leaves a clean file's tooltip alone", () => {

--- a/src/chrome/SurfaceTabs.tsx
+++ b/src/chrome/SurfaceTabs.tsx
@@ -2,7 +2,14 @@ import { GripVertical, Terminal, X } from "./icons";
 import type { PointerEvent as ReactPointerEvent, ReactNode } from "react";
 import { useLayoutEffect, useRef } from "react";
 import { basename } from "../lib/fs";
-import { isPlanTab, isReviewTab, isTerminalTab, type FilePaneTab } from "../lib/layout";
+import {
+  isPlanTab,
+  isReleaseNotesTab,
+  isReviewTab,
+  isTerminalTab,
+  type FilePaneTab,
+} from "../lib/layout";
+import { releaseNotesTitle } from "../lib/releaseNotes";
 import { terminalTabLabel } from "../lib/terminalTab";
 import { useLockOverscroll } from "../hooks/useLockOverscroll";
 import { useSortable } from "../hooks/useSortable";
@@ -20,6 +27,47 @@ type Props = {
   label?: string;
   trailing?: ReactNode;
 };
+
+export type SurfaceTabPresentation = {
+  name: string;
+  label: string;
+  iconName: string;
+  tooltip: string;
+};
+
+export function surfaceTabPresentation(
+  file: FilePaneTab,
+): SurfaceTabPresentation {
+  if (isReleaseNotesTab(file)) {
+    const title = releaseNotesTitle(file.releaseNotes.version);
+    return {
+      name: title,
+      label: title,
+      iconName: "CHANGELOG.md",
+      tooltip: title,
+    };
+  }
+
+  const review = isReviewTab(file);
+  const terminal = isTerminalTab(file);
+  const name = isPlanTab(file)
+    ? file.plan.title.trim() || "Plan"
+    : terminal
+      ? terminalTabLabel(file)
+      : basename(file.path);
+  return {
+    name,
+    label: review ? `${name} (Working Tree)` : name,
+    iconName: isPlanTab(file) ? "plan.md" : name,
+    tooltip: isPlanTab(file)
+      ? name
+      : terminal
+        ? `${name} — ${file.cwd}`
+        : review
+          ? `${file.path} (Working Tree)`
+          : file.path,
+  };
+}
 
 /** Mirrors the VS Code tab tooltip: the path, then what is wrong with it. */
 export function appendProblems(title: string, errors: number): string {
@@ -84,13 +132,7 @@ export function SurfaceTabs({
         const errors = fileErrorCounts.get(file.id) ?? 0;
         const review = isReviewTab(file);
         const terminal = isTerminalTab(file);
-        const name = isPlanTab(file)
-          ? file.plan?.title?.trim() || "Plan"
-          : terminal
-            ? terminalTabLabel(file)
-            : basename(file.path);
-        const label = review ? `${name} (Working Tree)` : name;
-        const iconName = isPlanTab(file) ? "plan.md" : name;
+        const { label, iconName, tooltip } = surfaceTabPresentation(file);
         const dragging = sortable.draggingId === file.id;
         const showStart =
           sortable.draggingId &&
@@ -135,16 +177,7 @@ export function SurfaceTabs({
               type="button"
               role="tab"
               aria-selected={active}
-              title={appendProblems(
-                isPlanTab(file)
-                  ? name
-                  : terminal
-                    ? `${name} — ${file.cwd}`
-                    : review
-                      ? `${file.path} (Working Tree)`
-                      : file.path,
-                errors,
-              )}
+              title={appendProblems(tooltip, errors)}
               onClick={() => {
                 if (sortable.consumeClick()) return;
                 onSelectFile(file.id);

--- a/src/chrome/UpdateToast.test.ts
+++ b/src/chrome/UpdateToast.test.ts
@@ -1,0 +1,21 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { UpdateToastCard } from "./UpdateToast";
+
+describe("UpdateToastCard", () => {
+  it("announces the update and names both actions", () => {
+    const markup = renderToStaticMarkup(
+      createElement(UpdateToastCard, {
+        update: { version: "0.1.23" },
+        onOpen: vi.fn(),
+        onDismiss: vi.fn(),
+      }),
+    );
+
+    expect(markup).toContain('role="status"');
+    expect(markup).toContain("MonoCode updated to 0.1.23");
+    expect(markup).toContain("What&#x27;s new");
+    expect(markup).toContain('aria-label="Dismiss update notification"');
+  });
+});

--- a/src/chrome/UpdateToast.tsx
+++ b/src/chrome/UpdateToast.tsx
@@ -1,0 +1,49 @@
+import { createPortal } from "react-dom";
+import type { InstalledUpdate } from "../lib/updateNotice";
+import { X } from "./icons";
+
+type Props = {
+  update: InstalledUpdate | null;
+  onOpen: (version: string) => void;
+  onDismiss: () => void;
+};
+
+export function UpdateToastCard({ update, onOpen, onDismiss }: Props) {
+  if (!update) return null;
+
+  return (
+    <section
+      role="status"
+      className="pointer-events-auto flex w-80 items-center gap-3 rounded-xl border border-content/15 bg-content/10 px-3 py-2.5 text-content shadow-xl backdrop-blur-xl"
+    >
+      <p className="min-w-0 flex-1 text-[13px] font-medium">
+        MonoCode updated to {update.version}
+      </p>
+      <button
+        type="button"
+        onClick={() => onOpen(update.version)}
+        className="min-h-6 shrink-0 rounded-md px-2 text-[12px] font-medium text-accent hover:bg-content/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      >
+        What's new
+      </button>
+      <button
+        type="button"
+        aria-label="Dismiss update notification"
+        onClick={onDismiss}
+        className="grid size-6 shrink-0 place-items-center rounded-md text-content/55 hover:bg-content/8 hover:text-content focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      >
+        <X className="size-3.5" strokeWidth={1.75} />
+      </button>
+    </section>
+  );
+}
+
+export function UpdateToast(props: Props) {
+  if (!props.update) return null;
+  return createPortal(
+    <div className="pointer-events-none fixed bottom-12 right-4 z-50">
+      <UpdateToastCard {...props} />
+    </div>,
+    document.body,
+  );
+}

--- a/src/lib/layout.test.ts
+++ b/src/lib/layout.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it } from "vitest";
 import {
   closeLeaf,
   editorTabKey,
+  isFilesystemTab,
+  isReleaseNotesTab,
+  isReviewTab,
   isTerminalTab,
   layoutLeaves,
   layoutSashes,
   leaf,
   newFileTab,
   newPlanTab,
+  newReleaseNotesWorkspaceTab,
   newTab,
   newTerminalFile,
   newTerminalWorkspaceTab,
@@ -89,6 +93,31 @@ describe("editorTabKey", () => {
   });
 });
 
+describe("newReleaseNotesWorkspaceTab", () => {
+  it("creates a projectless editor-only workspace tab", () => {
+    const tab = newReleaseNotesWorkspaceTab({ version: "0.1.23" });
+    const file = tab.editorPanes[0]?.files[0];
+
+    expect(file && isReleaseNotesTab(file)).toBe(true);
+    expect(file && editorTabKey(file)).toBe("release-notes:0.1.23");
+    expect(file && isReviewTab(file)).toBe(false);
+    expect(file && isFilesystemTab(file)).toBe(false);
+    expect(tab.terminalPanes).toEqual([]);
+    expect(layoutLeaves(tab.layout).map((pane) => pane.id)).toEqual([
+      tab.editorPanes[0]?.id,
+    ]);
+    expect(tab.focusedId).toBe(tab.editorPanes[0]?.id);
+  });
+
+  it("deduplicates release files by version", () => {
+    const first = newReleaseNotesWorkspaceTab({ version: "0.1.23" })
+      .editorPanes[0]!.files[0]!;
+    const second = newReleaseNotesWorkspaceTab({ version: "0.1.23" })
+      .editorPanes[0]!.files[0]!;
+    expect(editorTabKey(first)).toBe(editorTabKey(second));
+  });
+});
+
 describe("openTerminalTab", () => {
   it("occupies a session pane instead of splitting a leftover chat", () => {
     const tab = newTab("session-a");
@@ -124,7 +153,10 @@ describe("openTerminalTab", () => {
     );
     const first = newTerminalFile("/repo");
     const withTerminal = openTerminalTab(withFile, first);
-    const extra = newTerminalFile("/repo", nextTerminalTitle(withTerminal, "/repo"));
+    const extra = newTerminalFile(
+      "/repo",
+      nextTerminalTitle(withTerminal, "/repo"),
+    );
     const next = openTerminalTab(withTerminal, extra);
     expect(next.editorPanes).toHaveLength(1);
     expect(next.editorPanes[0]?.files.map((file) => file.path)).toEqual([
@@ -176,10 +208,7 @@ describe("openEditorTab", () => {
       newTab("session-a"),
       newTerminalFile("/repo"),
     );
-    const next = openEditorTab(
-      terminal,
-      newFileTab("/repo/App.tsx", "/repo"),
-    );
+    const next = openEditorTab(terminal, newFileTab("/repo/App.tsx", "/repo"));
     expect(next.terminalPanes[0]?.files.every(isTerminalTab)).toBe(true);
     expect(next.editorPanes[0]?.files.map((file) => file.path)).toEqual([
       "/repo/App.tsx",

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -1,3 +1,4 @@
+import type { ReleaseNotesTabSource } from "./releaseNotes";
 import {
   applyTerminalMeta,
   defaultTerminalTitle,
@@ -39,6 +40,7 @@ export type FilePaneTab = {
   path: string;
   cwd: string;
   plan?: PlanTabSource;
+  releaseNotes?: ReleaseNotesTabSource;
   review?: boolean;
   terminal?: boolean;
   /** Foreground command when it isn't the shell. Live only — not persisted. */
@@ -107,6 +109,26 @@ export function newPlanTab(
     path: `plan:${blockId}`,
     cwd,
     plan: { sessionId, blockId, title },
+  };
+}
+
+export function newReleaseNotesWorkspaceTab(
+  releaseNotes: ReleaseNotesTabSource,
+): WorkspaceTab {
+  const file: FilePaneTab = {
+    id: crypto.randomUUID(),
+    path: `release-notes:${releaseNotes.version}`,
+    cwd: "~",
+    releaseNotes,
+  };
+  const pane = newEditorPane(file);
+  return {
+    kind: "session",
+    id: crypto.randomUUID(),
+    layout: leaf(pane.id),
+    focusedId: pane.id,
+    editorPanes: [pane],
+    terminalPanes: [],
   };
 }
 
@@ -206,8 +228,22 @@ export function isPlanTab(
   return !!file.plan;
 }
 
+export function isReleaseNotesTab(
+  file: FilePaneTab,
+): file is FilePaneTab & { releaseNotes: ReleaseNotesTabSource } {
+  return !!file.releaseNotes;
+}
+
 export function isTerminalTab(file: FilePaneTab): boolean {
   return !!file.terminal;
+}
+
+export function isVirtualDocumentTab(file: FilePaneTab): boolean {
+  return isPlanTab(file) || isReleaseNotesTab(file);
+}
+
+export function isFilesystemTab(file: FilePaneTab): boolean {
+  return !isTerminalTab(file) && !isVirtualDocumentTab(file);
 }
 
 export function focusedFileTab(tab: WorkspaceTab): FilePaneTab | undefined {
@@ -220,9 +256,7 @@ export function focusedFileTab(tab: WorkspaceTab): FilePaneTab | undefined {
 /** Move terminal tabs out of file panes so the two never share a tab strip. */
 export function isolateTerminalPanes(tab: WorkspaceTab): WorkspaceTab {
   const existingTerminals = tab.terminalPanes ?? [];
-  const mixed = tab.editorPanes.some((pane) =>
-    pane.files.some(isTerminalTab),
-  );
+  const mixed = tab.editorPanes.some((pane) => pane.files.some(isTerminalTab));
   if (!mixed && tab.terminalPanes) return tab;
 
   let layout = tab.layout;
@@ -265,12 +299,13 @@ export function isolateTerminalPanes(tab: WorkspaceTab): WorkspaceTab {
 }
 
 export function isReviewTab(file: FilePaneTab): boolean {
-  return !!file.review && !file.plan;
+  return !!file.review && !isVirtualDocumentTab(file);
 }
 
 export function editorTabKey(file: FilePaneTab): string {
   if (file.terminal) return `terminal:${file.id}`;
   if (file.plan) return `plan:${file.plan.blockId}`;
+  if (file.releaseNotes) return `release-notes:${file.releaseNotes.version}`;
   return file.review ? `review:${file.path}` : `file:${file.path}`;
 }
 

--- a/src/lib/releaseNotes.test.ts
+++ b/src/lib/releaseNotes.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  releaseNotesForVersion,
+  releaseNotesMarkdown,
+  releaseNotesTitle,
+} from "./releaseNotes";
+
+const fixture = `# Changelog
+
+## [Unreleased]
+
+### Added
+- Future work.
+
+## [0.1.3] - 2026-09-01
+
+### Fixed
+- Newer fix.
+
+## [0.1.2] - 2026-08-31
+
+### Added
+- Requested feature.
+
+## [0.1.1]
+
+### Fixed
+- Older fix.
+`;
+
+describe("releaseNotesForVersion", () => {
+  it("extracts only the requested release", () => {
+    const release = releaseNotesForVersion("0.1.2", fixture);
+
+    expect(release?.source).toEqual({ version: "0.1.2" });
+    expect(releaseNotesTitle(release!.source.version)).toBe(
+      "What's new in MonoCode 0.1.2",
+    );
+    expect(release?.markdown).toContain("## [0.1.2]");
+    expect(release?.markdown).not.toContain("## [0.1.3]");
+    expect(release?.markdown).not.toContain("## [0.1.1]");
+  });
+
+  it.each(["", "   ", "Unreleased", "9.9.9"])(
+    "returns null for unavailable version %j",
+    (version) => {
+      expect(releaseNotesForVersion(version, fixture)).toBeNull();
+    },
+  );
+
+  it("requires the heading to occupy the complete line", () => {
+    const malformed = `## Prefix [0.1.2]\nNo.\n\n## [0.1.2] soon\nStill no.`;
+    expect(releaseNotesForVersion("0.1.2", malformed)).toBeNull();
+  });
+
+  it.each(["## [0.1.2]\n\nUndated.", "## [0.1.2] - 2026-08-31\n\nDated."])(
+    "accepts supported heading %j",
+    (changelog) => {
+      expect(releaseNotesForVersion("0.1.2", changelog)?.markdown).toBe(
+        changelog,
+      );
+    },
+  );
+
+  it("extracts the final release through the end of the changelog", () => {
+    const release = releaseNotesForVersion("0.1.1", fixture);
+    expect(release?.markdown).toContain("Older fix.");
+  });
+
+  it("escapes the requested version before matching", () => {
+    expect(
+      releaseNotesForVersion("0.1.2+test", "## [0.1.2+test]\n\nExact."),
+    ).toEqual({
+      source: { version: "0.1.2+test" },
+      markdown: "## [0.1.2+test]\n\nExact.",
+    });
+  });
+});
+
+describe("releaseNotesMarkdown", () => {
+  it("resolves a stored source against the bundled changelog shape", () => {
+    const release = releaseNotesForVersion("0.1.2", fixture);
+    expect(releaseNotesMarkdown(release!.source, fixture)).toBe(
+      release?.markdown,
+    );
+  });
+});

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -1,0 +1,47 @@
+import bundledChangelog from "../../CHANGELOG.md?raw";
+
+export type ReleaseNotesTabSource = {
+  version: string;
+};
+
+export type ReleaseNotesDocument = {
+  source: ReleaseNotesTabSource;
+  markdown: string;
+};
+
+export function releaseNotesTitle(version: string): string {
+  return `What's new in MonoCode ${version}`;
+}
+
+export function releaseNotesForVersion(
+  version: string,
+  changelog: string = bundledChangelog,
+): ReleaseNotesDocument | null {
+  const normalized = version.trim();
+  if (!normalized || normalized === "Unreleased") return null;
+
+  const escapedVersion = normalized.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const heading = new RegExp(
+    `^## \\[${escapedVersion}\\](?: - \\d{4}-\\d{2}-\\d{2})?\\r?$`,
+    "gm",
+  );
+  const match = heading.exec(changelog);
+  if (!match) return null;
+
+  const nextHeading = /^## /gm;
+  nextHeading.lastIndex = match.index + match[0].length;
+  const next = nextHeading.exec(changelog);
+  const markdown = changelog.slice(match.index, next?.index).trimEnd();
+
+  return {
+    source: { version: normalized },
+    markdown,
+  };
+}
+
+export function releaseNotesMarkdown(
+  source: ReleaseNotesTabSource,
+  changelog: string = bundledChangelog,
+): string | null {
+  return releaseNotesForVersion(source.version, changelog)?.markdown ?? null;
+}

--- a/src/lib/releaseNotesWorkspace.test.ts
+++ b/src/lib/releaseNotesWorkspace.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  leaf,
+  newEditorPane,
+  newFileTab,
+  newReleaseNotesWorkspaceTab,
+  newTab,
+  splitPane,
+  type WorkspaceTab,
+} from "./layout";
+import {
+  focusReleaseNotesTarget,
+  planReleaseNotesOpen,
+} from "./releaseNotesWorkspace";
+
+function tabWithHiddenRelease(): WorkspaceTab {
+  const tab = newReleaseNotesWorkspaceTab({ version: "0.1.23" });
+  const releasePane = tab.editorPanes[0];
+  if (!releasePane) throw new Error("expected release pane");
+  const activeFile = newFileTab("/repo/App.tsx", "/repo");
+  const otherPane = newEditorPane(newFileTab("/repo/Other.tsx", "/repo"));
+  return {
+    ...tab,
+    layout: splitPane(
+      leaf(releasePane.id),
+      releasePane.id,
+      "right",
+      otherPane.id,
+    ),
+    focusedId: otherPane.id,
+    editorPanes: [
+      {
+        ...releasePane,
+        files: [...releasePane.files, activeFile],
+        activeFileId: activeFile.id,
+      },
+      otherPane,
+    ],
+  };
+}
+
+describe("planReleaseNotesOpen", () => {
+  it("opens when the release is missing", () => {
+    expect(planReleaseNotesOpen([newTab("session-a")], "0.1.23")).toEqual({
+      kind: "open",
+    });
+  });
+
+  it("identifies the exact release tab, pane, and file", () => {
+    const tab = tabWithHiddenRelease();
+    const releasePane = tab.editorPanes[0]!;
+    const releaseFile = releasePane.files[0]!;
+
+    expect(planReleaseNotesOpen([tab], "0.1.23")).toEqual({
+      kind: "focus",
+      tabId: tab.id,
+      paneId: releasePane.id,
+      fileId: releaseFile.id,
+    });
+  });
+});
+
+describe("focusReleaseNotesTarget", () => {
+  it("reveals an existing release without adding a duplicate", () => {
+    const tab = tabWithHiddenRelease();
+    const target = planReleaseNotesOpen([tab], "0.1.23");
+    if (target.kind !== "focus") throw new Error("expected focus plan");
+
+    const result = focusReleaseNotesTarget([tab], target);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.focusedId).toBe(target.paneId);
+    expect(result[0]?.editorPanes[0]?.activeFileId).toBe(target.fileId);
+    expect(
+      result[0]?.editorPanes
+        .flatMap((pane) => pane.files)
+        .filter((file) => file.releaseNotes?.version === "0.1.23"),
+    ).toHaveLength(1);
+  });
+});

--- a/src/lib/releaseNotesWorkspace.ts
+++ b/src/lib/releaseNotesWorkspace.ts
@@ -1,0 +1,55 @@
+import { isReleaseNotesTab, type WorkspaceTab } from "./layout";
+
+export type ReleaseNotesOpenPlan =
+  | { kind: "open" }
+  | {
+      kind: "focus";
+      tabId: string;
+      paneId: string;
+      fileId: string;
+    };
+
+type ReleaseNotesFocusTarget = Extract<ReleaseNotesOpenPlan, { kind: "focus" }>;
+
+export function planReleaseNotesOpen(
+  tabs: WorkspaceTab[],
+  version: string,
+): ReleaseNotesOpenPlan {
+  for (const tab of tabs) {
+    for (const pane of tab.editorPanes) {
+      const file = pane.files.find(
+        (entry) =>
+          isReleaseNotesTab(entry) && entry.releaseNotes.version === version,
+      );
+      if (file) {
+        return {
+          kind: "focus",
+          tabId: tab.id,
+          paneId: pane.id,
+          fileId: file.id,
+        };
+      }
+    }
+  }
+  return { kind: "open" };
+}
+
+export function focusReleaseNotesTarget(
+  tabs: WorkspaceTab[],
+  target: ReleaseNotesFocusTarget,
+): WorkspaceTab[] {
+  return tabs.map((tab) =>
+    tab.id === target.tabId
+      ? {
+          ...tab,
+          focusedId: target.paneId,
+          diffFocused: false,
+          editorPanes: tab.editorPanes.map((pane) =>
+            pane.id === target.paneId
+              ? { ...pane, activeFileId: target.fileId }
+              : pane,
+          ),
+        }
+      : tab,
+  );
+}

--- a/src/lib/updateNotice.test.ts
+++ b/src/lib/updateNotice.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  consumeInstalledUpdate,
+  rememberInstalledUpdate,
+  type UpdateNoticeStore,
+} from "./updateNotice";
+
+function memoryStore(): UpdateNoticeStore {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => void values.delete(key),
+  };
+}
+
+describe("installed update marker", () => {
+  it("is consumed once", () => {
+    const store = memoryStore();
+    rememberInstalledUpdate("0.1.23", store);
+    expect(consumeInstalledUpdate(store)).toEqual({ version: "0.1.23" });
+    expect(consumeInstalledUpdate(store)).toBeNull();
+  });
+
+  it.each(["", "   "])("does not store blank version %j", (version) => {
+    const store = memoryStore();
+    rememberInstalledUpdate(version, store);
+    expect(consumeInstalledUpdate(store)).toBeNull();
+  });
+
+  it.each(["not json", "{}", '{"version":3}', '{"version":""}'])(
+    "removes malformed marker %j",
+    (value) => {
+      const store = memoryStore();
+      store.setItem("monocode.installedUpdate", value);
+      expect(consumeInstalledUpdate(store)).toBeNull();
+      expect(store.getItem("monocode.installedUpdate")).toBeNull();
+    },
+  );
+
+  it("treats missing storage as no marker", () => {
+    expect(consumeInstalledUpdate(memoryStore())).toBeNull();
+  });
+
+  it.each(["getItem", "setItem", "removeItem"] as const)(
+    "contains %s storage errors",
+    (method) => {
+      const store = memoryStore();
+      store[method] = () => {
+        throw new Error("storage unavailable");
+      };
+      expect(() => rememberInstalledUpdate("0.1.23", store)).not.toThrow();
+      expect(() => consumeInstalledUpdate(store)).not.toThrow();
+    },
+  );
+});

--- a/src/lib/updateNotice.ts
+++ b/src/lib/updateNotice.ts
@@ -1,0 +1,48 @@
+const INSTALLED_UPDATE_KEY = "monocode.installedUpdate";
+
+export type UpdateNoticeStore = Pick<
+  Storage,
+  "getItem" | "setItem" | "removeItem"
+>;
+
+export type InstalledUpdate = {
+  version: string;
+};
+
+export function rememberInstalledUpdate(
+  version: string,
+  store?: UpdateNoticeStore,
+): void {
+  const normalized = version.trim();
+  if (!normalized) return;
+  try {
+    const target = store ?? window.localStorage;
+    target.setItem(
+      INSTALLED_UPDATE_KEY,
+      JSON.stringify({ version: normalized }),
+    );
+  } catch {
+    return;
+  }
+}
+
+export function consumeInstalledUpdate(
+  store?: UpdateNoticeStore,
+): InstalledUpdate | null {
+  try {
+    const target = store ?? window.localStorage;
+    const stored = target.getItem(INSTALLED_UPDATE_KEY);
+    if (stored == null) return null;
+    target.removeItem(INSTALLED_UPDATE_KEY);
+    return parseInstalledUpdate(JSON.parse(stored));
+  } catch {
+    return null;
+  }
+}
+
+function parseInstalledUpdate(raw: unknown): InstalledUpdate | null {
+  if (!raw || typeof raw !== "object") return null;
+  const version = (raw as Record<string, unknown>).version;
+  if (typeof version !== "string" || !version.trim()) return null;
+  return { version: version.trim() };
+}

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  announce: vi.fn(),
+  check: vi.fn(),
+  downloadAndInstall: vi.fn(),
+  getVersion: vi.fn(),
+  message: vi.fn(),
+  relaunch: vi.fn(),
+  remember: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/app", () => ({ getVersion: mocks.getVersion }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  ask: vi.fn(),
+  message: mocks.message,
+}));
+vi.mock("@tauri-apps/plugin-process", () => ({ relaunch: mocks.relaunch }));
+vi.mock("@tauri-apps/plugin-updater", () => ({ check: mocks.check }));
+vi.mock("./sounds", () => ({ announceUpdateAvailable: mocks.announce }));
+vi.mock("./updateNotice", () => ({ rememberInstalledUpdate: mocks.remember }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  mocks.getVersion.mockResolvedValue("0.1.22");
+  mocks.relaunch.mockResolvedValue(undefined);
+  mocks.message.mockResolvedValue(undefined);
+});
+
+async function updaterWithPendingUpdate() {
+  const update = {
+    version: "0.1.23",
+    downloadAndInstall: mocks.downloadAndInstall,
+  };
+  mocks.check.mockResolvedValue(update);
+  const updater = await import("./updater");
+  await updater.probeForUpdate();
+  return updater;
+}
+
+describe("installPendingUpdate", () => {
+  it("records a successful installation before relaunching", async () => {
+    mocks.downloadAndInstall.mockResolvedValue(undefined);
+    const updater = await updaterWithPendingUpdate();
+
+    await updater.installPendingUpdate();
+
+    expect(mocks.remember).toHaveBeenCalledWith("0.1.23");
+    expect(mocks.relaunch).toHaveBeenCalledOnce();
+    expect(mocks.remember.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.relaunch.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("does not record or relaunch after installation fails", async () => {
+    mocks.downloadAndInstall.mockRejectedValue(new Error("install failed"));
+    const updater = await updaterWithPendingUpdate();
+
+    const result = await updater.installPendingUpdate();
+
+    expect(result.phase).toBe("error");
+    expect(mocks.remember).not.toHaveBeenCalled();
+    expect(mocks.relaunch).not.toHaveBeenCalled();
+  });
+
+  it("does not record when no update is pending", async () => {
+    const updater = await import("./updater");
+
+    expect((await updater.installPendingUpdate()).phase).toBe("idle");
+    expect(mocks.remember).not.toHaveBeenCalled();
+    expect(mocks.relaunch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -3,6 +3,7 @@ import { ask, message } from "@tauri-apps/plugin-dialog";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type DownloadEvent, type Update } from "@tauri-apps/plugin-updater";
 import { announceUpdateAvailable } from "./sounds";
+import { rememberInstalledUpdate } from "./updateNotice";
 
 export type UpdaterPhase =
   | "idle"
@@ -152,6 +153,7 @@ export async function installPendingUpdate(
       });
     });
 
+    rememberInstalledUpdate(update.version);
     pendingUpdate = null;
     await relaunch();
     return {

--- a/src/lib/workspaceSnapshot.test.ts
+++ b/src/lib/workspaceSnapshot.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { INTERRUPT_MESSAGE } from "./inFlight";
-import { leaf, newFileTab, newTab, newTerminalFile } from "./layout";
+import {
+  leaf,
+  newFileTab,
+  newReleaseNotesWorkspaceTab,
+  newTab,
+  newTerminalFile,
+} from "./layout";
 import { createProjectTerminal } from "./projectTerminal";
 import { newSession, type Session } from "./session";
 import {
@@ -25,16 +31,9 @@ describe("collectWorkspaceSnapshot", () => {
     const tab = {
       ...newTab("s1"),
       id: "t1",
-      editorPanes: [
-        { id: "e1", files: [file], activeFileId: file.id },
-      ],
+      editorPanes: [{ id: "e1", files: [file], activeFileId: file.id }],
     };
-    const snapshot = collectWorkspaceSnapshot(
-      [tab],
-      [session],
-      "t1",
-      "/tmp/a",
-    );
+    const snapshot = collectWorkspaceSnapshot([tab], [session], "t1", "/tmp/a");
     expect(snapshot.activeTabId).toBe("t1");
     expect(snapshot.tabs[0]?.editorPanes[0]?.files[0]?.path).toBe(
       "/tmp/a/README.md",
@@ -48,6 +47,17 @@ describe("collectWorkspaceSnapshot", () => {
     ]);
     expect("blocks" in snapshot.sessions[0]!).toBe(false);
     expect(snapshot.projectTerminals).toEqual([]);
+  });
+
+  it("round-trips a release-note descriptor", () => {
+    const tab = newReleaseNotesWorkspaceTab({ version: "0.1.22" });
+    const snapshot = collectWorkspaceSnapshot([tab], [], tab.id, "~");
+    const workspace = hydrateWorkspaceSnapshot(snapshot, new Map());
+
+    expect(workspace?.tabs[0]?.editorPanes[0]?.files[0]?.releaseNotes).toEqual({
+      version: "0.1.22",
+    });
+    expect(workspace?.sessions).toEqual([]);
   });
 
   it("stores the project terminal dock", () => {
@@ -75,19 +85,76 @@ describe("parseWorkspaceSnapshot", () => {
   it("returns null for empty or invalid payloads", () => {
     expect(parseWorkspaceSnapshot(null)).toBeNull();
     expect(parseWorkspaceSnapshot({ tabs: [], activeTabId: "t1" })).toBeNull();
-    expect(parseWorkspaceSnapshot({ tabs: [{}], activeTabId: "t1" })).toBeNull();
+    expect(
+      parseWorkspaceSnapshot({ tabs: [{}], activeTabId: "t1" }),
+    ).toBeNull();
   });
 
   it("drops unknown fields and repairs a missing active tab", () => {
     const tab = { ...newTab("s1"), id: "t1" };
     const parsed = parseWorkspaceSnapshot({
       tabs: [{ ...tab, extra: true }],
-      sessions: [{ id: "s1", harness: "cursor", runtimeMode: "supervised", cwd: "/tmp/a" }],
+      sessions: [
+        {
+          id: "s1",
+          harness: "cursor",
+          runtimeMode: "supervised",
+          cwd: "/tmp/a",
+        },
+      ],
       activeTabId: "missing",
       projectCwd: "/tmp/a",
     });
     expect(parsed?.activeTabId).toBe("t1");
     expect(parsed?.tabs[0] && "extra" in parsed.tabs[0]).toBe(false);
+  });
+
+  it.each([
+    { releaseNotes: { version: "" } },
+    { releaseNotes: { version: 123 } },
+    {
+      releaseNotes: { version: "0.1.22" },
+      plan: { sessionId: "s", blockId: "b", title: "Plan" },
+    },
+    { releaseNotes: { version: "0.1.22" }, review: true },
+    { releaseNotes: { version: "0.1.22" }, terminal: true },
+  ])("rejects a tab whose release pane is invalid: %j", (descriptor) => {
+    const valid = { ...newTab("session-a"), id: "valid-tab" };
+    const invalidPaneId = "invalid-release-pane";
+    const invalid = {
+      kind: "session",
+      id: "invalid-tab",
+      layout: leaf(invalidPaneId),
+      focusedId: invalidPaneId,
+      editorPanes: [
+        {
+          id: invalidPaneId,
+          activeFileId: "release-file",
+          files: [
+            {
+              id: "release-file",
+              path: "release-notes:0.1.22",
+              cwd: "~",
+              ...descriptor,
+            },
+          ],
+        },
+      ],
+      terminalPanes: [],
+    };
+
+    const parsed = parseWorkspaceSnapshot({
+      tabs: [valid, invalid],
+      sessions: [],
+      activeTabId: "invalid-tab",
+      projectCwd: "~",
+    });
+    expect(parsed?.tabs.map((tab) => tab.id)).toEqual(["valid-tab"]);
+
+    const workspace = parsed && hydrateWorkspaceSnapshot(parsed, new Map());
+    expect(
+      workspace?.sessions.some((session) => session.id === invalidPaneId),
+    ).toBe(false);
   });
 });
 
@@ -116,7 +183,16 @@ describe("hydrateWorkspaceSnapshot", () => {
       "/tmp/a",
     );
     const loaded = new Map([
-      ["s1", { ...left, blocks: [...left.blocks, { id: "a1", role: "assistant" as const, text: "stored" }] }],
+      [
+        "s1",
+        {
+          ...left,
+          blocks: [
+            ...left.blocks,
+            { id: "a1", role: "assistant" as const, text: "stored" },
+          ],
+        },
+      ],
     ]);
     const workspace = hydrateWorkspaceSnapshot(snapshot, loaded);
     expect(workspace?.tabs).toHaveLength(1);
@@ -124,12 +200,12 @@ describe("hydrateWorkspaceSnapshot", () => {
     expect(workspace?.tabs[0]?.editorPanes[0]?.files[0]?.path).toBe(
       "/tmp/a/src/lib.rs",
     );
-    expect(workspace?.sessions.find((session) => session.id === "s1")?.blocks).toEqual(
-      loaded.get("s1")?.blocks,
-    );
-    expect(workspace?.sessions.find((session) => session.id === "s2")?.blocks).toEqual(
-      [],
-    );
+    expect(
+      workspace?.sessions.find((session) => session.id === "s1")?.blocks,
+    ).toEqual(loaded.get("s1")?.blocks);
+    expect(
+      workspace?.sessions.find((session) => session.id === "s2")?.blocks,
+    ).toEqual([]);
   });
 
   it("marks in-flight chats interrupted and adds a tab if they were parked", () => {
@@ -153,9 +229,9 @@ describe("hydrateWorkspaceSnapshot", () => {
     expect(workspace?.tabs).toHaveLength(2);
     const resumed = workspace?.sessions.find((session) => session.id === "s2");
     expect(resumed?.busy).toBe(false);
-    expect(resumed?.blocks.some((block) => block.text === INTERRUPT_MESSAGE)).toBe(
-      true,
-    );
+    expect(
+      resumed?.blocks.some((block) => block.text === INTERRUPT_MESSAGE),
+    ).toBe(true);
   });
 
   it("keeps terminal-only tabs", () => {

--- a/src/lib/workspaceSnapshot.ts
+++ b/src/lib/workspaceSnapshot.ts
@@ -9,6 +9,7 @@ import {
   type PlanTabSource,
   type WorkspaceTab,
 } from "./layout";
+import type { ReleaseNotesTabSource } from "./releaseNotes";
 import {
   clampDockSize,
   isDockSide,
@@ -265,16 +266,15 @@ function sanitizeTab(raw: unknown): WorkspaceTab | null {
   if (typeof value.id !== "string" || !value.id) return null;
   const layout = sanitizeLayout(value.layout);
   if (!layout) return null;
-  const editorPanes = Array.isArray(value.editorPanes)
-    ? value.editorPanes
-        .map(sanitizePane)
-        .filter((pane): pane is EditorPane => pane != null)
-    : [];
-  const terminalPanes = Array.isArray(value.terminalPanes)
-    ? value.terminalPanes
-        .map(sanitizePane)
-        .filter((pane): pane is EditorPane => pane != null)
-    : [];
+  const editorResult = sanitizePanes(value.editorPanes);
+  const terminalResult = sanitizePanes(value.terminalPanes);
+  const invalidPaneIds = new Set([
+    ...editorResult.invalidIds,
+    ...terminalResult.invalidIds,
+  ]);
+  if (leafIds(layout).some((id) => invalidPaneIds.has(id))) return null;
+  const editorPanes = editorResult.panes;
+  const terminalPanes = terminalResult.panes;
   const focusedId =
     typeof value.focusedId === "string" && value.focusedId
       ? value.focusedId
@@ -324,6 +324,26 @@ function sanitizeLayout(raw: unknown): LayoutNode | null {
   return { type: "split", id: value.id, dir, children, sizes: normalized };
 }
 
+function sanitizePanes(raw: unknown): {
+  panes: EditorPane[];
+  invalidIds: string[];
+} {
+  if (!Array.isArray(raw)) return { panes: [], invalidIds: [] };
+  const panes: EditorPane[] = [];
+  const invalidIds: string[] = [];
+  for (const entry of raw) {
+    const pane = sanitizePane(entry);
+    if (pane) {
+      panes.push(pane);
+      continue;
+    }
+    if (!entry || typeof entry !== "object") continue;
+    const id = (entry as Record<string, unknown>).id;
+    if (typeof id === "string" && id) invalidIds.push(id);
+  }
+  return { panes, invalidIds };
+}
+
 function sanitizePane(raw: unknown): EditorPane | null {
   if (!raw || typeof raw !== "object") return null;
   const value = raw as Record<string, unknown>;
@@ -348,14 +368,33 @@ function sanitizeFile(raw: unknown): FilePaneTab | null {
   if (typeof value.path !== "string" || !value.path) return null;
   if (typeof value.cwd !== "string" || !value.cwd) return null;
   const plan = sanitizePlan(value.plan);
+  const hasReleaseNotes = "releaseNotes" in value;
+  const releaseNotes = sanitizeReleaseNotes(value.releaseNotes);
+  if (hasReleaseNotes && !releaseNotes) return null;
+  if (
+    releaseNotes &&
+    (value.plan != null || value.review === true || value.terminal === true)
+  ) {
+    return null;
+  }
   return {
     id: value.id,
     path: value.path,
     cwd: value.cwd,
     ...(plan ? { plan } : {}),
+    ...(releaseNotes ? { releaseNotes } : {}),
     ...(value.review === true ? { review: true } : {}),
     ...(value.terminal === true ? { terminal: true } : {}),
   };
+}
+
+function sanitizeReleaseNotes(
+  raw: unknown,
+): ReleaseNotesTabSource | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const version = (raw as Record<string, unknown>).version;
+  if (typeof version !== "string" || !version.trim()) return undefined;
+  return { version: version.trim() };
 }
 
 function sanitizeProjectTerminal(raw: unknown): ProjectTerminalDock | null {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import App from "./App";
 import { initAppearance } from "./lib/appearance";
 import { initSounds } from "./lib/sounds";
 import { handleQuitRequested, loadBootWorkspace } from "./lib/appLifecycle";
+import { consumeInstalledUpdate } from "./lib/updateNotice";
 import "./index.css";
 
 initAppearance();
@@ -39,10 +40,15 @@ void listen("quit_requested", () => {
 });
 
 void loadBootWorkspace().then(({ windowTransfer, resumed }) => {
+  const installedUpdate = windowTransfer ? null : consumeInstalledUpdate();
   ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
       <BootGate>
-        <App windowTransfer={windowTransfer} resumed={resumed} />
+        <App
+          windowTransfer={windowTransfer}
+          resumed={resumed}
+          installedUpdate={installedUpdate}
+        />
       </BootGate>
     </React.StrictMode>,
   );

--- a/src/surfaces/FilePane.tsx
+++ b/src/surfaces/FilePane.tsx
@@ -7,6 +7,7 @@ import {
 import { SurfaceTabs } from "../chrome/SurfaceTabs";
 import {
   isPlanTab,
+  isReleaseNotesTab,
   isTerminalTab,
   type EditorPane,
   type FilePaneTab,
@@ -17,6 +18,7 @@ import { editorPathsEqual } from "../lib/search";
 import type { Session } from "../lib/session";
 import { MarkdownPreview, MarkdownSource } from "./AgentMarkdown";
 import { FileEditor } from "./FileEditor";
+import { ReleaseNotesSurface } from "./ReleaseNotesSurface";
 import { TerminalView } from "./TerminalView";
 
 type Props = {
@@ -86,6 +88,8 @@ function FilePaneComponent({
                 sessions={sessions}
                 onOpenFile={onOpenFile}
               />
+            ) : isReleaseNotesTab(file) ? (
+              <ReleaseNotesSurface source={file.releaseNotes} />
             ) : isTerminalTab(file) ? (
               <TerminalView
                 id={file.id}

--- a/src/surfaces/ReleaseNotesSurface.tsx
+++ b/src/surfaces/ReleaseNotesSurface.tsx
@@ -1,0 +1,35 @@
+import { useLockOverscroll } from "../hooks/useLockOverscroll";
+import {
+  releaseNotesMarkdown,
+  type ReleaseNotesTabSource,
+} from "../lib/releaseNotes";
+import { AgentMarkdown } from "./AgentMarkdown";
+
+export function ReleaseNotesSurface({
+  source,
+}: {
+  source: ReleaseNotesTabSource;
+}) {
+  const lockOverscroll = useLockOverscroll<HTMLDivElement>();
+  const markdown = releaseNotesMarkdown(source);
+
+  return (
+    <div
+      ref={lockOverscroll}
+      className="h-full overflow-y-auto overscroll-none"
+    >
+      <article
+        aria-label="Release notes"
+        className="mx-auto w-full max-w-3xl px-8 py-10"
+      >
+        {markdown ? (
+          <AgentMarkdown text={markdown} streaming={false} />
+        ) : (
+          <p className="text-[13px] text-content/60">
+            Release notes for this version are not available in this build.
+          </p>
+        )}
+      </article>
+    </div>
+  );
+}

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -154,6 +154,7 @@ type Props = {
   onDeleteSession: (sessionId: string) => void;
   onRestoreProject?: (path: string) => void;
   onDeleteProject?: (path: string) => void;
+  onOpenWhatsNew: (version: string) => void;
 };
 
 export function SettingsView({
@@ -167,6 +168,7 @@ export function SettingsView({
   onDeleteSession,
   onRestoreProject,
   onDeleteProject,
+  onOpenWhatsNew,
 }: Props) {
   const lockOverscroll = useLockOverscroll<HTMLDivElement>();
   const onCloseRef = useRef(onClose);
@@ -228,7 +230,9 @@ export function SettingsView({
             title={settingsSectionLabel(section)}
             description={settingsSectionDescription(section)}
           />
-          {section === "general" ? <GeneralPage /> : null}
+          {section === "general" ? (
+            <GeneralPage onOpenWhatsNew={onOpenWhatsNew} />
+          ) : null}
           {section === "appearance" ? (
             <AppearancePage appearance={appearance} />
           ) : null}
@@ -251,7 +255,11 @@ export function SettingsView({
   );
 }
 
-function GeneralPage() {
+function GeneralPage({
+  onOpenWhatsNew,
+}: {
+  onOpenWhatsNew: (version: string) => void;
+}) {
   const [layout, setLayout] = useState<SidebarLayout>(loadSidebarLayout);
   const [transcriptLayout, setTranscriptLayout] =
     useState<TranscriptLayout>(loadTranscriptLayout);
@@ -441,7 +449,7 @@ function GeneralPage() {
       <LinearSettings />
 
       <Heading title="About" />
-      <UpdateRow />
+      <UpdateRow onOpenWhatsNew={onOpenWhatsNew} />
     </>
   );
 }
@@ -602,7 +610,11 @@ function LinearSettings() {
   );
 }
 
-function UpdateRow() {
+function UpdateRow({
+  onOpenWhatsNew,
+}: {
+  onOpenWhatsNew: (version: string) => void;
+}) {
   const [snapshot, setSnapshot] = useState<UpdaterSnapshot>({
     phase: "idle",
     currentVersion: "…",
@@ -657,16 +669,24 @@ function UpdateRow() {
       }
       description={status}
     >
-      <SecondaryButton onClick={() => void onClick()} disabled={busy}>
-        {busy ? (
+      <div className="flex items-center gap-2">
+        <SecondaryButton
+          onClick={() => onOpenWhatsNew(snapshot.currentVersion)}
+          disabled={snapshot.currentVersion === "…"}
+        >
+          What's new
+        </SecondaryButton>
+        <SecondaryButton onClick={() => void onClick()} disabled={busy}>
+          {busy ? (
           <Loader className="size-3.5 animate-spin" aria-hidden />
         ) : hasUpdate ? (
           <ArrowDownCircle className="size-3.5 text-accent" aria-hidden />
         ) : (
           <RefreshCw className="size-3.5" strokeWidth={1.75} aria-hidden />
         )}
-        {hasUpdate ? "Download" : "Check for updates"}
-      </SecondaryButton>
+          {hasUpdate ? "Download" : "Check for updates"}
+        </SecondaryButton>
+      </div>
     </Row>
   );
 }


### PR DESCRIPTION
## What changed

- Add a clickable and dismissible What’s New modal when Monocode relaunches after an update
- Add a clickable What’s New link in Settings
- Show updates based on version number

## Why

Makes it easy for devs to see what has changed in the application

## UI

<img width="2059" height="1415" alt="CleanShot 2026-08-31 at 13 40 04" src="https://github.com/user-attachments/assets/5ea8b4fa-5f2e-4c85-b3a1-b5b91a941b3a" />

<img width="2061" height="1415" alt="CleanShot 2026-08-31 at 13 40 15" src="https://github.com/user-attachments/assets/e83fc409-dd0c-4442-b079-e3d2df5eadab" />


## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes
