### PR TITLE
fix(shortcuts): stop focused agent turn on Escape

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -237,7 +237,12 @@ import { liveAgentsFromSessions } from "./lib/liveAgents";
 import { hiddenApprovalNotices } from "./lib/approvalToast";
 import { nextUnseenFinishedSessions } from "./lib/sessionDone";
 import { playCue } from "./lib/sounds";
-import { tabCommand } from "./lib/tabKeys";
+import {
+  deferUnhandledEscape,
+  focusedBusyAgentSessionId,
+  shouldStopFocusedTurnOnEscape,
+  tabCommand,
+} from "./lib/tabKeys";
 import {
   canTabVisitBack,
   canTabVisitForward,
@@ -548,6 +553,8 @@ export default function App({
   tabsRef.current = tabs;
   const projectTerminalsRef = useRef(projectTerminals);
   projectTerminalsRef.current = projectTerminals;
+  const projectTerminalFocusedRef = useRef(projectTerminalFocused);
+  projectTerminalFocusedRef.current = projectTerminalFocused;
   const activeTabIdRef = useRef(activeTabId);
   activeTabIdRef.current = activeTabId;
   const projectCwdRef = useRef(projectCwd);
@@ -3676,6 +3683,50 @@ export default function App({
     },
     [flushHarnessEvents],
   );
+
+  useEffect(() => {
+    const onEscape = (event: KeyboardEvent) => {
+      const target = event.target instanceof Element ? event.target : null;
+      const inTerminal = Boolean(target?.closest(".monocode-terminal"));
+      const activeTabId = activeTabIdRef.current;
+      const sessionId = focusedBusyAgentSessionId(
+        activeTabId,
+        tabsRef.current,
+        sessionsRef.current,
+        projectTerminalFocusedRef.current,
+      );
+      if (
+        !sessionId ||
+        !shouldStopFocusedTurnOnEscape(event, {
+          inTerminal,
+          focusedSessionBusy: true,
+        })
+      ) {
+        return;
+      }
+
+      // Other surfaces (drag/reorder included) can claim Escape later in the
+      // same keydown dispatch. Defer the destructive stop until every handler
+      // has had a chance to preventDefault, then verify focus did not move.
+      deferUnhandledEscape(event, () => {
+        const stillFocusedSessionId = focusedBusyAgentSessionId(
+          activeTabIdRef.current,
+          tabsRef.current,
+          sessionsRef.current,
+          projectTerminalFocusedRef.current,
+        );
+        if (
+          activeTabIdRef.current !== activeTabId ||
+          stillFocusedSessionId !== sessionId
+        ) {
+          return;
+        }
+        onStop(sessionId);
+      });
+    };
+    window.addEventListener("keydown", onEscape);
+    return () => window.removeEventListener("keydown", onEscape);
+  }, [onStop]);
 
   const onApproval = useCallback(
     (sessionId: string, requestId: number, decision: ApprovalDecision) => {

--- a/src/lib/tabKeys.test.ts
+++ b/src/lib/tabKeys.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { tabCommand } from "./tabKeys";
+import {
+  deferUnhandledEscape,
+  focusedBusyAgentSessionId,
+  shouldStopFocusedTurnOnEscape,
+  tabCommand,
+} from "./tabKeys";
 
 function key(
   partial: Partial<
@@ -12,11 +17,15 @@ function key(
       | "altKey"
       | "shiftKey"
       | "isComposing"
+      | "defaultPrevented"
+      | "repeat"
     >
   >,
 ): KeyboardEvent {
   return {
     isComposing: false,
+    defaultPrevented: false,
+    repeat: false,
     metaKey: false,
     ctrlKey: false,
     altKey: false,
@@ -70,5 +79,153 @@ describe("tabCommand", () => {
         key({ key: "}", code: "BracketRight", metaKey: true, shiftKey: true }),
       ),
     ).toBe("next");
+  });
+});
+
+describe("shouldStopFocusedTurnOnEscape", () => {
+  const escape = (partial: Partial<KeyboardEvent> = {}) =>
+    key({ key: "Escape", ...partial });
+
+  it("stops a busy focused agent turn on plain Escape", () => {
+    expect(
+      shouldStopFocusedTurnOnEscape(escape(), {
+        inTerminal: false,
+        focusedSessionBusy: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not steal Escape that another surface already handled", () => {
+    expect(
+      shouldStopFocusedTurnOnEscape(escape({ defaultPrevented: true }), {
+        inTerminal: false,
+        focusedSessionBusy: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("leaves terminal Escape and idle sessions alone", () => {
+    expect(
+      shouldStopFocusedTurnOnEscape(escape(), {
+        inTerminal: true,
+        focusedSessionBusy: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldStopFocusedTurnOnEscape(escape(), {
+        inTerminal: false,
+        focusedSessionBusy: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores modified, composing, or repeated Escape", () => {
+    for (const partial of [
+      { metaKey: true },
+      { ctrlKey: true },
+      { altKey: true },
+      { shiftKey: true },
+      { isComposing: true },
+      { repeat: true },
+    ]) {
+      expect(
+        shouldStopFocusedTurnOnEscape(escape(partial), {
+          inTerminal: false,
+          focusedSessionBusy: true,
+        }),
+      ).toBe(false);
+    }
+  });
+});
+
+describe("focusedBusyAgentSessionId", () => {
+  const tabs = [{ id: "tab-a", focusedId: "session-a" }];
+  const sessions = [{ id: "session-a", busy: true }];
+
+  it("returns only the busy agent session in the exact active tab", () => {
+    expect(focusedBusyAgentSessionId("tab-a", tabs, sessions, false)).toBe(
+      "session-a",
+    );
+    expect(
+      focusedBusyAgentSessionId("missing", tabs, sessions, false),
+    ).toBeNull();
+  });
+
+  it("does not stop through diff, terminal-dock, editor, or idle focus", () => {
+    expect(
+      focusedBusyAgentSessionId(
+        "tab-a",
+        [{ ...tabs[0], diffFocused: true }],
+        sessions,
+        false,
+      ),
+    ).toBeNull();
+    expect(focusedBusyAgentSessionId("tab-a", tabs, sessions, true)).toBeNull();
+    expect(
+      focusedBusyAgentSessionId(
+        "tab-a",
+        [{ id: "tab-a", focusedId: "editor-pane" }],
+        sessions,
+        false,
+      ),
+    ).toBeNull();
+    expect(
+      focusedBusyAgentSessionId(
+        "tab-a",
+        tabs,
+        [{ id: "session-a", busy: false }],
+        false,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("deferUnhandledEscape", () => {
+  const escape = (partial: Partial<KeyboardEvent> = {}) =>
+    key({ key: "Escape", ...partial });
+
+  it("runs after the keydown dispatch when Escape stays unhandled", () => {
+    let deferred: (() => void) | undefined;
+    let stopped = false;
+    deferUnhandledEscape(
+      escape(),
+      () => {
+        stopped = true;
+      },
+      (callback) => {
+        deferred = callback;
+      },
+    );
+    expect(stopped).toBe(false);
+    deferred?.();
+    expect(stopped).toBe(true);
+  });
+
+  it("yields to a later same-dispatch Escape handler", () => {
+    let deferred: (() => void) | undefined;
+    let stopped = false;
+    const event = escape() as KeyboardEvent & { defaultPrevented: boolean };
+    deferUnhandledEscape(
+      event,
+      () => {
+        stopped = true;
+      },
+      (callback) => {
+        deferred = callback;
+      },
+    );
+    Object.defineProperty(event, "defaultPrevented", { value: true });
+    deferred?.();
+    expect(stopped).toBe(false);
+  });
+
+  it("does not schedule an already-handled or repeated Escape", () => {
+    let scheduled = 0;
+    const defer = () => {
+      scheduled += 1;
+    };
+    deferUnhandledEscape(escape({ defaultPrevented: true }), () => {}, defer);
+    deferUnhandledEscape(escape({ repeat: true }), () => {}, defer);
+    expect(scheduled).toBe(0);
   });
 });

--- a/src/lib/tabKeys.ts
+++ b/src/lib/tabKeys.ts
@@ -16,6 +16,7 @@
  *   New terminal        cmd-`
  *   New terminal tab    shift-cmd-`
  *   Toggle terminal     cmd-j
+ *   Stop focused turn   escape
  */
 
 import type { FocusDir } from "./layout";
@@ -76,4 +77,75 @@ export function tabCommand(e: KeyboardEvent): TabCommand | null {
   if (key >= "1" && key <= "8") return { activate: Number(key) - 1 };
   if (key === "9") return { activate: -1 };
   return null;
+}
+
+type EscapeKeyEvent = Pick<
+  KeyboardEvent,
+  | "key"
+  | "isComposing"
+  | "defaultPrevented"
+  | "repeat"
+  | "metaKey"
+  | "ctrlKey"
+  | "altKey"
+  | "shiftKey"
+>;
+
+type EscapeFocusTab = {
+  id: string;
+  focusedId: string;
+  diffFocused?: boolean;
+};
+
+type EscapeFocusSession = {
+  id: string;
+  busy?: boolean;
+};
+
+function isPlainEscape(e: EscapeKeyEvent): boolean {
+  return (
+    e.key === "Escape" &&
+    !e.isComposing &&
+    !e.repeat &&
+    !e.metaKey &&
+    !e.ctrlKey &&
+    !e.altKey &&
+    !e.shiftKey
+  );
+}
+
+export function shouldStopFocusedTurnOnEscape(
+  e: EscapeKeyEvent,
+  options: { inTerminal: boolean; focusedSessionBusy: boolean },
+): boolean {
+  return (
+    isPlainEscape(e) &&
+    !e.defaultPrevented &&
+    !options.inTerminal &&
+    options.focusedSessionBusy
+  );
+}
+
+export function focusedBusyAgentSessionId(
+  activeTabId: string,
+  tabs: readonly EscapeFocusTab[],
+  sessions: readonly EscapeFocusSession[],
+  projectTerminalFocused: boolean,
+): string | null {
+  if (projectTerminalFocused) return null;
+  const tab = tabs.find((entry) => entry.id === activeTabId);
+  if (!tab || tab.diffFocused) return null;
+  const session = sessions.find((entry) => entry.id === tab.focusedId);
+  return session?.busy === true ? session.id : null;
+}
+
+export function deferUnhandledEscape(
+  e: EscapeKeyEvent,
+  run: () => void,
+  defer: (callback: () => void) => void = queueMicrotask,
+): void {
+  if (!isPlainEscape(e) || e.defaultPrevented) return;
+  defer(() => {
+    if (!e.defaultPrevented) run();
+  });
 }


### PR DESCRIPTION
## What changed

- makes plain Escape stop the active focused in-flight agent turn
- reuses the existing `onStop` path, including provider cancellation and local session cleanup
- never treats Escape as PTY cancellation; terminal panes keep normal terminal input
- yields to UI surfaces that already own Escape, including modals, pickers, search/editor controls, and drag/reorder cancellation
- only stops an actually busy agent pane; diff/editor/project-terminal focus, stale active tabs, held-key repeats, modifiers, and IME composition are ignored
- re-checks the active/focused busy session after the key event dispatch before stopping, so focus changes or a later Escape consumer win

## Why

Issue #4 was clarified to mean stopping an in-flight agent turn, not interrupting a shell command. PTY commands continue to use Ctrl+C; Escape becomes the quick stop shortcut for the active agent turn.

Fixes #4.

## UI

No layout or visual change, so there is no meaningful before/after screenshot.

## Verification

- exact head: `8add56753b527429ad9897f4b8a54620f442ad6d`
- exact upstream base: `2daf1a19649ed9eff87936fe60feb7ed4cad19d8` (MonoCode 0.1.27)
- one commit, three changed files; no unrelated repair code
- stable patch-id is unchanged across the final upstream rebase
- local `npm run check:web`: 94/94 test files, 1020/1020 tests
- targeted shortcut tests: 14/14 green
- `git diff --check`: clean
- exact-head GitHub CI: Ubuntu green and macOS green, including `npm test`, `tsc --noEmit`, `cargo fmt --check`, Clippy with `-D warnings`, `cargo check`, and `cargo test`
- negative-space review confirmed existing Escape consumers call `preventDefault`, so their behavior takes precedence over agent cancellation

## Checklist

- [x] Exact-head CI is green on all configured platforms
- [x] This PR is small and focused
- [x] I did not mix unrelated changes
