### PR TITLE
fix(chrome): restore development label helpers

### DIFF
--- a/src/chrome/TitleBar.tsx
+++ b/src/chrome/TitleBar.tsx
@@ -752,7 +752,7 @@ export function IconButton({
   );
 }
 
-function DevModeLabel() {
+export function DevModeLabel() {
   if (!import.meta.env.DEV) return null;
   return (
     <span
@@ -761,6 +761,14 @@ function DevModeLabel() {
     >
       Development
     </span>
+  );
+}
+
+export function DevModeSlot() {
+  return (
+    <div className="flex min-w-0 flex-1 items-center">
+      <DevModeLabel />
+    </div>
   );
 }
 
@@ -783,7 +791,6 @@ export function TabVisitNav({
 }) {
   return (
     <div className="flex min-w-0 items-center">
-      <DevModeLabel />
       <div className="flex shrink-0 items-center">
         <IconButton
           label={`Back (${MOD}[)`}


### PR DESCRIPTION
## What changed

- exports `DevModeLabel` for the new Sidebar import
- adds the missing `DevModeSlot` used by ProjectRail and Sidebar
- keeps the development badge in the explicit chrome slots instead of rendering it twice inside `TabVisitNav`

## Why

Current `main` at `0c63d7d` does not typecheck: `ProjectRail.tsx` and `Sidebar.tsx` import helpers that `TitleBar.tsx` does not export/define. This also causes PR CI based on the current merge ref to fail before reaching Rust checks.

## Verification

- `npm run check:web`: 93/93 test files, 985/985 tests
- `npx tsc --noEmit`: green
- `git diff --check`: green

This is intentionally separate from PR #44 so that shortcut PR stays scope-clean.