### PR TITLE
feat(linux): ship deb and AppImage releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,7 @@ jobs:
 
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev
+        run: bash scripts/install-linux-deps-debian.sh
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   release:
+    needs: linux
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -105,9 +106,9 @@ jobs:
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
           BUNDLE="target/release/bundle"
-          TAR=$(ls "$BUNDLE"/macos/*.app.tar.gz | head -n 1)
+          TAR=$(find "$BUNDLE/macos" -maxdepth 1 -type f -name '*.app.tar.gz' -print -quit)
           SIG="${TAR}.sig"
-          DMG=$(ls "$BUNDLE"/dmg/*.dmg | head -n 1)
+          DMG=$(find "$BUNDLE/dmg" -maxdepth 1 -type f -name '*.dmg' -print -quit)
           BASE="${R2_PUBLIC_BASE_URL%/}"
           ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           RELEASE_PREFIX="releases/${VERSION}"
@@ -148,16 +149,71 @@ jobs:
           aws s3 cp "$DMG" "s3://${R2_BUCKET_NAME}/MonoCode.dmg" --cache-control "$NO_CACHE" --endpoint-url "$ENDPOINT"
           aws s3 cp latest.json "s3://${R2_BUCKET_NAME}/latest.json" --content-type "application/json" --cache-control "$NO_CACHE" --endpoint-url "$ENDPOINT"
 
+      - name: Download Linux packages
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-packages
+          path: target/release/bundle/linux
+
       - name: GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
           BUNDLE="target/release/bundle"
-          TAR=$(ls "$BUNDLE"/macos/*.app.tar.gz | head -n 1)
+          TAR=$(find "$BUNDLE/macos" -maxdepth 1 -type f -name '*.app.tar.gz' -print -quit)
           SIG="${TAR}.sig"
-          DMG=$(ls "$BUNDLE"/dmg/*.dmg | head -n 1)
+          DMG=$(find "$BUNDLE/dmg" -maxdepth 1 -type f -name '*.dmg' -print -quit)
+          shopt -s nullglob
+          DEB=("$BUNDLE"/linux/*.deb)
+          APPIMAGE=("$BUNDLE"/linux/*.AppImage)
+          if (( ${#DEB[@]} != 1 || ${#APPIMAGE[@]} != 1 )); then
+            echo "Expected exactly one .deb and one AppImage" >&2
+            exit 1
+          fi
           gh release create "$GITHUB_REF_NAME" \
             --title "MonoCode $VERSION" \
             --notes "See CHANGELOG.md for details." \
-            "$DMG" "$TAR" "$SIG"
+            "$DMG" "$TAR" "$SIG" "${DEB[0]}" "${APPIMAGE[0]}"
+
+  linux:
+    name: Linux packages
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux system dependencies
+        run: bash scripts/install-linux-deps-debian.sh
+
+      - run: npm ci
+
+      - name: Build Linux packages
+        run: npm run build:linux
+
+      - name: Stage Linux packages
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          deb=(target/release/bundle/deb/*.deb)
+          appimage=(target/release/bundle/appimage/*.AppImage)
+          if (( ${#deb[@]} != 1 || ${#appimage[@]} != 1 )); then
+            echo "Expected exactly one .deb and one AppImage" >&2
+            exit 1
+          fi
+          mkdir -p release-artifacts
+          cp "${deb[0]}" "${appimage[0]}" release-artifacts/
+
+      - name: Upload Linux packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-packages
+          path: release-artifacts/
+          if-no-files-found: error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ You need Node.js 20+, a current stable Rust toolchain, and at least one provider
 - [omp](https://omp.sh) - `curl -fsSL https://omp.sh/install | sh`
 - [fx](https://fx.sh) - `curl -fsSL https://fx.sh/setup.sh | bash` then `fx login`
 
-macOS and Linux are supported targets.
+macOS and Linux are supported targets. On Debian/Ubuntu, `npm run setup:linux:deb` installs the native Tauri build dependencies.
 
 ```bash
 npm install

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Works with your subscriptions on Claude Code, Codex, Cursor, Grok Build, OpenCod
 
 macOS (Apple Silicon): download [MonoCode.dmg](https://dl.usemono.dev/MonoCode.dmg), open it, drag MonoCode to Applications.
 
+Linux (x86_64): download the `.deb` or AppImage from [GitHub Releases](https://github.com/hardbeat920/monocode/releases/latest). Install the `.deb` with `sudo apt install ./MonoCode_*.deb`, or make the AppImage executable with `chmod +x MonoCode_*.AppImage` and run it directly.
+
 ## Some notes
 
 This is very early and you should expect bugs.
@@ -45,6 +47,19 @@ Need Node.js 20+ and a current stable Rust toolchain. On Linux, ensure standard 
 npm install
 npm run tauri dev
 ```
+
+### Ubuntu / Debian packages
+
+On an Ubuntu/Debian workstation, the repository can install the native Tauri prerequisites and build distributable Linux packages directly:
+
+```bash
+npm run setup:linux:deb
+npm ci
+npm run build:linux
+```
+
+The Linux build emits `.deb` and AppImage bundles under `target/release/bundle/`.
+Tauri loads `src-tauri/tauri.linux.conf.json` automatically for Linux development and builds.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "check:rust": "cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test",
     "set-version": "node scripts/bump-version.mjs",
     "tauri": "tauri",
-    "tauri:stable": "tauri dev --no-watch --config src-tauri/tauri.stable.conf.json"
+    "tauri:stable": "tauri dev --no-watch --config src-tauri/tauri.stable.conf.json",
+    "setup:linux:deb": "bash scripts/install-linux-deps-debian.sh",
+    "build:linux": "tauri build --bundles deb,appimage"
   },
   "dependencies": {
     "@codemirror/lang-css": "^6.3.1",

--- a/scripts/install-linux-deps-debian.sh
+++ b/scripts/install-linux-deps-debian.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "This helper currently supports Ubuntu/Debian systems with apt-get." >&2
+  exit 1
+fi
+
+if [ "$(id -u)" -eq 0 ]; then
+  SUDO=()
+elif command -v sudo >/dev/null 2>&1; then
+  SUDO=(sudo)
+else
+  echo "sudo is required when not running as root." >&2
+  exit 1
+fi
+
+"${SUDO[@]}" apt-get update
+"${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  build-essential \
+  curl \
+  file \
+  libayatana-appindicator3-dev \
+  libgtk-3-dev \
+  libssl-dev \
+  libwebkit2gtk-4.1-dev \
+  libxdo-dev \
+  librsvg2-dev \
+  patchelf \
+  wget

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -18,10 +18,17 @@
     ]
   },
   "bundle": {
+    "targets": [
+      "deb",
+      "appimage"
+    ],
+    "createUpdaterArtifacts": false,
+    "category": "DeveloperTool",
     "linux": {
       "appimage": {
         "bundleMediaFramework": false
       }
-    }
+    },
+    "resources": null
   }
 }

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -22,6 +22,11 @@ export type UpdaterSnapshot = {
 
 let pendingUpdate: Update | null = null;
 
+function isUpdaterNotConfiguredError(error: unknown): boolean {
+  const text = error instanceof Error ? error.message : String(error);
+  return /updater does not have any endpoints set/i.test(text);
+}
+
 export async function readAppVersion(): Promise<string> {
   try {
     return await getVersion();
@@ -78,6 +83,19 @@ export async function runUpdateFlow(
 
     return installPendingUpdate(onProgress);
   } catch (err) {
+    if (isUpdaterNotConfiguredError(err)) {
+      pendingUpdate = null;
+      const idle: UpdaterSnapshot = { phase: "idle", currentVersion };
+      onProgress?.(idle);
+      if (manual) {
+        await message(
+          "Automatic updates aren't configured for this build.\n\nDownload releases at https://github.com/hardbeat920/monocode/releases/latest",
+          { title: "MonoCode" },
+        );
+      }
+      return idle;
+    }
+
     const error = err instanceof Error ? err.message : String(err);
     const failed: UpdaterSnapshot = { phase: "error", currentVersion, error };
     onProgress?.(failed);

--- a/src/lib/updaterConfig.test.ts
+++ b/src/lib/updaterConfig.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { getVersion, check, message, ask, relaunch } = vi.hoisted(() => ({
+  getVersion: vi.fn(),
+  check: vi.fn(),
+  message: vi.fn(),
+  ask: vi.fn(),
+  relaunch: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/app", () => ({ getVersion }));
+vi.mock("@tauri-apps/plugin-updater", () => ({ check }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ ask, message }));
+vi.mock("@tauri-apps/plugin-process", () => ({ relaunch }));
+vi.mock("./sounds", () => ({ announceUpdateAvailable: vi.fn() }));
+
+import { runUpdateFlow } from "./updater";
+
+describe("updater", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("keeps automatic checks quiet when updater endpoints are missing", async () => {
+    getVersion.mockResolvedValue("0.1.23");
+    check.mockRejectedValue(new Error("Updater does not have any endpoints set"));
+
+    await expect(runUpdateFlow(false)).resolves.toEqual({
+      phase: "idle",
+      currentVersion: "0.1.23",
+    });
+    expect(message).not.toHaveBeenCalled();
+  });
+
+  it("points manual checks without updater endpoints to GitHub releases", async () => {
+    getVersion.mockResolvedValue("0.1.23");
+    check.mockRejectedValue(new Error("Updater does not have any endpoints set"));
+
+    await expect(runUpdateFlow(true)).resolves.toEqual({
+      phase: "idle",
+      currentVersion: "0.1.23",
+    });
+    expect(message).toHaveBeenCalledWith(
+      expect.stringContaining("https://github.com/hardbeat920/monocode/releases/latest"),
+      { title: "MonoCode" },
+    );
+  });
+
+  it("still reports real updater failures", async () => {
+    getVersion.mockResolvedValue("0.1.23");
+    check.mockRejectedValue(new Error("network failed"));
+
+    await expect(runUpdateFlow(true)).resolves.toMatchObject({
+      phase: "error",
+      error: "network failed",
+    });
+    expect(message).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## What changed

- adds a shared Debian/Ubuntu Tauri dependency setup used locally and by CI
- adds explicit `.deb` and AppImage builds for tagged releases
- builds Linux first, transfers the packages as a workflow artifact, and only creates the public GitHub Release after both Linux and signed/notarized macOS artifacts are ready
- keeps macOS-only resources out of Linux bundles and sets Linux desktop category metadata
- suppresses the raw missing-updater-endpoint error; automatic checks stay quiet while manual checks point users to GitHub Releases

## Why

MonoCode already has Linux runtime support and Linux CI, but installable Linux builds required manual setup and tagged releases only shipped macOS. Source/Linux builds also intentionally have no updater endpoint configured.

The release dependency keeps publication atomic from GitHub's perspective: a failed Linux package build leaves no partial public release, so the workflow can be retried safely.

## UI

No layout change. A manual update check on a build without an updater feed now shows a short GitHub Releases message instead of the raw Tauri configuration error.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes

Additional verification:
- `npm run check`: 80 test files / 873 web tests; 147 Rust tests; TypeScript, fmt, clippy and doc tests green
- `actionlint .github/workflows/release.yml` passes cleanly
- built and inspected `.deb` and AppImage bundles; neither ships macOS `Assets.car`
- verified `Categories=Development;` in both Linux desktop entries
- package smoke test installed and launched successfully on Ubuntu amd64 / GNOME Wayland
