### PR TITLE
fix(skills): discover installed Claude plugin skills

### DIFF
--- a/src-tauri/src/skills.rs
+++ b/src-tauri/src/skills.rs
@@ -72,11 +72,199 @@ pub(crate) fn list_skills_from(project: &Path, home: Option<&Path>) -> Vec<Disco
     if let Some(home) = home {
         add_root(home.join(".pi/agent/skills"), "user", "pi");
         add_root(home.join(".omp/agent/skills"), "user", "omp");
+        for (root, scope, namespace) in claude_plugin_skill_roots(home, project) {
+            add_namespaced_root(&mut by_name, root, scope, "claude", &namespace);
+        }
     }
 
     let mut out: Vec<DiscoveredSkill> = by_name.into_values().collect();
     out.sort_by(|a, b| a.name.cmp(&b.name));
     out
+}
+
+fn add_namespaced_root(
+    by_name: &mut HashMap<String, DiscoveredSkill>,
+    root: PathBuf,
+    scope: &str,
+    source: &str,
+    namespace: &str,
+) {
+    if by_name.len() >= MAX_SKILLS {
+        return;
+    }
+    for mut skill in scan_root(&root, scope, source) {
+        if by_name.len() >= MAX_SKILLS {
+            break;
+        }
+        skill.name = format!("{namespace}:{}", skill.name);
+        by_name.entry(skill.name.clone()).or_insert(skill);
+    }
+}
+
+fn claude_plugin_skill_roots(home: &Path, project: &Path) -> Vec<(PathBuf, &'static str, String)> {
+    let registry = home.join(".claude/plugins/installed_plugins.json");
+    let Ok(raw) = std::fs::read_to_string(registry) else {
+        return Vec::new();
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return Vec::new();
+    };
+    let Some(plugins) = value.get("plugins").and_then(|value| value.as_object()) else {
+        return Vec::new();
+    };
+
+    let mut roots = Vec::new();
+    for (plugin_id, installed) in plugins {
+        if !claude_plugin_enabled(home, project, plugin_id) {
+            continue;
+        }
+        let namespace = plugin_id
+            .rsplit_once('@')
+            .map(|(name, _)| name)
+            .unwrap_or(plugin_id);
+        if !is_valid_skill_name(namespace) {
+            continue;
+        }
+        let entries: Vec<&serde_json::Value> = match installed.as_array() {
+            Some(entries) => entries.iter().collect(),
+            None if installed.is_object() => vec![installed],
+            None => continue,
+        };
+        for entry in entries {
+            let Some(install_path) = entry.get("installPath").and_then(|value| value.as_str())
+            else {
+                continue;
+            };
+            let scope = match entry.get("scope").and_then(|value| value.as_str()) {
+                Some("project" | "local") => {
+                    let Some(project_path) =
+                        entry.get("projectPath").and_then(|value| value.as_str())
+                    else {
+                        continue;
+                    };
+                    if !path_is_within(project, &resolve_home_path(project_path, home)) {
+                        continue;
+                    }
+                    "project"
+                }
+                Some("user") | None => "user",
+                Some(_) => continue,
+            };
+            roots.push((
+                resolve_home_path(install_path, home).join("skills"),
+                scope,
+                namespace.to_string(),
+            ));
+        }
+    }
+    roots.sort_by_key(|(_, scope, _)| if *scope == "project" { 0 } else { 1 });
+    roots
+}
+
+fn resolve_home_path(raw: &str, home: &Path) -> PathBuf {
+    if raw == "~" {
+        return home.to_path_buf();
+    }
+    if let Some(rest) = raw.strip_prefix("~/") {
+        return home.join(rest);
+    }
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        home.join(path)
+    }
+}
+
+fn claude_plugin_enabled(home: &Path, project: &Path, plugin_id: &str) -> bool {
+    if let Some(enabled) = managed_plugin_setting(plugin_id) {
+        return enabled;
+    }
+    let project_root = claude_settings_project_root(project);
+    for settings in [
+        project_root.join(".claude/settings.local.json"),
+        project_root.join(".claude/settings.json"),
+        home.join(".claude/settings.json"),
+    ] {
+        if let Some(enabled) = plugin_setting(&settings, plugin_id) {
+            return enabled;
+        }
+    }
+    true
+}
+
+fn claude_settings_project_root(project: &Path) -> PathBuf {
+    for candidate in project.ancestors() {
+        let claude = candidate.join(".claude");
+        if claude.join("settings.local.json").is_file() || claude.join("settings.json").is_file() {
+            return candidate.to_path_buf();
+        }
+    }
+    project.to_path_buf()
+}
+
+fn plugin_setting(path: &Path, plugin_id: &str) -> Option<bool> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let value = serde_json::from_str::<serde_json::Value>(&raw).ok()?;
+    value.get("enabledPlugins")?.get(plugin_id)?.as_bool()
+}
+
+fn managed_plugin_setting(plugin_id: &str) -> Option<bool> {
+    let root = managed_settings_root()?;
+    managed_plugin_setting_from_root(&root, plugin_id)
+}
+
+fn managed_plugin_setting_from_root(root: &Path, plugin_id: &str) -> Option<bool> {
+    let mut value = plugin_setting(&root.join("managed-settings.json"), plugin_id);
+    let dir = root.join("managed-settings.d");
+    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension().and_then(|ext| ext.to_str()) == Some("json")
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| !name.starts_with('.'))
+        })
+        .collect();
+    files.sort();
+    for file in files {
+        if let Some(enabled) = plugin_setting(&file, plugin_id) {
+            value = Some(enabled);
+        }
+    }
+    value
+}
+
+fn managed_settings_root() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        return Some(PathBuf::from("/Library/Application Support/ClaudeCode"));
+    }
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        return Some(PathBuf::from("/etc/claude-code"));
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return Some(PathBuf::from(r"C:\Program Files\ClaudeCode"));
+    }
+    #[allow(unreachable_code)]
+    None
+}
+
+fn path_is_within(path: &Path, root: &Path) -> bool {
+    let Ok(path) = std::fs::canonicalize(path) else {
+        return false;
+    };
+    let Ok(root) = std::fs::canonicalize(root) else {
+        return false;
+    };
+    path == root || path.starts_with(root)
 }
 
 fn scan_root(root: &Path, scope: &str, source: &str) -> Vec<DiscoveredSkill> {
@@ -308,6 +496,15 @@ mod tests {
         std::fs::write(dir.join("SKILL.md"), body).unwrap();
     }
 
+    fn write_plugin_setting(root: &Path, file: &str, plugin_id: &str, enabled: bool) {
+        let dir = root.join(".claude");
+        std::fs::create_dir_all(&dir).unwrap();
+        let settings = serde_json::json!({
+            "enabledPlugins": { plugin_id: enabled }
+        });
+        std::fs::write(dir.join(file), serde_json::to_vec(&settings).unwrap()).unwrap();
+    }
+
     #[test]
     fn parse_frontmatter_reads_name_and_folded_description() {
         let (name, desc) = parse_frontmatter(
@@ -435,6 +632,206 @@ mod tests {
         let user_skill = skills.iter().find(|s| s.name == "grok-global").unwrap();
         assert_eq!(user_skill.source, "grok");
         assert_eq!(user_skill.scope, "user");
+    }
+
+    #[test]
+    fn discovers_installed_claude_plugin_skills() {
+        let project = tmp("proj-claude-plugin");
+        let home = tmp("home-claude-plugin");
+        let plugin = home
+            .0
+            .join(".claude/plugins/cache/community/workflow-kit/1.2.3");
+        write_skill(
+            &plugin.join("skills"),
+            "quick-plan",
+            "---\nname: quick-plan\ndescription: Plan from plugin\n---\n",
+        );
+        write_skill(
+            &home.0.join(".claude/skills"),
+            "quick-plan",
+            "---\nname: quick-plan\ndescription: Personal plan\n---\n",
+        );
+        std::fs::create_dir_all(home.0.join(".claude/plugins")).unwrap();
+        std::fs::write(
+            home.0.join(".claude/plugins/installed_plugins.json"),
+            r#"{"version":2,"plugins":{"workflow-kit@community":[{"scope":"user","installPath":"~/.claude/plugins/cache/community/workflow-kit/1.2.3","version":"1.2.3"}]}}"#,
+        )
+        .unwrap();
+
+        let skills = list_skills_from(&project.0, Some(&home.0));
+        let skill = skills
+            .iter()
+            .find(|skill| skill.name == "workflow-kit:quick-plan")
+            .unwrap();
+        assert_eq!(skill.description, "Plan from plugin");
+        assert_eq!(skill.source, "claude");
+        assert_eq!(skill.scope, "user");
+        assert!(skill
+            .path
+            .ends_with("workflow-kit/1.2.3/skills/quick-plan/SKILL.md"));
+        assert!(skills.iter().any(|skill| skill.name == "quick-plan"));
+    }
+
+    #[test]
+    fn claude_project_plugins_only_apply_to_their_project() {
+        let project = tmp("proj-claude-scoped");
+        let other = tmp("other-claude-scoped");
+        let home = tmp("home-claude-scoped");
+        let plugin = home
+            .0
+            .join(".claude/plugins/cache/community/workflow-kit/2.0.0");
+        write_skill(
+            &plugin.join("skills"),
+            "feature-delivery",
+            "---\nname: feature-delivery\ndescription: Deliver feature\n---\n",
+        );
+        std::fs::create_dir_all(home.0.join(".claude/plugins")).unwrap();
+        let registry = serde_json::json!({
+            "version": 2,
+            "plugins": {
+                "workflow-kit@community": [{
+                    "scope": "project",
+                    "projectPath": project.0.to_string_lossy(),
+                    "installPath": plugin.to_string_lossy(),
+                    "version": "2.0.0"
+                }]
+            }
+        });
+        std::fs::write(
+            home.0.join(".claude/plugins/installed_plugins.json"),
+            serde_json::to_vec(&registry).unwrap(),
+        )
+        .unwrap();
+
+        let nested = project.0.join("src");
+        std::fs::create_dir_all(&nested).unwrap();
+        let matching = list_skills_from(&nested, Some(&home.0));
+        let skill = matching
+            .iter()
+            .find(|skill| skill.name == "workflow-kit:feature-delivery")
+            .unwrap();
+        assert_eq!(skill.scope, "project");
+
+        let unrelated = list_skills_from(&other.0, Some(&home.0));
+        assert!(!unrelated
+            .iter()
+            .any(|skill| skill.name == "workflow-kit:feature-delivery"));
+    }
+
+    #[test]
+    fn disabled_claude_plugin_skills_are_hidden() {
+        let project = tmp("proj-claude-disabled");
+        let home = tmp("home-claude-disabled");
+        let plugin = home
+            .0
+            .join(".claude/plugins/cache/community/workflow-kit/1.2.3");
+        write_skill(
+            &plugin.join("skills"),
+            "quick-plan",
+            "---\nname: quick-plan\ndescription: Plan from plugin\n---\n",
+        );
+        std::fs::create_dir_all(home.0.join(".claude/plugins")).unwrap();
+        std::fs::write(
+            home.0.join(".claude/plugins/installed_plugins.json"),
+            r#"{"version":2,"plugins":{"workflow-kit@community":[{"scope":"user","installPath":"~/.claude/plugins/cache/community/workflow-kit/1.2.3","version":"1.2.3"}]}}"#,
+        )
+        .unwrap();
+        write_plugin_setting(&home.0, "settings.json", "workflow-kit@community", false);
+
+        let skills = list_skills_from(&project.0, Some(&home.0));
+        assert!(!skills
+            .iter()
+            .any(|skill| skill.name == "workflow-kit:quick-plan"));
+    }
+
+    #[test]
+    fn claude_plugin_enablement_uses_local_project_user_precedence() {
+        let project = tmp("proj-claude-precedence");
+        let nested = project.0.join("src");
+        let home = tmp("home-claude-precedence");
+        std::fs::create_dir_all(&nested).unwrap();
+        write_plugin_setting(&home.0, "settings.json", "workflow-kit@community", false);
+        write_plugin_setting(&project.0, "settings.json", "workflow-kit@community", true);
+        assert!(claude_plugin_enabled(
+            &home.0,
+            &nested,
+            "workflow-kit@community"
+        ));
+        write_plugin_setting(
+            &project.0,
+            "settings.local.json",
+            "workflow-kit@community",
+            false,
+        );
+        assert!(!claude_plugin_enabled(
+            &home.0,
+            &nested,
+            "workflow-kit@community"
+        ));
+    }
+
+    #[test]
+    fn managed_plugin_settings_apply_dropins_in_order() {
+        let root = tmp("managed-settings");
+        let plugin_id = "workflow-kit@community";
+        let base = serde_json::json!({ "enabledPlugins": { plugin_id: true } });
+        std::fs::write(
+            root.0.join("managed-settings.json"),
+            serde_json::to_vec(&base).unwrap(),
+        )
+        .unwrap();
+        let dropins = root.0.join("managed-settings.d");
+        std::fs::create_dir_all(&dropins).unwrap();
+        let earlier = serde_json::json!({ "enabledPlugins": { plugin_id: true } });
+        let later = serde_json::json!({ "enabledPlugins": { plugin_id: false } });
+        std::fs::write(
+            dropins.join("10-enable.json"),
+            serde_json::to_vec(&earlier).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            dropins.join("20-disable.json"),
+            serde_json::to_vec(&later).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            managed_plugin_setting_from_root(&root.0, plugin_id),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn path_is_within_fails_closed_when_either_path_is_missing() {
+        let root = tmp("path-root");
+        let nested = root.0.join("src");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert!(path_is_within(&nested, &root.0));
+        assert!(!path_is_within(&root.0.join("missing"), &root.0));
+        assert!(!path_is_within(&nested, &root.0.join("missing")));
+    }
+
+    #[test]
+    fn ignores_unregistered_claude_plugin_cache_versions() {
+        let project = tmp("proj-claude-stale");
+        let home = tmp("home-claude-stale");
+        let stale = home
+            .0
+            .join(".claude/plugins/cache/community/workflow-kit/0.9.0");
+        write_skill(
+            &stale.join("skills"),
+            "stale-skill",
+            "---\nname: stale-skill\ndescription: Old cached skill\n---\n",
+        );
+        std::fs::create_dir_all(home.0.join(".claude/plugins")).unwrap();
+        std::fs::write(
+            home.0.join(".claude/plugins/installed_plugins.json"),
+            r#"{"version":2,"plugins":{}}"#,
+        )
+        .unwrap();
+
+        let skills = list_skills_from(&project.0, Some(&home.0));
+        assert!(!skills.iter().any(|skill| skill.name == "stale-skill"));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- discovers Claude plugin skills from registered plugin `installPath` entries in `~/.claude/plugins/installed_plugins.json`
- keeps plugin skills namespaced (for example `workflow-kit:quick-plan`) so they do not collide with normal project/user skills
- honors Claude `enabledPlugins` precedence: managed → project local → shared project → user
- supports file-based managed settings plus ordered `managed-settings.d/*.json` overrides
- respects project/local plugin scope for the configured project and its subdirectories
- ignores disabled plugins and stale plugin cache versions that are no longer registered
- fails closed when project-path canonicalization cannot be verified

## Why

Installed Claude plugins can provide skills under `<plugin>/skills/<skill>/SKILL.md`, but MonoCode only scanned the normal `.claude/skills` directories. That made installed plugin skills such as `workflow-kit` invisible in the MonoCode skill picker even though Claude Code could use them. Discovery also needs to follow Claude's enablement settings so a disabled plugin does not leak skills into MonoCode.

Fixes #3.

## UI

No layout change. Enabled plugin-provided skills now appear in the existing skill picker under their Claude plugin namespace.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes

Additional verification:
- rebased onto current upstream `main` / MonoCode 0.1.25 before the final check
- `npm run check`: 89 test files / 958 web tests; 163 Rust tests; fmt, clippy and doc tests green
- plugin-specific Rust coverage: installed discovery, namespace collision avoidance, user/project/local precedence, explicit `false` hiding skills, managed drop-in ordering, project scoping from nested cwd, stale cache filtering, and fail-closed path checks
- verified the reported `workflow-kit` repository uses the expected `plugins/workflow-kit/skills/<skill>/SKILL.md` layout
