### PR TITLE
feat(inbox): show item status in the list and fix the status filter

### DIFF
--- a/src/chrome/icons.tsx
+++ b/src/chrome/icons.tsx
@@ -19,6 +19,7 @@ import BrainIcon from "@hugeicons/core-free-icons/BrainIcon";
 import Cancel01Icon from "@hugeicons/core-free-icons/Cancel01Icon";
 import CaseSensitiveIcon from "@hugeicons/core-free-icons/CaseSensitiveIcon";
 import CircleArrowDown01Icon from "@hugeicons/core-free-icons/CircleArrowDown01Icon";
+import CancelCircleIcon from "@hugeicons/core-free-icons/CancelCircleIcon";
 import CircleDashedIcon from "@hugeicons/core-free-icons/CircleDashedIcon";
 import CircleDotIcon from "@hugeicons/core-free-icons/CircleDotIcon";
 import CloudUploadIcon from "@hugeicons/core-free-icons/CloudUploadIcon";
@@ -40,6 +41,9 @@ import FolderOpenIcon from "@hugeicons/core-free-icons/FolderOpenIcon";
 import GaugeIcon from "@hugeicons/core-free-icons/GaugeIcon";
 import GitBranchIcon from "@hugeicons/core-free-icons/GitBranchIcon";
 import GitCompareIcon from "@hugeicons/core-free-icons/GitCompareIcon";
+import GitMergeIcon from "@hugeicons/core-free-icons/GitMergeIcon";
+import GitPullRequestClosedIcon from "@hugeicons/core-free-icons/GitPullRequestClosedIcon";
+import GitPullRequestDraftIcon from "@hugeicons/core-free-icons/GitPullRequestDraftIcon";
 import GitPullRequestIcon from "@hugeicons/core-free-icons/GitPullRequestIcon";
 import ImageAdd01Icon from "@hugeicons/core-free-icons/ImageAdd01Icon";
 import InboxIcon from "@hugeicons/core-free-icons/InboxIcon";
@@ -146,6 +150,7 @@ export const ChevronUp = wrap(ArrowUp01Icon, "ChevronUp");
 export const CircleAlert = wrap(AlertCircleIcon, "CircleAlert");
 export const CircleDashed = wrap(CircleDashedIcon, "CircleDashed");
 export const CircleDot = wrap(CircleDotIcon, "CircleDot");
+export const CircleX = wrap(CancelCircleIcon, "CircleX");
 export const CloudUpload = wrap(CloudUploadIcon, "CloudUpload");
 export const Copy = wrap(Copy01Icon, "Copy");
 export const ExternalLink = wrap(LinkSquare02Icon, "ExternalLink");
@@ -159,7 +164,16 @@ export const FolderPlus = wrap(FolderAddIcon, "FolderPlus");
 export const Gauge = wrap(GaugeIcon, "Gauge");
 export const GitBranch = wrap(GitBranchIcon, "GitBranch");
 export const GitCompare = wrap(GitCompareIcon, "GitCompare");
+export const GitMerge = wrap(GitMergeIcon, "GitMerge");
 export const GitPullRequest = wrap(GitPullRequestIcon, "GitPullRequest");
+export const GitPullRequestClosed = wrap(
+  GitPullRequestClosedIcon,
+  "GitPullRequestClosed",
+);
+export const GitPullRequestDraft = wrap(
+  GitPullRequestDraftIcon,
+  "GitPullRequestDraft",
+);
 export const GripVertical = wrap(DragDropVerticalIcon, "GripVertical");
 export const ImagePlus = wrap(ImageAdd01Icon, "ImagePlus");
 export const Inbox = wrap(InboxIcon, "Inbox");

--- a/src/lib/githubTasks.ts
+++ b/src/lib/githubTasks.ts
@@ -120,6 +120,9 @@ export type InboxListResult = {
 
 const INBOX_CACHE_FRESH_MS = 30_000;
 
+/** Closed history competes for the same slots, so an unfiltered fetch needs the wider page. */
+const INBOX_ALL_LIMIT = 100;
+
 type InboxListCache = InboxListResult & {
   key: string;
   fetchedAt: number;
@@ -204,6 +207,7 @@ export function listGithubWorkItems(
     assignedToMe: query.assignedToMe,
     state: query.state,
     search: query.search.trim(),
+    limit: query.state === "all" ? INBOX_ALL_LIMIT : undefined,
   });
 }
 
@@ -504,6 +508,7 @@ async function fetchLinearInboxItems(query: InboxQuery): Promise<InboxItem[]> {
     assignedToMe: query.assignedToMe,
     state: query.state,
     teamIds: teamIds ?? [],
+    limit: query.state === "all" ? INBOX_ALL_LIMIT : undefined,
   });
   const hidden = new Set(hiddenIds);
   return issues

--- a/src/lib/inboxFilters.test.ts
+++ b/src/lib/inboxFilters.test.ts
@@ -266,12 +266,36 @@ describe("hasActiveInboxFilters", () => {
 });
 
 describe("inboxFetchState", () => {
-  it("fetches open items unless closed or merged is selected", () => {
-    expect(inboxFetchState(DEFAULT_INBOX_FILTERS)).toBe("open");
+  it("fetches everything while no status is selected", () => {
+    expect(inboxFetchState(DEFAULT_INBOX_FILTERS)).toBe("all");
+  });
+
+  it("narrows to open once only open or draft is selected", () => {
+    expect(
+      inboxFetchState({
+        ...DEFAULT_INBOX_FILTERS,
+        status: { ...DEFAULT_INBOX_FILTERS.status, open: true },
+      }),
+    ).toBe("open");
+    expect(
+      inboxFetchState({
+        ...DEFAULT_INBOX_FILTERS,
+        status: { ...DEFAULT_INBOX_FILTERS.status, draft: true },
+      }),
+    ).toBe("open");
+  });
+
+  it("widens to all when closed or merged is selected", () => {
     expect(
       inboxFetchState({
         ...DEFAULT_INBOX_FILTERS,
         status: { ...DEFAULT_INBOX_FILTERS.status, closed: true },
+      }),
+    ).toBe("all");
+    expect(
+      inboxFetchState({
+        ...DEFAULT_INBOX_FILTERS,
+        status: { ...DEFAULT_INBOX_FILTERS.status, open: true, merged: true },
       }),
     ).toBe("all");
   });

--- a/src/lib/inboxFilters.ts
+++ b/src/lib/inboxFilters.ts
@@ -135,9 +135,11 @@ export function hasActiveInboxFilters(
   );
 }
 
+/** No status box checked means "no restriction", so the fetch has to widen with it. */
 export function inboxFetchState(filters: InboxFilters): "open" | "all" {
-  if (filters.status.closed || filters.status.merged) return "all";
-  return "open";
+  const { open, draft, closed, merged } = filters.status;
+  if (closed || merged) return "all";
+  return open || draft ? "open" : "all";
 }
 
 export function filterInboxByProject(

--- a/src/lib/linear.ts
+++ b/src/lib/linear.ts
@@ -101,11 +101,13 @@ export function listLinearIssues(query: {
   assignedToMe: boolean;
   state: "open" | "all";
   teamIds: string[];
+  limit?: number;
 }): Promise<LinearIssue[]> {
   return invoke<LinearIssue[]>("linear_list_issues", {
     assignedToMe: query.assignedToMe,
     state: query.state,
     teamIds: query.teamIds,
+    limit: query.limit,
   });
 }
 

--- a/src/surfaces/InboxView.tsx
+++ b/src/surfaces/InboxView.tsx
@@ -2,14 +2,19 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   ChevronDown,
   CircleDot,
+  CircleX,
   ExternalLink,
   GitCompare,
+  GitMerge,
   GitPullRequest,
+  GitPullRequestClosed,
+  GitPullRequestDraft,
   Inbox,
   ListFilter,
   LoaderCircle,
   RefreshCw,
   Search,
+  type IconComponent,
 } from "../chrome/icons";
 import {
   useEffect,
@@ -731,6 +736,40 @@ function InboxDetailBody({
   );
 }
 
+type InboxStatusMark = {
+  Icon: IconComponent;
+  className: string;
+  label: string;
+};
+
+/** Status reads from the glyph first and the color second, so it survives color blindness. */
+function inboxStatusMark(item: InboxItem): InboxStatusMark {
+  const label = inboxItemStatus(item);
+  const pr = item.kind === "pr";
+  if (label === "Draft") {
+    return {
+      Icon: GitPullRequestDraft,
+      className: "text-content/50",
+      label,
+    };
+  }
+  if (label === "Merged") {
+    return { Icon: GitMerge, className: "text-violet-400/90", label };
+  }
+  if (label === "Closed") {
+    return {
+      Icon: pr ? GitPullRequestClosed : CircleX,
+      className: "text-rose-400/90",
+      label,
+    };
+  }
+  return {
+    Icon: pr ? GitPullRequest : CircleDot,
+    className: "text-emerald-400/90",
+    label,
+  };
+}
+
 function InboxCard({
   item,
   active,
@@ -747,7 +786,8 @@ function InboxCard({
   onSelect: () => void;
 }) {
   useInboxSeenTick();
-  const KindIcon = item.kind === "pr" ? GitPullRequest : CircleDot;
+  const status = inboxStatusMark(item);
+  const kindLabel = item.kind === "pr" ? "Pull request" : "Issue";
   const time = formatRelativeTime(item.updatedAt);
   const name = projectName(item.projectPath);
   const linear = item.provider === "linear";
@@ -762,7 +802,9 @@ function InboxCard({
       type="button"
       title={item.title}
       aria-current={active ? "true" : undefined}
-      aria-label={unseen ? `${item.title}, new` : undefined}
+      aria-label={`${status.label} ${kindLabel.toLowerCase()} ${inboxItemRef(
+        item,
+      )}: ${item.title}${unseen ? ", new" : ""}`}
       onClick={onSelect}
       className={`flex w-full flex-col rounded-md border px-2.5 py-2 text-left ${
         active
@@ -776,13 +818,12 @@ function InboxCard({
             provider={item.provider}
             className="size-3.5 shrink-0"
           />
-          <KindIcon
-            className="size-3 shrink-0 text-content/45"
+          <status.Icon
+            className={`size-3 shrink-0 ${status.className}`}
             strokeWidth={1.75}
           />
           <span className="min-w-0 truncate text-[11px] text-content/50">
-            {item.kind === "pr" ? "Pull request" : "Issue"} ·{" "}
-            {inboxItemRef(item)}
+            {kindLabel} · {inboxItemRef(item)}
           </span>
         </span>
         {time || unseen ? (
@@ -886,15 +927,7 @@ function InboxDetail({
   const status = linear
     ? item.state || inboxItemStatus(item)
     : inboxItemStatus(item);
-  const statusKind = inboxItemStatus(item);
-  const statusClass =
-    statusKind === "Open"
-      ? "text-emerald-400/90"
-      : statusKind === "Draft"
-        ? "text-content/50"
-        : statusKind === "Merged"
-          ? "text-violet-400/90"
-          : "text-content/45";
+  const statusMark = inboxStatusMark(item);
 
   const source = linear
     ? item.teamName || item.repo
@@ -1115,7 +1148,10 @@ function InboxDetail({
           <InboxProviderMark provider={item.provider} className="size-3.5" />
           <span>{item.kind === "pr" ? "Pull request" : "Issue"}</span>
           <span className="tabular-nums">{inboxItemRef(item)}</span>
-          <span className={statusClass}>{status}</span>
+          <span className={`flex items-center gap-1 ${statusMark.className}`}>
+            <statusMark.Icon className="size-3.5" strokeWidth={1.75} />
+            {status}
+          </span>
           {source ? <span className="truncate">{source}</span> : null}
         </div>
         <h1 className="text-[20px] font-semibold leading-tight text-content">


### PR DESCRIPTION
Two related inbox changes: the list never showed an item's status, and the status filter briefly showed the right list before snapping back.

## Status in the list

Every row drew the same neutral kind icon, so open, draft, merged and closed items looked identical until you opened one. The icon now carries the status in both its glyph and its colour:

| Status | Icon | Colour |
| --- | --- | --- |
| Open | `GitPullRequest` / `CircleDot` | green |
| Draft | `GitPullRequestDraft` | grey |
| Merged | `GitMerge` | purple |
| Closed | `GitPullRequestClosed` / `CircleX` | red |

The glyph changes with the status, so the meaning survives colour blindness, and the card's `aria-label` now names the status for screen readers. The detail header reuses the same map, which also gives closed items their own colour instead of the grey they used to share with drafts.

![Inbox list with status colours](https://raw.githubusercontent.com/emircan-sahin/monocode/assets/inbox-status/inbox-status.png)

## Filter no longer snaps back to open

`filterInboxByStatus` reads an empty status filter as "no restriction", but `inboxFetchState` asked the providers for open items only unless Closed or Merged was checked. The two layers disagreed, so unchecking Merged rendered the previous `all` response unfiltered and then, a moment later, replaced it with an open-only refetch.

The fetch now widens with the filter:

- nothing checked -> `all`
- only Open and/or Draft checked -> `open`
- Closed or Merged checked -> `all`

Because an unfiltered fetch competes with closed history for the same page, `all` now asks for 100 rows instead of 40 (`INBOX_ALL_LIMIT`, passed to both GitHub and Linear), so open work is not crowded out of the inbox.

One consequence worth flagging: the inbox unseen badge runs the same query, so with no status filter it can now light up for merged and closed activity too. That keeps the badge consistent with what the list shows, but happy to pin it to open items if you would rather it stayed quiet.

## Testing

`npm run check:web` - 1047 tests pass, `tsc --noEmit` clean.
