### PR TITLE
Show, stop and message Claude Code subagents from a panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Claude Code subagents get their own panel. A strip above the composer shows how many are running and what the first one is doing, and opens a right-hand drawer that lists every run as a tree (nested spawns under their parent) with activity, tokens and elapsed time. Selecting a run shows its brief and its own transcript — text, thinking and tool calls — plus a reply box that relays a message through the main agent. Stop one run or Stop all; the button reads "Stopping…" until Claude confirms, and a refusal is written to the transcript instead of vanishing. The turn footer counts the subagents each turn spawned and opens the panel on click. Claude only; other harnesses are unchanged. Subagent transcripts are kept for the session, not persisted.
+
 - Settings → General → Diff view: Editor or Unified. Unified stacks every working-tree change in one **Changes** tab — GitHub-style review, editor syntax colours, sticky file headers and line numbers, and a single horizontal scroll that stops at the end of the line. Editor keeps the previous per-file working-tree tabs.
+
+### Fixed
+
+- Claude subagents no longer appear as several transcript rows. Progress and background-task updates named the agent's current activity ("Running find …"), and each one was mistaken for a new agent.
 
 ## [0.1.29] - 2026-09-02
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,12 +121,15 @@ import {
   sendHarnessTurn,
   steerHarnessTurn,
   startHarnessBridge,
+  stopHarnessAgent,
+  harnessAgentRelayPrompt,
   stopStreaming,
   pickTextHarness,
   type ApprovalDecision,
   type HarnessEvent,
   type UserQuestionReply,
 } from "./lib/harness";
+import { isAgentEvent } from "./lib/harness/agentRuns";
 import {
   appendPreparingHandoff,
   buildDeterministicHandoff,
@@ -200,6 +203,7 @@ import {
   sessionDisplayTitle,
   sessionWorkCwd,
   titleFromPrompt,
+  type AgentRun,
   type Attachment,
   type Block,
   type HarnessId,
@@ -3227,7 +3231,13 @@ export default function App({
               : prompt,
             attachments: prepared,
             onEvent: (event) => {
-              if (turnGen.current.get(sessionId) !== gen) return;
+              if (turnGen.current.get(sessionId) !== gen) {
+                // Stop bumps the generation before the harness has answered,
+                // and subagents can outlive the turn. Their lifecycle is not
+                // turn output: drop it and Stop leaves runs "running" forever.
+                if (isAgentEvent(event)) enqueueHarnessEvent(sessionId, event);
+                return;
+              }
               if (
                 wrap &&
                 (event.type === "session.started" ||
@@ -3443,6 +3453,34 @@ export default function App({
       }
     },
     [flushHarnessEvents],
+  );
+
+  const onStopAgent = useCallback(
+    (sessionId: string, agent: AgentRun) => {
+      const session = sessionsRef.current.find((s) => s.id === sessionId);
+      if (!session) return;
+      // A refusal used to vanish, which is what made Stop look like a no-op.
+      void stopHarnessAgent(session.harness, sessionId, agent).catch((error: unknown) => {
+        enqueueHarnessEvent(sessionId, {
+          type: "status",
+          text: `Could not stop "${agent.title}": ${
+            error instanceof Error ? error.message : "Claude refused."
+          }`,
+        });
+        flushHarnessEvents();
+      });
+    },
+    [enqueueHarnessEvent, flushHarnessEvents],
+  );
+
+  const onMessageAgent = useCallback(
+    (sessionId: string, agent: AgentRun, text: string) => {
+      const session = sessionsRef.current.find((s) => s.id === sessionId);
+      if (!session) return;
+      const prompt = harnessAgentRelayPrompt(session.harness, agent, text);
+      if (prompt) onSubmit(sessionId, prompt);
+    },
+    [onSubmit],
   );
 
   const onApproval = useCallback(
@@ -4164,6 +4202,8 @@ export default function App({
                       onHandoff={onHandoff}
                       onMovePane={onMovePane}
                       onNewTerminal={onNewTerminalInSession}
+                      onStopAgent={onStopAgent}
+                      onMessageAgent={onMessageAgent}
                       onTerminalMetaChange={onTerminalMetaChange}
                     />
                   </div>

--- a/src/lib/agentRelay.ts
+++ b/src/lib/agentRelay.ts
@@ -1,0 +1,19 @@
+import type { AgentRun } from "./session";
+
+/**
+ * There is no channel from a host to a running subagent — the CLI's control
+ * protocol has no such request, and the only address a subagent answers on is
+ * SendMessage, which belongs to the model. So a reply from the agents panel is
+ * an instruction to the main agent, written plainly enough that it forwards the
+ * message instead of acting on it.
+ */
+export function buildAgentRelayPrompt(agent: AgentRun, text: string): string {
+  const target = agent.address
+    ? `the running subagent "${agent.title}" (SendMessage to: "${agent.address}")`
+    : `the running subagent "${agent.title}"`;
+  return [
+    `Forward this message to ${target} with the SendMessage tool. Do not act on it yourself, and do not summarize it — pass it through as written.`,
+    "",
+    text,
+  ].join("\n");
+}

--- a/src/lib/harness/agentRuns.test.ts
+++ b/src/lib/harness/agentRuns.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { applyHarnessEvent } from "./apply";
+import { newSession, type Session } from "../session";
+
+function base(): Session {
+  return newSession("claude");
+}
+
+function run(session: Session, ...events: Parameters<typeof applyHarnessEvent>[1][]) {
+  return events.reduce(applyHarnessEvent, session);
+}
+
+describe("agent runs", () => {
+  it("keeps a subagent's text out of the main transcript", () => {
+    const session = run(
+      base(),
+      { type: "agent.started", agentId: "a1", title: "Explore" },
+      { type: "agent.output", agentId: "a1", kind: "assistant", text: "hello" },
+    );
+    expect(session.blocks).toHaveLength(0);
+    expect(session.agents?.[0].blocks[0].text).toBe("hello");
+  });
+
+  it("joins streamed deltas into one block", () => {
+    const session = run(
+      base(),
+      { type: "agent.started", agentId: "a1", title: "Explore" },
+      { type: "agent.output", agentId: "a1", kind: "assistant", text: "one " },
+      { type: "agent.output", agentId: "a1", kind: "assistant", text: "two" },
+    );
+    expect(session.agents?.[0].blocks).toHaveLength(1);
+    expect(session.agents?.[0].blocks[0].text).toBe("one two");
+  });
+
+  it("upserts a tool call by id instead of stacking rows", () => {
+    const session = run(
+      base(),
+      { type: "agent.started", agentId: "a1", title: "Explore" },
+      {
+        type: "agent.tool",
+        agentId: "a1",
+        callId: "t1",
+        title: "Grep token",
+        status: "pending",
+      },
+      {
+        type: "agent.tool",
+        agentId: "a1",
+        callId: "t1",
+        title: "Grep token",
+        status: "completed",
+        detail: "3 matches",
+      },
+    );
+    const blocks = session.agents?.[0].blocks ?? [];
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].tool?.status).toBe("completed");
+    expect(blocks[0].streaming).toBe(false);
+  });
+
+  it("settles a finished run and seals whatever it was streaming", () => {
+    const session = run(
+      base(),
+      { type: "agent.started", agentId: "a1", title: "Explore" },
+      { type: "agent.output", agentId: "a1", kind: "assistant", text: "hi" },
+      {
+        type: "agent.updated",
+        agentId: "a1",
+        status: "completed",
+        summary: "Found it",
+        tokens: 900,
+      },
+    );
+    const agent = session.agents?.[0];
+    expect(agent?.status).toBe("completed");
+    expect(agent?.summary).toBe("Found it");
+    expect(agent?.tokens).toBe(900);
+    expect(agent?.endedAt).toBeGreaterThan(0);
+    expect(agent?.blocks.every((block) => !block.streaming)).toBe(true);
+  });
+
+  it("ages out finished runs before live ones", () => {
+    let session = base();
+    for (let i = 0; i < 60; i++) {
+      session = run(session, {
+        type: "agent.started",
+        agentId: `a${i}`,
+        title: `Run ${i}`,
+      });
+      // Every run but the first two settles, so the cap has settled runs to
+      // drop and never has to touch the two that are still going.
+      if (i > 1) {
+        session = run(session, {
+          type: "agent.updated",
+          agentId: `a${i}`,
+          status: "completed",
+        });
+      }
+    }
+    expect(session.agents).toHaveLength(50);
+    expect(session.agents?.map((agent) => agent.id)).toContain("a0");
+    expect(session.agents?.map((agent) => agent.id)).toContain("a1");
+    expect(session.agents?.map((agent) => agent.id)).toContain("a59");
+  });
+
+  it("ignores updates for a run it never saw start", () => {
+    const session = applyHarnessEvent(base(), {
+      type: "agent.updated",
+      agentId: "ghost",
+      status: "completed",
+    });
+    expect(session.agents).toBeUndefined();
+  });
+
+  it("re-announcing a run patches its header without losing the transcript", () => {
+    const session = run(
+      base(),
+      { type: "agent.started", agentId: "a1", title: "Subagent" },
+      { type: "agent.output", agentId: "a1", kind: "assistant", text: "hi" },
+      {
+        type: "agent.started",
+        agentId: "a1",
+        title: "Explore the auth module",
+        taskId: "t1",
+        agentType: "explore",
+        depth: 1,
+      },
+    );
+    const agent = session.agents?.[0];
+    expect(session.agents).toHaveLength(1);
+    expect(agent?.title).toBe("Explore the auth module");
+    expect(agent?.taskId).toBe("t1");
+    expect(agent?.agentType).toBe("explore");
+    expect(agent?.blocks).toHaveLength(1);
+  });
+
+  it("flags a run as stopping until the harness settles it", () => {
+    let session = applyHarnessEvent(base(), {
+      type: "agent.started",
+      agentId: "a1",
+      title: "Explore",
+    });
+    session = applyHarnessEvent(session, {
+      type: "agent.updated",
+      agentId: "a1",
+      stopping: true,
+    });
+    expect(session.agents?.[0]).toMatchObject({ status: "running", stopping: true });
+    session = applyHarnessEvent(session, {
+      type: "agent.updated",
+      agentId: "a1",
+      status: "stopped",
+    });
+    expect(session.agents?.[0].status).toBe("stopped");
+    expect(session.agents?.[0].stopping).toBeUndefined();
+  });
+});

--- a/src/lib/harness/agentRuns.ts
+++ b/src/lib/harness/agentRuns.ts
@@ -1,0 +1,241 @@
+import type { AgentRun, Block, Session } from "../session";
+import { mergeToolPreview } from "./preview";
+import { joinStreamText } from "./streamText";
+import type { HarnessEvent } from "./types";
+
+export type AgentHarnessEvent = Extract<
+  HarnessEvent,
+  { type: "agent.started" | "agent.updated" | "agent.output" | "agent.tool" }
+>;
+
+/**
+ * A runaway subagent can write for minutes before anyone opens its panel, and
+ * its transcript is never persisted, so the cap is about the app's memory, not
+ * about what a reader can scroll. Oldest blocks fall off the front.
+ */
+const MAX_AGENT_BLOCKS = 400;
+
+/**
+ * A long session can spawn hundreds of subagents, each holding a transcript.
+ * Finished runs age out first so a live one is never dropped out from under
+ * the panel someone is reading.
+ */
+const MAX_AGENT_RUNS = 50;
+
+export function isAgentEvent(event: HarnessEvent): event is AgentHarnessEvent {
+  return (
+    event.type === "agent.started" ||
+    event.type === "agent.updated" ||
+    event.type === "agent.output" ||
+    event.type === "agent.tool"
+  );
+}
+
+export function applyAgentEvent(
+  session: Session,
+  event: AgentHarnessEvent,
+): Session {
+  const agents = session.agents ?? [];
+  const index = agents.findIndex((agent) => agent.id === event.agentId);
+
+  if (index < 0) {
+    if (event.type !== "agent.started") return session;
+    return {
+      ...session,
+      agents: capRuns([...agents, startedRun(event)]),
+    };
+  }
+
+  const next = patchRun(agents[index], event);
+  if (next === agents[index]) return session;
+  const list = agents.slice();
+  list[index] = next;
+  return { ...session, agents: list };
+}
+
+function capRuns(runs: AgentRun[]): AgentRun[] {
+  if (runs.length <= MAX_AGENT_RUNS) return runs;
+  let over = runs.length - MAX_AGENT_RUNS;
+  const kept = runs.filter((agent) => {
+    if (over > 0 && agent.status !== "running") {
+      over -= 1;
+      return false;
+    }
+    return true;
+  });
+  // Every run is still live: drop the oldest anyway rather than grow forever.
+  return over > 0 ? kept.slice(over) : kept;
+}
+
+function startedRun(
+  event: Extract<AgentHarnessEvent, { type: "agent.started" }>,
+): AgentRun {
+  return {
+    id: event.agentId,
+    title: event.title,
+    status: "running",
+    startedAt: Date.now(),
+    blocks: [],
+    ...(event.callId ? { callId: event.callId } : {}),
+    ...(event.taskId ? { taskId: event.taskId } : {}),
+    ...(event.agentType ? { agentType: event.agentType } : {}),
+    ...(event.depth ? { depth: event.depth } : {}),
+    ...(event.prompt ? { prompt: event.prompt } : {}),
+    ...(event.parentId ? { parentId: event.parentId } : {}),
+  };
+}
+
+function patchRun(run: AgentRun, event: AgentHarnessEvent): AgentRun {
+  switch (event.type) {
+    case "agent.started":
+      // A resumed or re-announced task; keep the transcript it already wrote.
+      return {
+        ...run,
+        title: event.title || run.title,
+        status: "running",
+        ...(event.callId ? { callId: event.callId } : {}),
+        ...(event.taskId ? { taskId: event.taskId } : {}),
+        ...(event.agentType ? { agentType: event.agentType } : {}),
+        ...(event.depth ? { depth: event.depth } : {}),
+        ...(event.prompt ? { prompt: event.prompt } : {}),
+        ...(event.parentId ? { parentId: event.parentId } : {}),
+      };
+    case "agent.updated":
+      return updateRun(run, event);
+    case "agent.output":
+      return {
+        ...run,
+        blocks: appendOutput(run.blocks, event.kind, event.text),
+      };
+    case "agent.tool":
+      return { ...run, blocks: upsertAgentTool(run.blocks, event) };
+  }
+}
+
+function updateRun(
+  run: AgentRun,
+  event: Extract<AgentHarnessEvent, { type: "agent.updated" }>,
+): AgentRun {
+  const status = event.status ?? run.status;
+  const settled = status !== "running";
+  const next: AgentRun = {
+    ...run,
+    status,
+    title: event.title || run.title,
+    ...(event.activity ? { activity: event.activity } : {}),
+    ...(event.summary ? { summary: event.summary } : {}),
+    ...(event.tokens != null ? { tokens: event.tokens } : {}),
+    ...(event.toolUses != null ? { toolUses: event.toolUses } : {}),
+    ...(event.address ? { address: event.address } : {}),
+    ...(settled && run.endedAt == null ? { endedAt: Date.now() } : {}),
+  };
+  const stopping = settled ? false : (event.stopping ?? run.stopping ?? false);
+  if (stopping) next.stopping = true;
+  else delete next.stopping;
+  if (settled) next.blocks = sealBlocks(next.blocks);
+  return sameRun(run, next) ? run : next;
+}
+
+function sameRun(a: AgentRun, b: AgentRun): boolean {
+  return (
+    a.status === b.status &&
+    a.title === b.title &&
+    a.activity === b.activity &&
+    a.summary === b.summary &&
+    a.tokens === b.tokens &&
+    a.toolUses === b.toolUses &&
+    a.address === b.address &&
+    a.stopping === b.stopping &&
+    a.endedAt === b.endedAt &&
+    a.blocks === b.blocks
+  );
+}
+
+function trim(blocks: Block[]): Block[] {
+  return blocks.length > MAX_AGENT_BLOCKS
+    ? blocks.slice(blocks.length - MAX_AGENT_BLOCKS)
+    : blocks;
+}
+
+function sealBlocks(blocks: Block[]): Block[] {
+  if (!blocks.some((block) => block.streaming)) return blocks;
+  return blocks.map((block) =>
+    block.streaming ? { ...block, streaming: false } : block,
+  );
+}
+
+function appendOutput(
+  blocks: Block[],
+  role: "assistant" | "reasoning",
+  text: string,
+): Block[] {
+  if (!text) return blocks;
+  const last = blocks[blocks.length - 1];
+  if (last?.role === role) {
+    const joined = joinStreamText(last.text, text);
+    if (joined === last.text) return blocks;
+    const next = blocks.slice();
+    next[next.length - 1] = { ...last, text: joined, streaming: true };
+    return next;
+  }
+  return trim([
+    ...sealBlocks(blocks),
+    { id: crypto.randomUUID(), role, text, streaming: true },
+  ]);
+}
+
+function upsertAgentTool(
+  blocks: Block[],
+  event: Extract<AgentHarnessEvent, { type: "agent.tool" }>,
+): Block[] {
+  const streaming = event.status !== "completed" && event.status !== "failed";
+  const index = blocks.findIndex(
+    (block) => block.tool?.callId === event.callId,
+  );
+  if (index < 0) {
+    return trim([
+      ...sealBlocks(blocks),
+      {
+        id: crypto.randomUUID(),
+        role: "tool",
+        text: event.title,
+        streaming,
+        tool: {
+          callId: event.callId,
+          title: event.title,
+          ...(event.kind ? { kind: event.kind } : {}),
+          ...(event.status ? { status: event.status } : {}),
+          ...(event.detail ? { detail: event.detail } : {}),
+          ...(event.preview ? { preview: event.preview } : {}),
+        },
+      },
+    ]);
+  }
+  const prev = blocks[index];
+  const preview = mergeToolPreview(event.preview, prev.tool?.preview);
+  const next = blocks.slice();
+  next[index] = {
+    ...prev,
+    text: event.title || prev.text,
+    streaming,
+    tool: {
+      ...prev.tool,
+      callId: event.callId,
+      title: event.title || prev.tool?.title,
+      kind: event.kind ?? prev.tool?.kind,
+      status: event.status ?? prev.tool?.status,
+      detail: event.detail ?? prev.tool?.detail,
+      ...(preview ? { preview } : {}),
+    },
+  };
+  return next;
+}
+
+/**
+ * What a harness can address a running subagent by. Claude's `stop_task`
+ * takes the task id, and the SendMessage address is the same id (measured),
+ * so a run seen only through forwarded frames still has a handle.
+ */
+export function stoppableId(agent: AgentRun): string | undefined {
+  return agent.taskId ?? agent.address;
+}

--- a/src/lib/harness/apply.ts
+++ b/src/lib/harness/apply.ts
@@ -1,5 +1,6 @@
 import type { Attachment, Block, Session, ToolPreview } from "../session";
 import { mergeContextUsage } from "../contextUsage";
+import { applyAgentEvent, isAgentEvent } from "./agentRuns";
 import { displayPath } from "../paths";
 import {
   composeToolTitle,
@@ -15,6 +16,7 @@ export function applyHarnessEvent(
   session: Session,
   event: HarnessEvent,
 ): Session {
+  if (isAgentEvent(event)) return applyAgentEvent(session, event);
   switch (event.type) {
     case "message.delta":
       return patchStreaming(session, "assistant", event.text, true);

--- a/src/lib/harness/claude.ts
+++ b/src/lib/harness/claude.ts
@@ -12,6 +12,7 @@ import {
 import {
   askUserQuestionAllowInput,
   assistantTextBlocks,
+  assistantThinkingBlocks,
   assistantToolUses,
   contextFromResult,
   contextUsedFromAssistant,
@@ -19,6 +20,8 @@ import {
   buildClaudeUserMessage,
   buildControlRequest,
   buildControlResponse,
+  buildInitializeRequest,
+  buildStopTaskRequest,
   claudeSettingsKey,
   extractAskUserQuestionTitle,
   extractExitPlanModePlan,
@@ -32,6 +35,7 @@ import {
   parseBackgroundAgentTasks,
   parseControlCancelId,
   parseControlRequest,
+  parseControlResponse,
   parseJsonLine,
   parseTaskNotification,
   parseTaskProgress,
@@ -42,7 +46,9 @@ import {
   previewFromTool,
   resolveClaudeApiModelId,
   runtimeModeToPermission,
+  sendMessageAddress,
   sessionIdFromMessage,
+  subagentParentId,
   statusTextFromSystem,
   streamDeltaFromEvent,
   stringField,
@@ -56,6 +62,7 @@ import {
   turnStatusFromResult,
   type ClaudeCliSettings,
   type ClaudeControlRequest,
+  type ClaudeControlResponse,
 } from "./claudeProtocol";
 import { isAgentToolName } from "./preview";
 import { joinStreamText, snapshotRemainder } from "./streamText";
@@ -99,6 +106,25 @@ type LiveAgentTask = {
   backgrounded: boolean;
 };
 
+/**
+ * A subagent as the agents panel sees it. Keyed by the Agent tool call that
+ * spawned it, because that is the only id a forwarded subagent frame carries;
+ * the task id arrives separately and only some of the time.
+ */
+type LiveAgentRun = {
+  id: string;
+  title: string;
+  taskId?: string;
+  parentId?: string;
+  settled: boolean;
+  /** Same snapshot-versus-token bookkeeping the main transcript does, per run. */
+  emittedAssistant: string;
+  emittedReasoning: string;
+};
+
+/** A tool call inside a subagent. Indexes repeat across concurrent runs. */
+type SubagentTool = InFlightTool & { agentId: string };
+
 type Live = {
   cwd: string;
   claudeSessionId: string;
@@ -112,6 +138,16 @@ type Live = {
   toolsByIndex: Map<number, InFlightTool>;
   toolsById: Map<string, InFlightTool>;
   agentTasks: Map<string, LiveAgentTask>;
+  agents: Map<string, LiveAgentRun>;
+  /** Harness task id → agent run id, for the lifecycle events that only name a task. */
+  agentByTask: Map<string, string>;
+  subTools: Map<string, SubagentTool>;
+  /** Keyed `${parentToolUseId}#${index}`: block indexes are per message, not global. */
+  subToolsByIndex: Map<string, SubagentTool>;
+  /** Control requests we still want the CLI's verdict on, by request id. */
+  pendingControls: Map<string, (response: ClaudeControlResponse) => void>;
+  /** Task ids the CLI last reported as live in the background. */
+  backgroundTaskIds: Set<string>;
   turnResultSeen: boolean;
   cancelled: boolean;
   muteUpdates: boolean;
@@ -220,6 +256,10 @@ export async function cancelClaudeTurn(sessionId: string): Promise<void> {
   live.approvals.clear();
   for (const [, pending] of live.questions) pending.resolve({ kind: "skipped" });
   live.questions.clear();
+  // Declaring `perTaskStopAffordance` means an interrupt now spares background
+  // agents. Stop has always meant "stop everything", so end them explicitly
+  // rather than quietly leaving a subagent burning tokens after Stop.
+  const stops = stopLiveAgents(sessionId, live);
   await writeJson(
     sessionId,
     buildControlRequest(nextControlId(live), { subtype: "interrupt" }),
@@ -228,6 +268,132 @@ export async function cancelClaudeTurn(sessionId: string): Promise<void> {
     { type: "message.completed" },
     { type: "reasoning.completed" },
   ]);
+  await stops;
+}
+
+/**
+ * Asks the CLI to stop every live subagent, leaves first. The requests go out
+ * together and are only awaited after the interrupt is written, so a slow
+ * answer cannot hold the interrupt back — but each verdict is still read:
+ * settling a run on our own say-so is how a refused stop once showed as done.
+ */
+async function stopLiveAgents(sessionId: string, live: Live): Promise<void> {
+  const roots = [...live.agents.values()].filter((run) => !run.parentId);
+  const ordered = roots.flatMap((run) => [...descendants(live, run.id), run]);
+  const pending = ordered
+    .filter((run) => !run.settled && run.taskId)
+    .map((run) => stopOne(sessionId, live, run));
+  await Promise.all(pending);
+}
+
+/** One stop_task, with the run flagged as stopping until the CLI answers. */
+async function stopOne(
+  sessionId: string,
+  live: Live,
+  run: LiveAgentRun,
+): Promise<ClaudeControlResponse> {
+  markStopping(live, run.id, true);
+  const result = await sendControl(
+    sessionId,
+    live,
+    buildStopTaskRequest(run.taskId!),
+  );
+  if (result.ok) settleAgent(live, run.id, "stopped");
+  else markStopping(live, run.id, false);
+  return result;
+}
+
+function markStopping(live: Live, id: string, stopping: boolean): void {
+  const run = live.agents.get(id);
+  if (!run || run.settled) return;
+  live.onEvent({ type: "agent.updated", agentId: id, stopping });
+}
+
+/**
+ * Stops one subagent without touching the turn around it. The session declares
+ * `perTaskStopAffordance` at initialize, which is what keeps a plain Stop from
+ * killing background agents — so this is now the only way to end one early.
+ */
+export async function stopClaudeAgent(
+  sessionId: string,
+  taskId: string,
+): Promise<void> {
+  const live = liveByThread.get(sessionId);
+  if (!live) {
+    throw new Error("This session's Claude process is no longer running.");
+  }
+  // The CLI does not stop a subagent's own subagents with it — measured: two
+  // nested agents kept reporting progress after their parent was killed. So
+  // stop the tree from the leaves up, or Stop leaves orphans burning tokens.
+  const root = [...live.agents.values()].find((run) => run.taskId === taskId);
+  for (const child of descendants(live, root?.id)) {
+    if (child.settled || !child.taskId) continue;
+    const result = await stopOne(sessionId, live, child);
+    if (!result.ok) {
+      throw new Error(
+        `${child.title}: ${result.error ?? "Claude refused to stop it."}`,
+      );
+    }
+  }
+  const result = root
+    ? await stopOne(sessionId, live, root)
+    : await sendControl(sessionId, live, buildStopTaskRequest(taskId));
+  if (!result.ok) throw new Error(result.error ?? "Claude refused to stop it.");
+}
+
+/** Runs spawned under `id`, deepest first, so a parent is stopped last. */
+function descendants(live: Live, id: string | undefined): LiveAgentRun[] {
+  if (!id) return [];
+  const out: LiveAgentRun[] = [];
+  for (const run of live.agents.values()) {
+    if (run.parentId !== id) continue;
+    out.push(...descendants(live, run.id), run);
+  }
+  return out;
+}
+
+const CONTROL_TIMEOUT_MS = 10_000;
+
+/**
+ * A control request whose verdict we actually read. Fire-and-forget was how a
+ * refused `stop_task` turned into a button that looked broken: the CLI answered
+ * with an error and nothing was listening.
+ */
+async function sendControl(
+  sessionId: string,
+  live: Live,
+  request: Record<string, unknown>,
+): Promise<ClaudeControlResponse> {
+  const requestId = nextControlId(live);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const settled = new Promise<ClaudeControlResponse>((resolve) => {
+    live.pendingControls.set(requestId, (response) => {
+      clearTimeout(timer);
+      resolve(response);
+    });
+    timer = setTimeout(() => {
+      if (!live.pendingControls.delete(requestId)) return;
+      resolve({
+        requestId,
+        ok: false,
+        payload: null,
+        error: "Claude did not answer in time.",
+      });
+    }, CONTROL_TIMEOUT_MS);
+  });
+  try {
+    await writeJson(sessionId, buildControlRequest(requestId, request));
+  } catch {
+    clearTimeout(timer);
+    live.pendingControls.delete(requestId);
+    return {
+      requestId,
+      ok: false,
+      payload: null,
+      error: "Could not reach the Claude process.",
+    };
+  }
+  return settled;
 }
 
 export async function stopClaudeSession(sessionId: string): Promise<void> {
@@ -307,6 +473,12 @@ async function ensureLive(input: SendTurnInput): Promise<Live> {
     toolsByIndex: new Map(),
     toolsById: new Map(),
     agentTasks: new Map(),
+    agents: new Map(),
+    agentByTask: new Map(),
+    subTools: new Map(),
+    subToolsByIndex: new Map(),
+    pendingControls: new Map(),
+    backgroundTaskIds: new Set(),
     turnResultSeen: false,
     cancelled: false,
     muteUpdates: false,
@@ -331,6 +503,12 @@ async function ensureLive(input: SendTurnInput): Promise<Live> {
     },
     (code) => {
       liveByThread.delete(input.sessionId);
+      const exiting = liveRef.current;
+      // Nothing outlives the CLI process, so a run still marked running here
+      // would spin in the agents panel forever.
+      if (exiting) {
+        for (const id of exiting.agents.keys()) settleAgent(exiting, id, "stopped");
+      }
       input.onEvent({ type: "session.ended", code });
       const current = liveRef.current;
       current?.turnFailed?.(new Error("Claude Code exited"));
@@ -359,7 +537,7 @@ async function ensureLive(input: SendTurnInput): Promise<Live> {
   try {
     await writeJson(
       input.sessionId,
-      buildControlRequest(nextControlId(live), { subtype: "initialize" }),
+      buildControlRequest(nextControlId(live), buildInitializeRequest()),
     );
     await waitForInit(live, INIT_TIMEOUT_MS);
     live.onEvent({
@@ -445,8 +623,6 @@ function handleLine(sessionId: string, live: Live, line: string): void {
     return;
   }
 
-  if (live.muteUpdates) return;
-
   const sessionIdFromLine = sessionIdFromMessage(rec);
   if (sessionIdFromLine && sessionIdFromLine !== live.claudeSessionId) {
     live.claudeSessionId = sessionIdFromLine;
@@ -469,10 +645,21 @@ function handleLine(sessionId: string, live: Live, line: string): void {
 
   if (type === "control_response") {
     markInitialized(live);
+    const response = parseControlResponse(rec);
+    const waiting = response && live.pendingControls.get(response.requestId);
+    if (response && waiting) {
+      live.pendingControls.delete(response.requestId);
+      waiting(response);
+    }
     return;
   }
 
   if (handleAgentLifecycle(live, rec)) return;
+  // A cancelled turn mutes its own trailing output, nothing more. Muting the
+  // whole stream here once ate every control_response after Stop, so each
+  // later stop_task "timed out" while its answer sat unread — and subagents
+  // that outlived the turn kept writing into the void.
+  if (live.muteUpdates && !isSubagentMessage(rec)) return;
   if (type === "tool_progress") {
     handleToolProgress(live, rec);
     return;
@@ -500,10 +687,25 @@ function handleLine(sessionId: string, live: Live, line: string): void {
 }
 
 function handleStreamEvent(live: Live, rec: Record<string, unknown>): void {
-  const subagent = isSubagentMessage(rec);
+  const parentId = subagentParentId(rec);
   const delta = streamDeltaFromEvent(rec);
   if (delta) {
-    if (subagent) return;
+    if (parentId) {
+      const run = agentForParent(live, parentId);
+      if (!run) return;
+      if (delta.kind === "assistant") {
+        run.emittedAssistant = joinStreamText(run.emittedAssistant, delta.text);
+      } else {
+        run.emittedReasoning = joinStreamText(run.emittedReasoning, delta.text);
+      }
+      live.onEvent({
+        type: "agent.output",
+        agentId: run.id,
+        kind: delta.kind,
+        text: delta.text,
+      });
+      return;
+    }
     if (delta.kind === "assistant") {
       live.emittedAssistant = joinStreamText(live.emittedAssistant, delta.text);
       live.onEvent({ type: "message.delta", text: delta.text });
@@ -516,7 +718,8 @@ function handleStreamEvent(live: Live, rec: Record<string, unknown>): void {
 
   const started = toolStartFromEvent(rec);
   if (started) {
-    if (subagent) {
+    if (parentId) {
+      startSubagentTool(live, parentId, started);
       noteSubagentTool(live, rec, started.name, started.input);
       return;
     }
@@ -543,7 +746,10 @@ function handleStreamEvent(live: Live, rec: Record<string, unknown>): void {
 
   const jsonDelta = inputJsonDeltaFromEvent(rec);
   if (jsonDelta) {
-    if (subagent) return;
+    if (parentId) {
+      updateSubagentToolInput(live, parentId, jsonDelta);
+      return;
+    }
     const tool = live.toolsByIndex.get(jsonDelta.index);
     if (!tool) return;
     tool.partialJson += jsonDelta.partial;
@@ -566,7 +772,9 @@ function handleStreamEvent(live: Live, rec: Record<string, unknown>): void {
 }
 
 function handleAssistant(live: Live, rec: Record<string, unknown>): void {
-  if (isSubagentMessage(rec)) {
+  const parentId = subagentParentId(rec);
+  if (parentId) {
+    handleSubagentAssistant(live, parentId, rec);
     for (const use of assistantToolUses(rec)) {
       noteSubagentTool(live, rec, use.name, use.input);
     }
@@ -610,12 +818,16 @@ function handleAssistant(live: Live, rec: Record<string, unknown>): void {
 }
 
 function handleUser(live: Live, rec: Record<string, unknown>): void {
-  if (isSubagentMessage(rec)) return;
+  if (subagentParentId(rec) !== undefined) {
+    handleSubagentToolResults(live, rec);
+    return;
+  }
   for (const result of toolResultsFromUserMessage(rec)) {
     const tool = live.toolsById.get(result.toolUseId);
     if (!tool) continue;
-    if (isAgentToolName(tool.name) && isBackgroundedAgentTool(live, tool.id)) {
-      continue;
+    if (isAgentToolName(tool.name)) {
+      noteAgentAddress(live, tool.id, result.text);
+      if (isBackgroundedAgentTool(live, tool.id)) continue;
     }
     live.onEvent({
       type: "tool.updated",
@@ -816,27 +1028,67 @@ function handleAgentLifecycle(
       description: started.description,
       backgrounded: started.backgrounded,
     });
-    upsertAgentTool(live, started.toolUseId, started.description, "in_progress");
+    const agentId = agentIdForTask(live, started.taskId, started.toolUseId);
+    announceAgent(live, agentId, {
+      title: started.description,
+      taskId: started.taskId,
+      ...(started.toolUseId ? { callId: started.toolUseId } : {}),
+      ...(started.subagentType ? { agentType: started.subagentType } : {}),
+      ...(started.spawnDepth ? { depth: started.spawnDepth } : {}),
+      ...(started.prompt ? { prompt: started.prompt } : {}),
+    });
+    // A nested spawn is the subagent's tool call, not the main agent's; it
+    // lives in the agents panel tree, not as a row in the main transcript.
+    if ((started.spawnDepth ?? 1) <= 1) {
+      upsertAgentTool(
+        live,
+        started.toolUseId ?? `agent:${started.taskId}`,
+        started.description,
+        "in_progress",
+      );
+    }
     return true;
   }
 
   const progress = parseTaskProgress(rec);
   if (progress) {
     const task = live.agentTasks.get(progress.taskId);
-    const title = progress.description || task?.description || "Subagent";
+    // `description` is what the agent is doing right now ("Reading d3.md"),
+    // so it is the detail line; the row keeps the name it was spawned with.
     const detail =
       progress.summary ||
+      progress.description ||
       progress.lastToolName ||
       (progress.subagentType
         ? `${progress.subagentType.replace(/[_-]+/g, " ")} subagent`
         : undefined);
-    upsertAgentTool(
+    const rowId =
+      progress.toolUseId ?? task?.toolUseId ?? `agent:${progress.taskId}`;
+    if (live.toolsById.has(rowId)) {
+      upsertAgentTool(live, rowId, "", "in_progress", detail);
+    }
+    const agentId = knownAgentId(
       live,
+      progress.taskId,
       progress.toolUseId ?? task?.toolUseId,
-      title,
-      "in_progress",
-      detail,
     );
+    if (agentId) {
+      // `description` here is the agent's current activity, not its name —
+      // it changes with every tool ("Reading d3.md"); the name stays put.
+      const activity = progress.description || progress.lastToolName;
+      live.onEvent({
+        type: "agent.updated",
+        agentId,
+        ...(activity ? { activity } : {}),
+        ...(progress.summary ? { summary: progress.summary } : {}),
+        ...(progress.usage?.totalTokens != null
+          ? { tokens: progress.usage.totalTokens }
+          : {}),
+        ...(progress.usage?.toolUses != null
+          ? { toolUses: progress.usage.toolUses }
+          : {}),
+      });
+    }
     return true;
   }
 
@@ -848,6 +1100,15 @@ function handleAgentLifecycle(
     }
     if (task && updated.description) task.description = updated.description;
     if (isTerminalAgentTaskStatus(updated.status)) {
+      const settling = knownAgentId(live, updated.taskId, task?.toolUseId);
+      if (settling) {
+        settleAgent(
+          live,
+          settling,
+          agentStatusFrom(updated.status),
+          updated.error,
+        );
+      }
       completeAgentTask(
         live,
         updated.taskId,
@@ -861,6 +1122,32 @@ function handleAgentLifecycle(
   const notice = parseTaskNotification(rec);
   if (notice) {
     if (!notice.ambient) {
+      const task = live.agentTasks.get(notice.taskId);
+      const agentId = knownAgentId(
+        live,
+        notice.taskId,
+        notice.toolUseId ?? task?.toolUseId,
+      );
+      if (agentId && notice.usage) {
+        live.onEvent({
+          type: "agent.updated",
+          agentId,
+          ...(notice.usage.totalTokens != null
+            ? { tokens: notice.usage.totalTokens }
+            : {}),
+          ...(notice.usage.toolUses != null
+            ? { toolUses: notice.usage.toolUses }
+            : {}),
+        });
+      }
+      if (agentId) {
+        settleAgent(
+          live,
+          agentId,
+          agentStatusFrom(notice.status),
+          notice.summary || undefined,
+        );
+      }
       completeAgentTask(
         live,
         notice.taskId,
@@ -874,8 +1161,13 @@ function handleAgentLifecycle(
   const liveTasks = parseBackgroundAgentTasks(rec);
   if (!liveTasks) return false;
   const next = new Set(liveTasks.map((task) => task.taskId));
+  live.backgroundTaskIds = next;
   for (const id of [...live.agentTasks.keys()]) {
-    if (!next.has(id)) completeAgentTask(live, id, "completed");
+    if (next.has(id)) continue;
+    const task = live.agentTasks.get(id);
+    const gone = knownAgentId(live, id, task?.toolUseId);
+    if (gone) settleAgent(live, gone, "completed");
+    completeAgentTask(live, id, "completed");
   }
   for (const row of liveTasks) {
     if (live.agentTasks.has(row.taskId)) continue;
@@ -884,10 +1176,22 @@ function handleAgentLifecycle(
       description: row.description,
       backgrounded: true,
     });
-    upsertAgentTool(live, undefined, row.description, "in_progress");
+    // No row and no run yet: this frame beats `task_started` for the same
+    // task, and anything keyed here would never meet what the tool call keys
+    // — two rows for one agent, one of them stuck "running". The map entry
+    // alone keeps the turn busy until the task reports back.
   }
   maybeFinishTurn(live);
   return true;
+}
+
+function agentStatusFrom(
+  status: string | undefined,
+): "completed" | "failed" | "stopped" {
+  const key = (status ?? "").toLowerCase();
+  if (key === "completed") return "completed";
+  if (key === "killed" || key === "stopped") return "stopped";
+  return "failed";
 }
 
 function handleToolProgress(live: Live, rec: Record<string, unknown>): void {
@@ -910,6 +1214,260 @@ function handleToolProgress(live: Live, rec: Record<string, unknown>): void {
     status: "in_progress",
     ...(detail ? { detail } : {}),
   });
+}
+
+/**
+ * The run a forwarded frame belongs to. A frame can beat `task_started` here,
+ * and nested spawns never announce a tool call we hold, so an unseen parent
+ * opens a run rather than dropping the subagent's work on the floor.
+ *
+ * A parent we *do* hold and that is not an Agent call is something else
+ * entirely (a skill fork, an MCP task); those get no row in the agents panel.
+ */
+function agentForParent(live: Live, parentId: string): LiveAgentRun | null {
+  const existing = live.agents.get(parentId);
+  if (existing) return existing;
+  const parent = live.toolsById.get(parentId);
+  if (parent && !isAgentToolName(parent.name)) return null;
+  return announceAgent(live, parentId, {
+    title: parent?.title,
+    callId: parentId,
+  });
+}
+
+function announceAgent(
+  live: Live,
+  id: string,
+  init: {
+    title?: string;
+    callId?: string;
+    taskId?: string;
+    agentType?: string;
+    depth?: number;
+    prompt?: string;
+  },
+): LiveAgentRun {
+  const title = init.title || live.agents.get(id)?.title || "Subagent";
+  const run = live.agents.get(id) ?? {
+    id,
+    title,
+    settled: false,
+    emittedAssistant: "",
+    emittedReasoning: "",
+  };
+  run.title = title;
+  run.settled = false;
+  if (init.taskId) run.taskId = init.taskId;
+  // A nested spawn's Agent call streamed through its parent first, so the
+  // parent run is whoever owns that tool call.
+  run.parentId ??= live.subTools.get(id)?.agentId;
+  live.agents.set(id, run);
+  live.onEvent({
+    type: "agent.started",
+    agentId: id,
+    title,
+    ...(init.callId ? { callId: init.callId } : {}),
+    ...(run.taskId ? { taskId: run.taskId } : {}),
+    ...(init.agentType ? { agentType: init.agentType } : {}),
+    ...(init.depth ? { depth: init.depth } : {}),
+    ...(init.prompt ? { prompt: init.prompt } : {}),
+    ...(run.parentId ? { parentId: run.parentId } : {}),
+  });
+  return run;
+}
+
+function settleAgent(
+  live: Live,
+  id: string,
+  status: "completed" | "failed" | "stopped",
+  summary?: string,
+): void {
+  const run = live.agents.get(id);
+  if (!run || run.settled) return;
+  run.settled = true;
+  live.onEvent({
+    type: "agent.updated",
+    agentId: id,
+    status,
+    ...(summary ? { summary } : {}),
+  });
+}
+
+/**
+ * The run id for a task we have already registered. `task_progress` and the
+ * settle events carry no task_type, so a background Bash task looks exactly
+ * like a subagent here — minting an id from one of those is how a shell
+ * command ended up wearing a subagent's token count.
+ */
+function knownAgentId(
+  live: Live,
+  taskId: string,
+  toolUseId?: string,
+): string | undefined {
+  const known = live.agentByTask.get(taskId);
+  if (known) return known;
+  return toolUseId && live.agents.has(toolUseId) ? toolUseId : undefined;
+}
+
+/** The run id for a task, minted from the spawning tool call when there is one. */
+function agentIdForTask(
+  live: Live,
+  taskId: string,
+  toolUseId?: string,
+): string {
+  const known = live.agentByTask.get(taskId);
+  if (known) return known;
+  const id = toolUseId ?? `task:${taskId}`;
+  live.agentByTask.set(taskId, id);
+  return id;
+}
+
+function subToolKey(parentId: string, index: number): string {
+  return `${parentId}#${index}`;
+}
+
+function startSubagentTool(
+  live: Live,
+  parentId: string,
+  started: { index: number; id: string; name: string; input: Record<string, unknown> },
+): void {
+  const run = agentForParent(live, parentId);
+  if (!run) return;
+  const tool: SubagentTool = {
+    agentId: run.id,
+    id: started.id,
+    name: started.name,
+    input: started.input,
+    partialJson: "",
+    title: toolTitle(started.name, started.input),
+  };
+  live.subTools.set(started.id, tool);
+  if (started.index >= 0) {
+    live.subToolsByIndex.set(subToolKey(parentId, started.index), tool);
+  }
+  emitSubagentTool(live, tool, "pending");
+}
+
+function updateSubagentToolInput(
+  live: Live,
+  parentId: string,
+  jsonDelta: { index: number; partial: string },
+): void {
+  const tool = live.subToolsByIndex.get(subToolKey(parentId, jsonDelta.index));
+  if (!tool) return;
+  tool.partialJson += jsonDelta.partial;
+  const parsed = tryParseJsonRecord(tool.partialJson);
+  if (!parsed) return;
+  tool.input = parsed;
+  tool.title = toolTitle(tool.name, parsed);
+  emitSubagentTool(live, tool, "pending");
+}
+
+function handleSubagentAssistant(
+  live: Live,
+  parentId: string,
+  rec: Record<string, unknown>,
+): void {
+  const run = agentForParent(live, parentId);
+  if (!run) return;
+  const thinkingSnapshot = assistantThinkingBlocks(rec).join("");
+  const thinking = snapshotRemainder(run.emittedReasoning, thinkingSnapshot);
+  if (thinking) {
+    const text = separateMessages(run.emittedReasoning, thinkingSnapshot, thinking);
+    run.emittedReasoning = joinStreamText(run.emittedReasoning, text);
+    live.onEvent({
+      type: "agent.output",
+      agentId: run.id,
+      kind: "reasoning",
+      text,
+    });
+  }
+  const snapshot = assistantTextBlocks(rec).join("");
+  const extra = snapshotRemainder(run.emittedAssistant, snapshot);
+  if (extra) {
+    const text = separateMessages(run.emittedAssistant, snapshot, extra);
+    run.emittedAssistant = joinStreamText(run.emittedAssistant, text);
+    live.onEvent({
+      type: "agent.output",
+      agentId: run.id,
+      kind: "assistant",
+      text,
+    });
+  }
+  for (const use of assistantToolUses(rec)) {
+    if (live.subTools.has(use.id)) continue;
+    const tool: SubagentTool = {
+      agentId: run.id,
+      id: use.id,
+      name: use.name,
+      input: use.input,
+      partialJson: "",
+      title: toolTitle(use.name, use.input),
+    };
+    live.subTools.set(use.id, tool);
+    emitSubagentTool(live, tool, "pending");
+  }
+}
+
+/**
+ * The CLI forwards a subagent as whole messages rather than deltas, so two
+ * replies in a row would otherwise be glued into one paragraph. A remainder
+ * that is a suffix of what we hold is the same message continuing; one that is
+ * the whole snapshot is a new message and earns a break.
+ */
+function separateMessages(
+  already: string,
+  snapshot: string,
+  extra: string,
+): string {
+  if (!already || extra !== snapshot || already.endsWith("\n")) return extra;
+  return `\n\n${extra}`;
+}
+
+function handleSubagentToolResults(
+  live: Live,
+  rec: Record<string, unknown>,
+): void {
+  for (const result of toolResultsFromUserMessage(rec)) {
+    const tool = live.subTools.get(result.toolUseId);
+    if (!tool) continue;
+    emitSubagentTool(
+      live,
+      tool,
+      result.isError ? "failed" : "completed",
+      result.text,
+    );
+    // A result is terminal, so the entry has no further use; a long-lived
+    // background agent would otherwise grow this map for the whole session.
+    live.subTools.delete(result.toolUseId);
+  }
+}
+
+function emitSubagentTool(
+  live: Live,
+  tool: SubagentTool,
+  status: "pending" | "completed" | "failed",
+  resultText?: string,
+): void {
+  live.onEvent({
+    type: "agent.tool",
+    agentId: tool.agentId,
+    callId: tool.id,
+    title: tool.title,
+    kind: toolKindFromName(tool.name),
+    status,
+    ...(resultText ? { detail: resultText } : {}),
+    preview: previewFromTool(tool.name, tool.input, resultText),
+  });
+}
+
+/** The Agent tool's result is the only place the CLI names a reachable agent. */
+function noteAgentAddress(live: Live, toolUseId: string, text: string): void {
+  const address = sendMessageAddress(text);
+  if (!address) return;
+  const run = live.agents.get(toolUseId);
+  if (!run) return;
+  live.onEvent({ type: "agent.updated", agentId: run.id, address });
 }
 
 function noteSubagentTool(
@@ -941,12 +1499,11 @@ function isBackgroundedAgentTool(live: Live, toolUseId: string): boolean {
 
 function upsertAgentTool(
   live: Live,
-  callId: string | undefined,
+  id: string,
   title: string,
   status: string,
   detail?: string,
 ): void {
-  const id = callId ?? `agent:${title}`;
   const existing = live.toolsById.get(id);
   if (!existing) {
     live.toolsById.set(id, {
@@ -994,14 +1551,9 @@ function completeAgentTask(
 ): void {
   const task = live.agentTasks.get(taskId);
   live.agentTasks.delete(taskId);
-  if (task) {
-    upsertAgentTool(
-      live,
-      task.toolUseId,
-      task.description,
-      status,
-      detail,
-    );
+  const rowId = task?.toolUseId ?? `agent:${taskId}`;
+  if (task && live.toolsById.has(rowId)) {
+    upsertAgentTool(live, rowId, task.description, status, detail);
   }
   maybeFinishTurn(live);
 }
@@ -1010,10 +1562,24 @@ function maybeFinishTurn(live: Live): void {
   if (!live.turnResultSeen) return;
   if (live.agentTasks.size > 0) return;
   if (!live.activeTurn && !live.turnDone) return;
+  settleStaleAgents(live);
   finishActiveTurn(live, [
     { type: "message.completed" },
     { type: "reasoning.completed" },
   ]);
+}
+
+/**
+ * The turn is over and nothing is pending, so any run still marked running
+ * that the CLI does not list as a live background task cannot be alive — its
+ * terminal event was lost or never sent. Left alone it would spin forever.
+ */
+function settleStaleAgents(live: Live): void {
+  for (const run of live.agents.values()) {
+    if (run.settled) continue;
+    if (run.taskId && live.backgroundTaskIds.has(run.taskId)) continue;
+    settleAgent(live, run.id, "completed");
+  }
 }
 
 function finishActiveTurn(live: Live, extraEvents: HarnessEvent[] = []): void {

--- a/src/lib/harness/claudeAdapter.ts
+++ b/src/lib/harness/claudeAdapter.ts
@@ -6,8 +6,11 @@ import {
   respondClaudeQuestion,
   sendClaudeTurn,
   steerClaudeTurn,
+  stopClaudeAgent,
   stopClaudeSession,
 } from "./claude";
+import { stoppableId } from "./agentRuns";
+import { buildAgentRelayPrompt } from "../agentRelay";
 import { refreshClaudeCatalog } from "./claudeCatalog";
 import {
   generateClaudeBranchName,
@@ -24,6 +27,12 @@ export const claudeAdapter: HarnessAdapter = {
   sendTurn: sendClaudeTurn,
   steerTurn: steerClaudeTurn,
   cancelTurn: cancelClaudeTurn,
+  stopAgent: async (sessionId, agent) => {
+    const target = stoppableId(agent);
+    if (!target) throw new Error("Claude never reported an id for it.");
+    await stopClaudeAgent(sessionId, target);
+  },
+  agentRelayPrompt: buildAgentRelayPrompt,
   respondApproval: respondClaudeApproval,
   respondQuestion: respondClaudeQuestion,
   stopSession: stopClaudeSession,

--- a/src/lib/harness/claudeLive.test.ts
+++ b/src/lib/harness/claudeLive.test.ts
@@ -16,9 +16,13 @@ vi.mock("./child", () => ({
   },
 }));
 
-const { sendClaudeTurn, stopClaudeSession, __claudeTestReset } = await import(
-  "./claude"
-);
+const {
+  cancelClaudeTurn,
+  sendClaudeTurn,
+  stopClaudeAgent,
+  stopClaudeSession,
+  __claudeTestReset,
+} = await import("./claude");
 import type { HarnessEvent } from "./types";
 
 function parse() {
@@ -38,6 +42,22 @@ const waitFor = async (pred: () => boolean, label: string) => {
     `timed out waiting for ${label}; sent=${JSON.stringify(parse())}`,
   );
 };
+
+function findRequest(subtype: string) {
+  return parse().find((line) => {
+    const request = line.request as Record<string, unknown> | undefined;
+    return request?.subtype === subtype;
+  });
+}
+
+async function waitForRequest(subtype: string) {
+  await waitFor(() => findRequest(subtype) !== undefined, subtype);
+  return findRequest(subtype)!.request as Record<string, unknown>;
+}
+
+function stopRequestId(): string {
+  return findRequest("stop_task")!.request_id as string;
+}
 
 async function startTurn(sessionId: string) {
   const events: HarnessEvent[] = [];
@@ -234,5 +254,621 @@ describe("claude subagents", () => {
           event.text.includes("I will grep for tokens"),
       ),
     ).toBe(false);
+  });
+
+  it("routes forwarded subagent text and tools to the run that wrote them", async () => {
+    const { events, turn } = await startTurn("s1");
+    emit({
+      type: "assistant",
+      session_id: "sess_1",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_agent",
+            name: "Agent",
+            input: { description: "Explore", subagent_type: "explore" },
+          },
+        ],
+      },
+    });
+    emit({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t1",
+      tool_use_id: "toolu_agent",
+      description: "Explore the auth module",
+      subagent_type: "explore",
+      spawn_depth: 1,
+      task_type: "local_agent",
+    });
+    emit({
+      type: "assistant",
+      parent_tool_use_id: "toolu_agent",
+      message: {
+        content: [
+          { type: "thinking", thinking: "tokens probably live in auth" },
+          { type: "text", text: "I will grep for tokens" },
+        ],
+      },
+    });
+    emit({
+      type: "assistant",
+      parent_tool_use_id: "toolu_agent",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_sub_grep",
+            name: "Grep",
+            input: { pattern: "token" },
+          },
+        ],
+      },
+    });
+    emit({
+      type: "user",
+      parent_tool_use_id: "toolu_agent",
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_sub_grep",
+            content: "3 matches",
+          },
+        ],
+      },
+    });
+    emit({
+      type: "system",
+      subtype: "task_progress",
+      task_id: "t1",
+      tool_use_id: "toolu_agent",
+      description: "Explore the auth module",
+      last_tool_name: "Grep",
+      usage: { total_tokens: 1234, tool_uses: 1, duration_ms: 900 },
+    });
+    emit({ type: "result", subtype: "success", session_id: "sess_1" });
+    emit({
+      type: "system",
+      subtype: "task_notification",
+      task_id: "t1",
+      tool_use_id: "toolu_agent",
+      status: "completed",
+      summary: "Found the tokens",
+    });
+    await turn;
+
+    const started = events.find((event) => event.type === "agent.started");
+    expect(started).toMatchObject({
+      agentId: "toolu_agent",
+      taskId: "t1",
+      agentType: "explore",
+      depth: 1,
+    });
+    expect(
+      events.some(
+        (event) =>
+          event.type === "agent.output" &&
+          event.agentId === "toolu_agent" &&
+          event.kind === "assistant" &&
+          event.text.includes("I will grep for tokens"),
+      ),
+    ).toBe(true);
+    // Subagent thinking never arrives as a delta, so it has to come off the
+    // message block or the panel shows a gap where the reasoning was.
+    expect(
+      events.some(
+        (event) =>
+          event.type === "agent.output" &&
+          event.kind === "reasoning" &&
+          event.text.includes("tokens probably live in auth"),
+      ),
+    ).toBe(true);
+    expect(
+      events.some(
+        (event) =>
+          event.type === "agent.tool" &&
+          event.agentId === "toolu_agent" &&
+          event.status === "completed",
+      ),
+    ).toBe(true);
+    expect(
+      events.some(
+        (event) => event.type === "agent.updated" && event.tokens === 1234,
+      ),
+    ).toBe(true);
+  });
+
+  it("asks the CLI to forward subagent text and to leave background agents to us", async () => {
+    const { turn } = await startTurn("s1");
+    emit({ type: "result", subtype: "success", session_id: "sess_1" });
+    await turn;
+    const init = parse().find((line) => {
+      const request = line.request as Record<string, unknown> | undefined;
+      return request?.subtype === "initialize";
+    });
+    expect(init?.request).toMatchObject({
+      forwardSubagentText: true,
+      agentProgressSummaries: true,
+      perTaskStopAffordance: true,
+    });
+  });
+
+  it("opens no run for a forwarded frame whose parent is not an Agent call", async () => {
+    const { events, turn } = await startTurn("s1");
+    emit({
+      type: "assistant",
+      session_id: "sess_1",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_bash",
+            name: "Bash",
+            input: { command: "ls" },
+          },
+        ],
+      },
+    });
+    emit({
+      type: "assistant",
+      parent_tool_use_id: "toolu_bash",
+      message: { content: [{ type: "text", text: "inner text" }] },
+    });
+    emit({ type: "result", subtype: "success", session_id: "sess_1" });
+    await turn;
+    expect(events.some((event) => event.type === "agent.started")).toBe(false);
+  });
+
+  it("breaks between two forwarded messages instead of gluing them", async () => {
+    const { events, turn } = await startTurn("s1");
+    emit({
+      type: "assistant",
+      session_id: "sess_1",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_agent",
+            name: "Agent",
+            input: { description: "Explore" },
+          },
+        ],
+      },
+    });
+    emit({
+      type: "assistant",
+      parent_tool_use_id: "toolu_agent",
+      message: { content: [{ type: "text", text: "Searching." }] },
+    });
+    emit({
+      type: "assistant",
+      parent_tool_use_id: "toolu_agent",
+      message: { content: [{ type: "text", text: "Found 3." }] },
+    });
+    emit({ type: "result", subtype: "success", session_id: "sess_1" });
+    await turn;
+    const outputs = events.flatMap((event) =>
+      event.type === "agent.output" ? [event.text] : [],
+    );
+    expect(outputs).toEqual(["Searching.", "\n\nFound 3."]);
+  });
+
+  it("stops background subagents when the turn is cancelled", async () => {
+    const { events, turn } = await startTurn("s1");
+    emit({
+      type: "assistant",
+      session_id: "sess_1",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_agent",
+            name: "Agent",
+            input: { description: "Explore" },
+          },
+        ],
+      },
+    });
+    emit({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t1",
+      tool_use_id: "toolu_agent",
+      description: "Explore",
+      task_type: "local_agent",
+      is_backgrounded: true,
+    });
+    const cancelling = cancelClaudeTurn("s1");
+    await waitForRequest("interrupt");
+    const requests = parse().flatMap((line) => {
+      const request = line.request as Record<string, unknown> | undefined;
+      return request?.subtype ? [request] : [];
+    });
+    const stopIndex = requests.findIndex((r) => r.subtype === "stop_task");
+    const interruptIndex = requests.findIndex((r) => r.subtype === "interrupt");
+    expect(requests[stopIndex]).toMatchObject({ task_id: "t1" });
+    // The stop has to land first; an interrupt now spares background agents.
+    expect(stopIndex).toBeLessThan(interruptIndex);
+    // The turn is already over while the stop is still unanswered, so the
+    // run reads as stopping, not stopped — Stop once claimed success blindly.
+    await turn;
+    const run = events.find((e) => e.type === "agent.started")!;
+    expect(
+      events.some(
+        (e) => e.type === "agent.updated" && e.agentId === run.agentId && e.stopping,
+      ),
+    ).toBe(true);
+    expect(
+      events.some((e) => e.type === "agent.updated" && e.status === "stopped"),
+    ).toBe(false);
+    // Stop muted the stream; the verdict must still get through.
+    emit({
+      type: "control_response",
+      response: { subtype: "success", request_id: stopRequestId() },
+    });
+    await cancelling;
+    expect(
+      events.some(
+        (e) =>
+          e.type === "agent.updated" &&
+          e.agentId === run.agentId &&
+          e.status === "stopped",
+      ),
+    ).toBe(true);
+  });
+
+  it("still answers a stop asked after the turn was cancelled", async () => {
+    const { events, turn } = await startTurn("s1");
+    emit({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t1",
+      tool_use_id: "toolu_agent",
+      description: "Explore",
+      task_type: "local_agent",
+      is_backgrounded: true,
+    });
+    const cancelling = cancelClaudeTurn("s1");
+    await waitForRequest("interrupt");
+    await turn;
+    // The CLI refuses the cancel-time stop; the run goes back to plain running.
+    emit({
+      type: "control_response",
+      response: {
+        subtype: "error",
+        request_id: stopRequestId(),
+        error: "stop_task: busy",
+      },
+    });
+    await cancelling;
+    expect(events.at(-1)).toMatchObject({
+      type: "agent.updated",
+      stopping: false,
+    });
+    // A second stop from the panel, after the turn ended, must be heard.
+    const stopping = stopClaudeAgent("s1", "t1");
+    await waitFor(
+      () =>
+        parse().filter((line) => {
+          const request = line.request as Record<string, unknown> | undefined;
+          return request?.subtype === "stop_task";
+        }).length === 2,
+      "second stop_task",
+    );
+    const second = parse()
+      .filter((line) => {
+        const request = line.request as Record<string, unknown> | undefined;
+        return request?.subtype === "stop_task";
+      })
+      .at(-1)!.request_id as string;
+    emit({
+      type: "control_response",
+      response: { subtype: "success", request_id: second },
+    });
+    await stopping;
+    expect(events.at(-1)).toMatchObject({
+      type: "agent.updated",
+      agentId: "toolu_agent",
+      status: "stopped",
+    });
+    // And the CLI's own lifecycle for a run that outlived the turn is not lost.
+    emit({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t2",
+      tool_use_id: "toolu_agent2",
+      description: "Late",
+      task_type: "local_agent",
+      is_backgrounded: true,
+    });
+    expect(
+      events.some((e) => e.type === "agent.started" && e.taskId === "t2"),
+    ).toBe(true);
+  });
+
+  it("stops one subagent without interrupting the turn", async () => {
+    const { turn } = await startTurn("s1");
+    const stopping = stopClaudeAgent("s1", "t1");
+    const stop = await waitForRequest("stop_task");
+    expect(stop).toMatchObject({ subtype: "stop_task", task_id: "t1" });
+    emit({
+      type: "control_response",
+      response: { subtype: "success", request_id: stopRequestId() },
+    });
+    await stopping;
+    expect(
+      parse().some((line) => {
+        const request = line.request as Record<string, unknown> | undefined;
+        return request?.subtype === "interrupt";
+      }),
+    ).toBe(false);
+    emit({ type: "result", subtype: "success", session_id: "sess_1" });
+    await turn;
+  });
+
+  it("reports a refused stop instead of swallowing it", async () => {
+    const { turn } = await startTurn("s1");
+    const stopping = stopClaudeAgent("s1", "t1");
+    await waitForRequest("stop_task");
+    emit({
+      type: "control_response",
+      response: {
+        subtype: "error",
+        request_id: stopRequestId(),
+        error: "stop_task: task not found",
+      },
+    });
+    await expect(stopping).rejects.toThrow("task not found");
+    emit({ type: "result", subtype: "success", session_id: "sess_1" });
+    await turn;
+  });
+});
+
+describe("claude subagent identity", () => {
+  const spawnAgentTool = (id: string, description: string, parent?: string) =>
+    emit({
+      type: "assistant",
+      ...(parent ? { parent_tool_use_id: parent } : { session_id: "sess_1" }),
+      message: {
+        content: [{ type: "tool_use", id, name: "Agent", input: { description } }],
+      },
+    });
+
+  it("keeps one run when background_tasks_changed beats task_started", async () => {
+    const { events, turn } = await startTurn("s1");
+    spawnAgentTool("toolu_agent", "Explore");
+    // Measured order on the real CLI: the background list names the task a
+    // frame before task_started does.
+    emit({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1", task_type: "local_agent", description: "Explore" }],
+    });
+    emit({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t1",
+      tool_use_id: "toolu_agent",
+      description: "Explore",
+      task_type: "local_agent",
+      is_backgrounded: true,
+    });
+    emit({
+      type: "assistant",
+      parent_tool_use_id: "toolu_agent",
+      message: { content: [{ type: "text", text: "hi" }] },
+    });
+    emit({ type: "result", subtype: "success", session_id: "sess_1" });
+    emit({
+      type: "system",
+      subtype: "task_notification",
+      task_id: "t1",
+      tool_use_id: "toolu_agent",
+      status: "completed",
+      summary: "",
+    });
+    await turn;
+    const started = events.filter((event) => event.type === "agent.started");
+    expect(new Set(started.map((event) => event.agentId)).size).toBe(1);
+    expect(started[0]).toMatchObject({ agentId: "toolu_agent", taskId: "t1" });
+    expect(
+      events.some(
+        (event) =>
+          event.type === "agent.updated" &&
+          event.agentId === "toolu_agent" &&
+          event.status === "completed",
+      ),
+    ).toBe(true);
+  });
+
+  it("links a nested spawn to the run that made it and stops the tree leaves first", async () => {
+    const { events, turn } = await startTurn("s1");
+    spawnAgentTool("toolu_top", "Coordinate");
+    emit({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t_top",
+      tool_use_id: "toolu_top",
+      description: "Coordinate",
+      task_type: "local_agent",
+    });
+    spawnAgentTool("toolu_child", "Summarize", "toolu_top");
+    emit({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t_child",
+      tool_use_id: "toolu_child",
+      description: "Summarize",
+      task_type: "local_agent",
+      spawn_depth: 2,
+      is_backgrounded: true,
+    });
+    expect(
+      events.find(
+        (event) => event.type === "agent.started" && event.agentId === "toolu_child",
+      ),
+    ).toMatchObject({ parentId: "toolu_top" });
+
+    const stopping = stopClaudeAgent("s1", "t_top");
+    await waitForRequest("stop_task");
+    const stops = () =>
+      parse().flatMap((line) => {
+        const request = line.request as Record<string, unknown> | undefined;
+        return request?.subtype === "stop_task"
+          ? [{ id: line.request_id as string, task: request.task_id as string }]
+          : [];
+      });
+    expect(stops()[0].task).toBe("t_child");
+    emit({
+      type: "control_response",
+      response: { subtype: "success", request_id: stops()[0].id },
+    });
+    await waitFor(() => stops().length === 2, "parent stop");
+    expect(stops()[1].task).toBe("t_top");
+    emit({
+      type: "control_response",
+      response: { subtype: "success", request_id: stops()[1].id },
+    });
+    await stopping;
+
+    for (const task of ["t_child", "t_top"]) {
+      emit({
+        type: "system",
+        subtype: "task_notification",
+        task_id: task,
+        status: "stopped",
+        summary: "",
+      });
+    }
+    emit({ type: "result", subtype: "success", session_id: "sess_1" });
+    await turn;
+  });
+
+  it("does not let progress rename a run, only describe what it is doing", async () => {
+    const { events, turn } = await startTurn("s1");
+    spawnAgentTool("toolu_agent", "Explore");
+    emit({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t1",
+      tool_use_id: "toolu_agent",
+      description: "Explore the auth module",
+      task_type: "local_agent",
+    });
+    emit({
+      type: "system",
+      subtype: "task_progress",
+      task_id: "t1",
+      tool_use_id: "toolu_agent",
+      description: "Reading auth.ts",
+      usage: { total_tokens: 10, tool_uses: 1, duration_ms: 5 },
+    });
+    emit({ type: "result", subtype: "success", session_id: "sess_1" });
+    emit({
+      type: "system",
+      subtype: "task_notification",
+      task_id: "t1",
+      tool_use_id: "toolu_agent",
+      status: "completed",
+      summary: "",
+    });
+    await turn;
+    const update = events.find(
+      (event) => event.type === "agent.updated" && event.activity !== undefined,
+    );
+    expect(update).toMatchObject({ activity: "Reading auth.ts" });
+    expect(update && "title" in update && update.title).toBeFalsy();
+  });
+
+  it("settles a run whose terminal event never came once the turn is over", async () => {
+    const { events, turn } = await startTurn("s1");
+    spawnAgentTool("toolu_agent", "Explore");
+    // No task_started: the run exists only because its text was forwarded.
+    emit({
+      type: "assistant",
+      parent_tool_use_id: "toolu_agent",
+      message: { content: [{ type: "text", text: "hi" }] },
+    });
+    emit({ type: "result", subtype: "success", session_id: "sess_1" });
+    await turn;
+    expect(
+      events.some(
+        (event) =>
+          event.type === "agent.updated" &&
+          event.agentId === "toolu_agent" &&
+          event.status === "completed",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("claude subagent transcript rows", () => {
+  it("keeps one row per agent: progress and the live list never add rows", async () => {
+    const { events, turn } = await startTurn("s1");
+    emit({
+      type: "assistant",
+      session_id: "sess_1",
+      message: {
+        content: [
+          { type: "tool_use", id: "toolu_agent", name: "Agent", input: { description: "Map architecture" } },
+        ],
+      },
+    });
+    emit({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1", task_type: "local_agent", description: "Running ls -la /repo" }],
+    });
+    emit({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t1",
+      tool_use_id: "toolu_agent",
+      description: "Map architecture",
+      task_type: "local_agent",
+      is_backgrounded: true,
+    });
+    emit({
+      type: "system",
+      subtype: "task_progress",
+      task_id: "t1",
+      tool_use_id: "toolu_agent",
+      description: "Running find /repo -name *.ts",
+      usage: { total_tokens: 5, tool_uses: 1, duration_ms: 1 },
+    });
+    emit({ type: "result", subtype: "success", session_id: "sess_1" });
+    emit({
+      type: "system",
+      subtype: "task_notification",
+      task_id: "t1",
+      tool_use_id: "toolu_agent",
+      status: "completed",
+      summary: "",
+    });
+    await turn;
+    const rows = new Set(
+      events.flatMap((event) =>
+        event.type === "tool.started" && event.kind === "agent" ? [event.callId] : [],
+      ),
+    );
+    expect([...rows]).toEqual(["toolu_agent"]);
+    const titles = events.flatMap((event) =>
+      (event.type === "tool.started" || event.type === "tool.updated") &&
+      event.callId === "toolu_agent" &&
+      event.title
+        ? [event.title]
+        : [],
+    );
+    expect(titles.every((title) => title === "Map architecture")).toBe(true);
+    expect(
+      events.some(
+        (event) =>
+          event.type === "tool.updated" &&
+          event.callId === "toolu_agent" &&
+          event.detail === "Running find /repo -name *.ts",
+      ),
+    ).toBe(true);
   });
 });

--- a/src/lib/harness/claudeProtocol.test.ts
+++ b/src/lib/harness/claudeProtocol.test.ts
@@ -5,12 +5,15 @@ import {
   askUserQuestionAllowInput,
   buildClaudeSpawnArgs,
   buildClaudeUserMessage,
+  buildInitializeRequest,
+  buildStopTaskRequest,
   contextFromResult,
   contextUsedFromAssistant,
   extractExitPlanModePlan,
   isClaudeInitMessage,
   isSubagentMessage,
   isTodoTool,
+  sendMessageAddress,
   listModelsFromControlResponse,
   normalizeClaudeCliEffort,
   parseBackgroundAgentTasks,
@@ -707,5 +710,67 @@ describe("subagent messages", () => {
       toolUseId: "toolu_agent",
       subagentType: "explore",
     });
+  });
+
+  it("reads task lifecycle detail the agents panel needs", () => {
+    expect(
+      parseTaskStarted({
+        type: "system",
+        subtype: "task_started",
+        task_id: "t1",
+        tool_use_id: "toolu_agent",
+        description: "Explore",
+        task_type: "local_agent",
+        subagent_type: "explore",
+        spawn_depth: 2,
+      }),
+    ).toMatchObject({ subagentType: "explore", spawnDepth: 2 });
+
+    expect(
+      parseTaskProgress({
+        type: "system",
+        subtype: "task_progress",
+        task_id: "t1",
+        description: "Explore",
+        usage: { total_tokens: 1234, tool_uses: 3, duration_ms: 900 },
+      })?.usage,
+    ).toEqual({ totalTokens: 1234, toolUses: 3, durationMs: 900 });
+
+    // skip_transcript marks the CLI's own housekeeping tasks; they are not
+    // the user's subagents even when the ambient flag is absent.
+    expect(
+      parseTaskStarted({
+        type: "system",
+        subtype: "task_started",
+        task_id: "t2",
+        description: "watcher",
+        task_type: "local_agent",
+        skip_transcript: true,
+      })?.ambient,
+    ).toBe(true);
+  });
+
+  it("declares the subagent capabilities the panel depends on", () => {
+    expect(buildInitializeRequest()).toEqual({
+      subtype: "initialize",
+      forwardSubagentText: true,
+      agentProgressSummaries: true,
+      perTaskStopAffordance: true,
+    });
+    expect(buildStopTaskRequest("t1")).toEqual({
+      subtype: "stop_task",
+      task_id: "t1",
+    });
+  });
+
+  it("picks the SendMessage address out of an Agent tool result", () => {
+    expect(
+      sendMessageAddress(
+        "agentId: abc123 (use SendMessage with to: 'abc123', summary: '<recap>')",
+      ),
+    ).toBe("abc123");
+    expect(sendMessageAddress("Subagent completed but returned no output.")).toBe(
+      undefined,
+    );
   });
 });

--- a/src/lib/harness/claudeProtocol.ts
+++ b/src/lib/harness/claudeProtocol.ts
@@ -263,6 +263,28 @@ export function buildClaudeSpawnArgs(input: {
   return args;
 }
 
+/**
+ * The CLI keeps subagents opaque unless the session opts in. `initialize` is
+ * the safe place to ask: the matching `--forward-subagent-text` flag hard-errors
+ * on a CLI that predates it, while unknown initialize keys are just dropped.
+ *
+ * `perTaskStopAffordance` is a promise, not a preference — declaring it makes
+ * Stop spare running subagents, which is only right because the agents panel
+ * stops them one by one through `stop_task`.
+ */
+export function buildInitializeRequest(): Record<string, unknown> {
+  return {
+    subtype: "initialize",
+    forwardSubagentText: true,
+    agentProgressSummaries: true,
+    perTaskStopAffordance: true,
+  };
+}
+
+export function buildStopTaskRequest(taskId: string): Record<string, unknown> {
+  return { subtype: "stop_task", task_id: taskId };
+}
+
 export function buildControlRequest(
   requestId: string,
   request: Record<string, unknown>,
@@ -540,8 +562,26 @@ export function inputJsonDeltaFromEvent(
 }
 
 export function isSubagentMessage(rec: Record<string, unknown>): boolean {
+  return subagentParentId(rec) !== undefined;
+}
+
+/** The Agent tool call a forwarded subagent frame belongs to. */
+export function subagentParentId(
+  rec: Record<string, unknown>,
+): string | undefined {
   const parent = rec.parent_tool_use_id;
-  return typeof parent === "string" && parent.length > 0;
+  return typeof parent === "string" && parent.length > 0 ? parent : undefined;
+}
+
+/**
+ * A spawned agent is only reachable by SendMessage once the CLI has told the
+ * model its address, which it does in the Agent tool's own result text. Nothing
+ * else carries it, so the panel's reply box reads it back out from there.
+ */
+export function sendMessageAddress(text: string | undefined): string | undefined {
+  if (!text) return undefined;
+  const match = /SendMessage\s+with\s+to:\s*'([^']+)'/.exec(text);
+  return match?.[1];
 }
 
 export function isAgentTaskType(taskType: string | undefined): boolean {
@@ -554,6 +594,11 @@ export type ClaudeAgentTaskStarted = {
   toolUseId?: string;
   description: string;
   taskType: string;
+  subagentType?: string;
+  /** 1 for a top-level spawn, N+1 when spawned from inside a depth-N agent. */
+  spawnDepth?: number;
+  /** The brief the subagent was handed. Nothing else in the stream carries it. */
+  prompt?: string;
   backgrounded: boolean;
   ambient: boolean;
 };
@@ -574,8 +619,39 @@ export function parseTaskStarted(
     toolUseId: stringField(rec, "tool_use_id"),
     description: stringField(rec, "description") ?? "Subagent",
     taskType: stringField(rec, "task_type") ?? "",
+    subagentType: stringField(rec, "subagent_type"),
+    spawnDepth: optionalNumber(rec, "spawn_depth"),
+    prompt: stringField(rec, "prompt"),
+    // `skip_transcript` marks the CLI's own housekeeping tasks; they are
+    // ambient for our purposes even when the ambient flag is absent.
     backgrounded: rec.is_backgrounded === true,
-    ambient: rec.ambient === true,
+    ambient: rec.ambient === true || rec.skip_transcript === true,
+  };
+}
+
+function optionalNumber(
+  rec: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = rec[key];
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+export type ClaudeAgentUsage = {
+  totalTokens?: number;
+  toolUses?: number;
+  durationMs?: number;
+};
+
+function usageField(rec: Record<string, unknown>): ClaudeAgentUsage | undefined {
+  const usage = asRecord(rec.usage);
+  if (!usage) return undefined;
+  return {
+    totalTokens: optionalNumber(usage, "total_tokens"),
+    toolUses: optionalNumber(usage, "tool_uses"),
+    durationMs: optionalNumber(usage, "duration_ms"),
   };
 }
 
@@ -586,6 +662,7 @@ export type ClaudeAgentTaskProgress = {
   subagentType?: string;
   lastToolName?: string;
   summary?: string;
+  usage?: ClaudeAgentUsage;
 };
 
 export function parseTaskProgress(
@@ -606,6 +683,7 @@ export function parseTaskProgress(
     subagentType: stringField(rec, "subagent_type"),
     lastToolName: stringField(rec, "last_tool_name"),
     summary: stringField(rec, "summary"),
+    usage: usageField(rec),
   };
 }
 
@@ -650,6 +728,7 @@ export type ClaudeAgentTaskNotification = {
   status: string;
   summary: string;
   ambient: boolean;
+  usage?: ClaudeAgentUsage;
 };
 
 export function parseTaskNotification(
@@ -668,7 +747,8 @@ export function parseTaskNotification(
     toolUseId: stringField(rec, "tool_use_id"),
     status: stringField(rec, "status") ?? "completed",
     summary: stringField(rec, "summary") ?? "",
-    ambient: rec.ambient === true,
+    ambient: rec.ambient === true || rec.skip_transcript === true,
+    usage: usageField(rec),
   };
 }
 
@@ -734,6 +814,24 @@ export function isTerminalAgentTaskStatus(status: string | undefined): boolean {
     key === "killed" ||
     key === "stopped"
   );
+}
+
+/**
+ * Subagent thinking never arrives as a stream delta — the CLI forwards a
+ * subagent as whole messages — so the panel has to read it off the block.
+ */
+export function assistantThinkingBlocks(
+  rec: Record<string, unknown>,
+): string[] {
+  const message = asRecord(rec.message);
+  const content = message?.content;
+  if (!Array.isArray(content)) return [];
+  return content.flatMap((block) => {
+    const row = asRecord(block);
+    if (stringField(row, "type") !== "thinking") return [];
+    const text = typeof row?.thinking === "string" ? row.thinking : "";
+    return text ? [text] : [];
+  });
 }
 
 export function assistantTextBlocks(rec: Record<string, unknown>): string[] {

--- a/src/lib/harness/index.ts
+++ b/src/lib/harness/index.ts
@@ -126,6 +126,8 @@ export {
   steerHarnessTurn,
   canSteerHarness,
   cancelHarnessTurn,
+  stopHarnessAgent,
+  harnessAgentRelayPrompt,
   respondHarnessApproval,
   respondHarnessQuestion,
   stopHarnessSession,

--- a/src/lib/harness/registry.ts
+++ b/src/lib/harness/registry.ts
@@ -1,4 +1,4 @@
-import type { HarnessId } from "../session";
+import type { AgentRun, HarnessId } from "../session";
 import type { PrContent } from "../gitText";
 import { hasLiveCatalog } from "../models";
 import type { UserQuestionReply } from "../userQuestion";
@@ -33,6 +33,17 @@ export type HarnessAdapter = {
     requestId: number,
     reply: UserQuestionReply,
   ): void;
+  /**
+   * Stop one subagent without ending the turn. Absent when the harness has
+   * no per-agent handle; the agents panel then offers no Stop.
+   */
+  stopAgent?(sessionId: string, agent: AgentRun): Promise<void>;
+  /**
+   * How a message from the agents panel reaches a subagent. None of the
+   * harnesses expose a direct channel, so this phrases a relay for the main
+   * agent in the harness's own vocabulary (Claude: the SendMessage tool).
+   */
+  agentRelayPrompt?(agent: AgentRun, text: string): string;
   /** Kill the child but keep resume state for later rebind. */
   stopSession(sessionId: string): Promise<void>;
   /** Drop resume state and kill the child (delete, harness switch, idle detach). */
@@ -154,6 +165,27 @@ export async function cancelHarnessTurn(
   cancelIdlePark(sessionId);
   await adapter.cancelTurn(sessionId);
   scheduleIdlePark(harness, sessionId);
+}
+
+export async function stopHarnessAgent(
+  harness: HarnessId,
+  sessionId: string,
+  agent: AgentRun,
+): Promise<void> {
+  const adapter = getHarness(harness);
+  if (!adapter?.stopAgent) {
+    throw new Error(`${harness} cannot stop a single subagent.`);
+  }
+  await adapter.stopAgent(sessionId, agent);
+}
+
+/** The prompt that relays `text` to `agent`, or null when the harness has no way. */
+export function harnessAgentRelayPrompt(
+  harness: HarnessId,
+  agent: AgentRun,
+  text: string,
+): string | null {
+  return getHarness(harness)?.agentRelayPrompt?.(agent, text) ?? null;
 }
 
 export function respondHarnessApproval(

--- a/src/lib/harness/types.ts
+++ b/src/lib/harness/types.ts
@@ -1,4 +1,9 @@
-import type { Attachment, RuntimeMode, ToolPreview } from "../session";
+import type {
+  AgentRunStatus,
+  Attachment,
+  RuntimeMode,
+  ToolPreview,
+} from "../session";
 import type { UserQuestion } from "../userQuestion";
 
 export type HarnessEvent =
@@ -56,7 +61,48 @@ export type HarnessEvent =
     }
   | { type: "plan"; text: string }
   /** Context-window level after the harness's latest request. */
-  | { type: "context"; used?: number; window?: number };
+  | { type: "context"; used?: number; window?: number }
+  | {
+      type: "agent.started";
+      agentId: string;
+      title: string;
+      callId?: string;
+      taskId?: string;
+      agentType?: string;
+      depth?: number;
+      prompt?: string;
+      parentId?: string;
+    }
+  | {
+      type: "agent.updated";
+      agentId: string;
+      title?: string;
+      status?: AgentRunStatus;
+      activity?: string;
+      summary?: string;
+      tokens?: number;
+      toolUses?: number;
+      address?: string;
+      /** A stop was requested and the harness has not answered yet. */
+      stopping?: boolean;
+    }
+  /** A body or thinking delta the subagent wrote. */
+  | {
+      type: "agent.output";
+      agentId: string;
+      kind: "assistant" | "reasoning";
+      text: string;
+    }
+  | {
+      type: "agent.tool";
+      agentId: string;
+      callId: string;
+      title: string;
+      kind?: string;
+      status?: string;
+      detail?: string;
+      preview?: ToolPreview;
+    };
 
 export type ApprovalDecision = "allow" | "deny";
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -121,6 +121,44 @@ export type Block = {
   noteCard?: NoteCardMeta;
 };
 
+export type AgentRunStatus = "running" | "completed" | "failed" | "stopped";
+
+/**
+ * One spawned subagent, with the transcript it wrote. Claude only forwards a
+ * subagent's text when the session declares `forwardSubagentText`, so `blocks`
+ * is empty on harnesses that keep their subagents opaque; the header fields
+ * still fill in from task lifecycle events.
+ */
+export type AgentRun = {
+  id: string;
+  /** Harness task id, when the harness names one. Needed to stop it. */
+  taskId?: string;
+  /** The Agent tool call that spawned it — ties the run to its transcript row. */
+  callId?: string;
+  title: string;
+  /** Agent type as the harness named it ("Explore", "general-purpose", …). */
+  agentType?: string;
+  /** The brief this subagent was handed, when the harness reports one. */
+  prompt?: string;
+  status: AgentRunStatus;
+  /** A stop is in flight; cleared when the harness answers either way. */
+  stopping?: boolean;
+  /** 1 for a top-level spawn, N+1 for one spawned inside a depth-N agent. */
+  depth?: number;
+  startedAt: number;
+  endedAt?: number;
+  /** What the subagent is doing right now, as the harness last described it. */
+  activity?: string;
+  /** The run that spawned this one, for nested subagents. */
+  parentId?: string;
+  summary?: string;
+  tokens?: number;
+  toolUses?: number;
+  /** Address for SendMessage, when the harness reported one. */
+  address?: string;
+  blocks: Block[];
+};
+
 export type RuntimeMode =
   "supervised" | "auto-accept-edits" | "auto" | "full-access";
 
@@ -188,6 +226,12 @@ export type Session = {
    * In-memory; request ids do not survive restarts.
    */
   pendingQuestion?: UserQuestionPrompt;
+  /**
+   * Subagents this session spawned, oldest first. In-memory: a subagent's
+   * transcript is only forwarded while its process is live, so it cannot be
+   * rebuilt after a restart the way the main transcript can.
+   */
+  agents?: AgentRun[];
 };
 
 export type PendingHarnessSwitch = {

--- a/src/surfaces/AgentTranscript.tsx
+++ b/src/surfaces/AgentTranscript.tsx
@@ -14,8 +14,10 @@ import {
   X,
 } from "../chrome/icons";
 import {
+  createContext,
   memo,
   useCallback,
+  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -32,6 +34,7 @@ import { NoteMiniCard } from "../chrome/NoteMiniCard";
 import { TerminalSpinner } from "../chrome/TerminalSpinner";
 import type { ApprovalDecision } from "../lib/harness";
 import {
+  isAgentTool,
   isEditTool,
   isReadTool,
   isSearchTool,
@@ -67,6 +70,7 @@ import {
   hasRunningSubagent,
   isIncompleteTool,
   isThinkingBlock,
+  isToolBlock,
   lastActivityIndex,
   isProseBlock,
   needsApproval,
@@ -84,6 +88,30 @@ const NEAR_BOTTOM_PX = 16;
 const INITIAL_TURNS = 20;
 const TURN_PAGE_SIZE = 20;
 
+/**
+ * An Agent tool row is rendered five levels below the transcript root, through
+ * components that already take a dozen props each. Context keeps the click
+ * target out of every signature in between.
+ */
+type OpenAgent = {
+  open: (callId: string) => void;
+  /** Runs the panel can actually show, by the tool call that spawned them. */
+  ids: ReadonlySet<string>;
+};
+
+const OpenAgentContext = createContext<OpenAgent | undefined>(undefined);
+
+/** The panel opener for this block, when the block is a subagent we can show. */
+function useOpenAgent(block: Block): (() => void) | undefined {
+  const openAgent = useContext(OpenAgentContext);
+  const callId = block.tool?.callId;
+  if (!openAgent || !callId || !openAgent.ids.has(callId)) return undefined;
+  if (!isAgentTool(block.tool?.kind, block.text || block.tool?.title)) {
+    return undefined;
+  }
+  return () => openAgent.open(callId);
+}
+
 type Props = {
   blocks: Block[];
   busy?: boolean;
@@ -100,6 +128,10 @@ type Props = {
   onHandoff?: (harness: HarnessId, turn: Block[], model: string) => void;
   onJumpToBottomChange?: (show: boolean) => void;
   onJumpToBottomReady?: (jump: () => void) => void;
+  /** Opens the subagents panel on the run a given Agent tool call spawned. */
+  onOpenAgent?: (callId: string) => void;
+  /** Tool calls that have a run behind them; rows without one get no Open. */
+  agentCallIds?: ReadonlySet<string>;
   /** False while another tab is in front. Hidden tabs stay laid out. */
   visible?: boolean;
 };
@@ -120,8 +152,17 @@ export function AgentTranscript({
   onHandoff,
   onJumpToBottomChange,
   onJumpToBottomReady,
+  onOpenAgent,
+  agentCallIds,
   visible = true,
 }: Props) {
+  const openAgent = useMemo<OpenAgent | undefined>(
+    () =>
+      onOpenAgent && agentCallIds
+        ? { open: onOpenAgent, ids: agentCallIds }
+        : undefined,
+    [onOpenAgent, agentCallIds],
+  );
   const lockOverscroll = useLockOverscroll<HTMLDivElement>();
   const scroller = useRef<HTMLDivElement>(null);
   const stickToBottom = useRef(true);
@@ -291,6 +332,7 @@ export function AgentTranscript({
   };
 
   return (
+    <OpenAgentContext.Provider value={openAgent}>
     <div
       ref={setScroller}
       className="agent-transcript h-full overflow-y-auto overscroll-none [overflow-anchor:none] font-mono text-[13px] leading-5"
@@ -376,6 +418,12 @@ export function AgentTranscript({
                   completedAt={
                     startedAt != null ? startedAt + durationMs : undefined
                   }
+                  subagentCount={countSubagents(turn)}
+                  onOpenSubagents={
+                    openAgent
+                      ? () => openAgent.open(firstKnownAgentCall(turn, openAgent.ids))
+                      : undefined
+                  }
                   copyText={turnCopyText(turn)}
                   onSaveNote={onSaveNote}
                   fromHarness={
@@ -415,6 +463,7 @@ export function AgentTranscript({
         />
       ) : null}
     </div>
+    </OpenAgentContext.Provider>
   );
 }
 
@@ -449,6 +498,8 @@ function TurnDuration({
   waitingLabel,
   subagent = false,
   completedAt,
+  subagentCount = 0,
+  onOpenSubagents,
   copyText: output,
   onSaveNote,
   fromHarness,
@@ -462,6 +513,10 @@ function TurnDuration({
   waitingLabel?: string;
   subagent?: boolean;
   completedAt?: number;
+  /** Subagents this turn spawned, shown once the turn has settled. */
+  subagentCount?: number;
+  /** Opens the subagent panel on this turn's first run, when the panel has one. */
+  onOpenSubagents?: () => void;
   copyText?: string;
   onSaveNote?: (text: string) => void;
   fromHarness?: HarnessId;
@@ -531,8 +586,48 @@ function TurnDuration({
           </span>
         </>
       ) : null}
+
+      {done && subagentCount > 0 ? (
+        <>
+          {dot}
+          {onOpenSubagents ? (
+            <button
+              type="button"
+              title="Show this turn's subagents"
+              onClick={onOpenSubagents}
+              className="flex items-center gap-1 rounded text-content/35 transition-colors hover:text-content/70"
+            >
+              <Bot className="size-3" strokeWidth={1.75} />
+              {subagentCount === 1 ? "1 subagent" : `${subagentCount} subagents`}
+            </button>
+          ) : (
+            <span className="flex items-center gap-1 text-content/35">
+              <Bot className="size-3" strokeWidth={1.75} />
+              {subagentCount === 1 ? "1 subagent" : `${subagentCount} subagents`}
+            </span>
+          )}
+        </>
+      ) : null}
     </div>
   );
+}
+
+/** Top-level subagents a settled turn spawned — its Agent tool rows. */
+function countSubagents(turn: Block[]): number {
+  return turn.filter(
+    (block) =>
+      isToolBlock(block) &&
+      isAgentTool(block.tool?.kind, block.text || block.tool?.title),
+  ).length;
+}
+
+/** The first Agent call in `turn` the panel can show; "" opens it unselected. */
+function firstKnownAgentCall(turn: Block[], ids: ReadonlySet<string>): string {
+  for (const block of turn) {
+    const callId = block.tool?.callId;
+    if (callId && ids.has(callId) && isToolBlock(block)) return callId;
+  }
+  return "";
 }
 
 /** Wall-clock stamp for a finished turn, in the reader's own locale. */
@@ -1297,6 +1392,7 @@ function ActivityToolRow({
   const label = toolCallLabel(block, cwd);
   const state = toolCallState(block);
   const pending = needsApproval(block);
+  const openAgent = useOpenAgent(block);
   const openFile = isEditTool(
     block.tool?.kind,
     block.text || block.tool?.title,
@@ -1320,12 +1416,27 @@ function ActivityToolRow({
           failed={state === "rejected"}
           onOpenFile={openFile}
         />
+        {openAgent ? <OpenAgentButton onOpen={openAgent} /> : null}
         {pending ? null : <ToolCallStatusIcon state={state} />}
       </div>
       {pending ? (
         <ApprovalControls block={block} onApproval={onApproval} />
       ) : null}
     </div>
+  );
+}
+
+function OpenAgentButton({ onOpen }: { onOpen: () => void }) {
+  return (
+    <button
+      type="button"
+      title="Open this subagent's transcript"
+      aria-label="Open this subagent's transcript"
+      onClick={onOpen}
+      className="shrink-0 rounded px-1 font-sans text-[11px] text-content/45 hover:bg-content/10 hover:text-content"
+    >
+      Open
+    </button>
   );
 }
 
@@ -1436,6 +1547,7 @@ function ToolCall({
   embedded?: boolean;
 }) {
   const [open, setOpen] = useState(false);
+  const openAgent = useOpenAgent(block);
   const preview = block.tool?.preview;
   const label = toolCallLabel(block, cwd);
   const detail = block.tool?.detail?.trim();
@@ -1511,6 +1623,7 @@ function ToolCall({
             failed={state === "rejected"}
             onOpenFile={onOpenFile}
           />
+          {openAgent ? <OpenAgentButton onOpen={openAgent} /> : null}
         </div>
       )}
       {open && expandable ? (

--- a/src/surfaces/AgentsPanel.tsx
+++ b/src/surfaces/AgentsPanel.tsx
@@ -1,0 +1,501 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowUp,
+  Bot,
+  Check,
+  CircleDashed,
+  CircleX,
+  Square,
+  X,
+} from "../chrome/icons";
+import { TerminalSpinner } from "../chrome/TerminalSpinner";
+import { stoppableId } from "../lib/harness/agentRuns";
+import type { AgentRun, Block } from "../lib/session";
+import { AgentMarkdown } from "./AgentMarkdown";
+import { toolCallLabel } from "./transcriptActivity";
+
+type Props = {
+  agents: AgentRun[];
+  cwd?: string;
+  /** False once the session's process is gone: stop and reply stop working. */
+  live: boolean;
+  selectedId?: string;
+  onSelect: (agentId: string) => void;
+  onClose: () => void;
+  onStop?: (agent: AgentRun) => void;
+  onMessage?: (agent: AgentRun, text: string) => void;
+};
+
+export function AgentsPanel({
+  agents,
+  cwd,
+  live,
+  selectedId,
+  onSelect,
+  onClose,
+  onStop,
+  onMessage,
+}: Props) {
+  const selected =
+    agents.find((agent) => agent.id === selectedId) ??
+    agents.find((agent) => agent.status === "running") ??
+    agents[agents.length - 1];
+  const running = agents.filter((agent) => agent.status === "running").length;
+  const finished = agents.length - running;
+  const stoppable = agents.some(
+    (agent) => agent.status === "running" && !agent.stopping,
+  );
+  const rows = useMemo(() => treeRows(agents), [agents]);
+  // Elapsed time is derived from wall clock, so a run with no traffic would
+  // otherwise sit at whatever second it last rendered on.
+  useNowWhile(running > 0);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <aside
+      aria-label="Subagents"
+      className="absolute inset-y-0 right-0 z-40 flex w-[min(30rem,85%)] flex-col border-l border-content/10 bg-background-base/95 shadow-xl backdrop-blur-xl"
+    >
+      <header className="flex shrink-0 items-center gap-2 border-b border-content/10 px-3 py-2">
+        <Bot className="size-4 shrink-0 text-content/50" strokeWidth={1.75} />
+        <span className="min-w-0 flex-1 truncate font-sans text-xs text-content">
+          Subagents
+          <span className="text-content/45">
+            {" · "}
+            {running > 0 ? `${running} running` : "none running"}
+            {finished > 0 ? ` · ${finished} finished` : ""}
+          </span>
+        </span>
+        {running > 0 && onStop && live ? (
+          <button
+            type="button"
+            disabled={!stoppable}
+            title={
+              stoppable
+                ? "Stop every running subagent"
+                : "Waiting for Claude to confirm the stops"
+            }
+            onClick={() => {
+              // A stop cascades to nested runs, so only the top of each live
+              // subtree needs asking; stopping a child twice reads as an error.
+              for (const agent of agents) {
+                if (
+                  agent.status === "running" &&
+                  !agent.stopping &&
+                  !hasRunningAncestor(agents, agent)
+                ) {
+                  onStop(agent);
+                }
+              }
+            }}
+            className="flex shrink-0 items-center gap-1 rounded border border-content/15 px-1.5 py-0.5 font-sans text-[11px] text-content/60 hover:bg-content/10 hover:text-content disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+          >
+            <Square className="size-2.5" strokeWidth={2} />
+            {stoppable ? "Stop all" : "Stopping…"}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          aria-label="Close subagents"
+          title="Close subagents"
+          onClick={onClose}
+          className="grid size-5 shrink-0 place-items-center rounded text-content/50 hover:bg-content/10 hover:text-content"
+        >
+          <X className="size-3" strokeWidth={1.75} />
+        </button>
+      </header>
+
+      <div className="max-h-44 shrink-0 overflow-y-auto border-b border-content/10">
+        {rows.map(({ agent, level }) => (
+          <AgentListRow
+            key={agent.id}
+            agent={agent}
+            level={level}
+            selected={agent.id === selected?.id}
+            onSelect={() => onSelect(agent.id)}
+          />
+        ))}
+      </div>
+
+      {selected ? (
+        <AgentDetail
+          agent={selected}
+          agents={agents}
+          cwd={cwd}
+          live={live}
+          onStop={onStop}
+          onMessage={onMessage}
+        />
+      ) : (
+        <p className="p-4 font-sans text-xs text-content/45">
+          No subagents yet.
+        </p>
+      )}
+    </aside>
+  );
+}
+
+/**
+ * Spawn order, but with each run's children right under it. A nested agent
+ * listed away from its parent is what made "3 running" read as a lie next to
+ * six rows: the rows were real, the relationship was missing.
+ */
+function treeRows(agents: AgentRun[]): Array<{ agent: AgentRun; level: number }> {
+  const ids = new Set(agents.map((agent) => agent.id));
+  const out: Array<{ agent: AgentRun; level: number }> = [];
+  const walk = (parentId: string | undefined, level: number) => {
+    for (const agent of agents) {
+      const parent = agent.parentId && ids.has(agent.parentId) ? agent.parentId : undefined;
+      if (parent !== parentId) continue;
+      out.push({ agent, level });
+      walk(agent.id, level + 1);
+    }
+  };
+  walk(undefined, 0);
+  return out;
+}
+
+function hasRunningAncestor(agents: AgentRun[], agent: AgentRun): boolean {
+  let parent = agents.find((row) => row.id === agent.parentId);
+  while (parent) {
+    if (parent.status === "running") return true;
+    parent = agents.find((row) => row.id === parent?.parentId);
+  }
+  return false;
+}
+
+/** Running descendants of a run — what a Stop on it will take down too. */
+function runningDescendants(agents: AgentRun[], id: string): number {
+  let count = 0;
+  for (const agent of agents) {
+    if (agent.parentId !== id) continue;
+    if (agent.status === "running") count += 1;
+    count += runningDescendants(agents, agent.id);
+  }
+  return count;
+}
+
+const STATUS_LABEL: Record<AgentRun["status"], string> = {
+  running: "running",
+  completed: "done",
+  failed: "failed",
+  stopped: "stopped",
+};
+
+/** Re-renders once a second while anything is still running. */
+function useNowWhile(active: boolean) {
+  const [, tick] = useState(0);
+  useEffect(() => {
+    if (!active) return;
+    const id = window.setInterval(() => tick((n) => n + 1), 1000);
+    return () => window.clearInterval(id);
+  }, [active]);
+}
+
+function AgentListRow({
+  agent,
+  level,
+  selected,
+  onSelect,
+}: {
+  agent: AgentRun;
+  level: number;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const running = agent.status === "running";
+  return (
+    <button
+      type="button"
+      aria-current={selected}
+      onClick={onSelect}
+      style={{ paddingLeft: 12 + level * 14 }}
+      className={`flex w-full min-w-0 items-center gap-2 py-1.5 pr-3 text-left font-sans text-xs ${
+        selected
+          ? "bg-content/10 text-content"
+          : running
+            ? "text-content/70 hover:bg-content/5"
+            : "text-content/40 hover:bg-content/5"
+      }`}
+    >
+      {level > 0 ? (
+        <span aria-hidden className="shrink-0 text-content/25">
+          ↳
+        </span>
+      ) : null}
+      <AgentStatusIcon status={agent.status} />
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate" title={agent.title}>
+          {agent.title}
+        </span>
+        {running && agent.activity ? (
+          <span className="truncate text-[11px] text-content/40">
+            {agent.activity}
+          </span>
+        ) : null}
+      </span>
+      <span className="shrink-0 tabular-nums text-content/40">
+        {running ? agentMetrics(agent) : STATUS_LABEL[agent.status]}
+      </span>
+    </button>
+  );
+}
+
+function AgentStatusIcon({ status }: { status: AgentRun["status"] }) {
+  if (status === "running") {
+    return (
+      <CircleDashed
+        className="size-3.5 shrink-0 zen-tool-spin text-content/50"
+        strokeWidth={1.75}
+      />
+    );
+  }
+  if (status === "completed") {
+    return <Check className="size-3.5 shrink-0 text-content/45" strokeWidth={1.75} />;
+  }
+  return <CircleX className="size-3.5 shrink-0 text-red-400" strokeWidth={1.75} />;
+}
+
+function agentMetrics(agent: AgentRun): string {
+  const parts: string[] = [];
+  if (agent.tokens != null) parts.push(compactTokens(agent.tokens));
+  const elapsed = (agent.endedAt ?? Date.now()) - agent.startedAt;
+  if (elapsed > 1000) parts.push(`${Math.round(elapsed / 1000)}s`);
+  return parts.join(" · ");
+}
+
+function compactTokens(tokens: number): string {
+  if (tokens < 1000) return `${tokens}`;
+  return `${(tokens / 1000).toFixed(tokens < 10_000 ? 1 : 0)}k`;
+}
+
+function AgentDetail({
+  agent,
+  agents,
+  cwd,
+  live,
+  onStop,
+  onMessage,
+}: {
+  agent: AgentRun;
+  agents: AgentRun[];
+  cwd?: string;
+  live: boolean;
+  onStop?: (agent: AgentRun) => void;
+  onMessage?: (agent: AgentRun, text: string) => void;
+}) {
+  const scroller = useRef<HTMLDivElement>(null);
+  const pinned = useRef(true);
+  const lastBlock = agent.blocks[agent.blocks.length - 1];
+
+  useEffect(() => {
+    const el = scroller.current;
+    if (el && pinned.current) el.scrollTop = el.scrollHeight;
+  }, [agent.id, agent.blocks.length, lastBlock?.text]);
+
+  const subtitle = useMemo(() => {
+    const parts = [
+      agent.agentType,
+      agent.status === "running" ? agent.activity : STATUS_LABEL[agent.status],
+    ].filter(Boolean);
+    return parts.join(" · ");
+  }, [agent.agentType, agent.activity, agent.status]);
+  const nested = runningDescendants(agents, agent.id);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-start gap-2 px-3 py-2">
+        <div className="min-w-0 flex-1">
+          <p className="truncate font-sans text-xs text-content">{agent.title}</p>
+          {subtitle ? (
+            <p className="truncate font-sans text-[11px] text-content/45">
+              {subtitle}
+            </p>
+          ) : null}
+        </div>
+        {agent.status === "running" && onStop && live ? (
+          <button
+            type="button"
+            // Hiding this when Claude never named the run was the wrong call:
+            // a missing button reads as "this one cannot be stopped" with no
+            // reason given. Show it, disabled, and say why.
+            disabled={!stoppableId(agent) || agent.stopping}
+            title={
+              agent.stopping
+                ? "Waiting for Claude to confirm the stop"
+                : stoppableId(agent)
+                  ? "Stop this subagent"
+                  : "Claude never reported an id for this subagent — use the session Stop to end the whole turn."
+            }
+            aria-label="Stop this subagent"
+            onClick={() => onStop(agent)}
+            className="flex shrink-0 items-center gap-1 rounded border border-content/15 px-1.5 py-0.5 font-sans text-[11px] text-content/60 hover:bg-content/10 hover:text-content disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+          >
+            <Square className="size-2.5" strokeWidth={2} />
+            {agent.stopping
+              ? "Stopping…"
+              : nested > 0
+                ? `Stop (+${nested} nested)`
+                : "Stop"}
+          </button>
+        ) : null}
+      </div>
+
+      <div
+        ref={scroller}
+        onScroll={(event) => {
+          const el = event.currentTarget;
+          pinned.current =
+            el.scrollHeight - el.scrollTop - el.clientHeight < 24;
+        }}
+        className="min-h-0 flex-1 overflow-y-auto px-3 pb-2"
+      >
+        {agent.prompt ? (
+          <p className="mb-2 whitespace-pre-wrap break-words rounded border border-content/10 bg-content/5 px-2 py-1.5 font-sans text-xs text-content/60">
+            {agent.prompt}
+          </p>
+        ) : null}
+        {agent.blocks.length === 0 ? (
+          <EmptyAgentBody agent={agent} />
+        ) : (
+          agent.blocks.map((block) => (
+            <AgentBlockRow key={block.id} block={block} cwd={cwd} />
+          ))
+        )}
+        {agent.summary ? (
+          <p className="mt-2 border-t border-content/10 pt-2 font-sans text-xs text-content/55">
+            {agent.summary}
+          </p>
+        ) : null}
+      </div>
+
+      {onMessage ? (
+        <AgentComposer
+          agent={agent}
+          disabled={!live || agent.status !== "running"}
+          onSend={(text) => onMessage(agent, text)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function EmptyAgentBody({ agent }: { agent: AgentRun }) {
+  if (agent.status === "running") {
+    return (
+      <div className="flex items-center gap-2 py-3 font-sans text-xs text-content/45">
+        <TerminalSpinner />
+        Waiting for the subagent to write something.
+      </div>
+    );
+  }
+  return (
+    <p className="py-3 font-sans text-xs text-content/45">
+      This subagent finished without forwarding a transcript.
+    </p>
+  );
+}
+
+function AgentBlockRow({ block, cwd }: { block: Block; cwd?: string }) {
+  if (block.role === "tool") {
+    return (
+      <div className="flex min-w-0 items-center gap-1.5 py-0.5 font-sans text-xs text-content/55">
+        <ToolStateDot status={block.tool?.status} />
+        <span className="min-w-0 truncate">{toolCallLabel(block, cwd)}</span>
+      </div>
+    );
+  }
+  if (block.role === "reasoning") {
+    return (
+      <p className="whitespace-pre-wrap break-words py-1 font-sans text-xs italic text-content/40">
+        {block.text}
+      </p>
+    );
+  }
+  return (
+    <div className="min-w-0 py-1 text-sm text-content/85">
+      <AgentMarkdown text={block.text} streaming={block.streaming} cwd={cwd} />
+    </div>
+  );
+}
+
+function ToolStateDot({ status }: { status?: string }) {
+  const color =
+    status === "failed"
+      ? "bg-red-400"
+      : status === "completed"
+        ? "bg-content/30"
+        : "bg-accent";
+  return <span aria-hidden className={`size-1.5 shrink-0 rounded-full ${color}`} />;
+}
+
+/**
+ * Nothing in the CLI protocol delivers a message straight to a running
+ * subagent, so this asks the main agent to relay it. The copy says so, because
+ * a box that looks like a direct channel and is not would be a lie.
+ */
+function AgentComposer({
+  agent,
+  disabled,
+  onSend,
+}: {
+  agent: AgentRun;
+  disabled: boolean;
+  onSend: (text: string) => void;
+}) {
+  const [text, setText] = useState("");
+
+  const send = () => {
+    const trimmed = text.trim();
+    if (!trimmed || disabled) return;
+    onSend(trimmed);
+    setText("");
+  };
+
+  return (
+    <div className="shrink-0 border-t border-content/10 p-2">
+      <div className="flex items-end gap-1.5">
+        <textarea
+          value={text}
+          rows={1}
+          disabled={disabled}
+          placeholder={
+            disabled
+              ? "This subagent is no longer running."
+              : `Relay a message to ${agent.title}`
+          }
+          onChange={(event) => setText(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              send();
+            }
+          }}
+          className="max-h-24 min-h-7 flex-1 resize-none rounded border border-content/15 bg-transparent px-2 py-1 font-sans text-xs text-content outline-none placeholder:text-content/35 focus:border-content/30 disabled:opacity-50"
+        />
+        <button
+          type="button"
+          aria-label="Relay message"
+          title="Relay message through the main agent"
+          disabled={disabled || !text.trim()}
+          onClick={send}
+          className="grid size-7 shrink-0 place-items-center rounded bg-content/10 text-content hover:bg-content/15 disabled:opacity-40"
+        >
+          <ArrowUp className="size-3.5" strokeWidth={2} />
+        </button>
+      </div>
+      {disabled ? null : (
+        <p className="px-0.5 pt-1 font-sans text-[10px] text-content/35">
+          Sent through the main agent — it forwards this with SendMessage.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/surfaces/PaneTree.tsx
+++ b/src/surfaces/PaneTree.tsx
@@ -25,6 +25,7 @@ import {
 import type { RecentProject } from "../lib/recents";
 import type { TerminalMetaPatch } from "../lib/terminalTab";
 import type {
+  AgentRun,
   Attachment,
   Block,
   HarnessId,
@@ -97,6 +98,8 @@ type Shared = {
   ) => void;
   onMovePane: (fromId: string, toId: string, edge: PaneEdge) => void;
   onNewTerminal: (sessionId: string) => void;
+  onStopAgent?: (sessionId: string, agent: AgentRun) => void;
+  onMessageAgent?: (sessionId: string, agent: AgentRun, text: string) => void;
   onTerminalMetaChange?: (fileId: string, patch: TerminalMetaPatch) => void;
 };
 
@@ -149,6 +152,8 @@ function PaneTreeComponent({
   onHandoff,
   onMovePane,
   onNewTerminal,
+  onStopAgent,
+  onMessageAgent,
   onTerminalMetaChange,
 }: Props) {
   const treeRef = useRef<HTMLDivElement>(null);
@@ -332,6 +337,8 @@ function PaneTreeComponent({
                 onSecondOpinion={onSecondOpinion}
                 onHandoff={onHandoff}
                 onNewTerminal={onNewTerminal}
+                onStopAgent={onStopAgent}
+                onMessageAgent={onMessageAgent}
                 onPaneDragStart={onPaneDragStart}
               />
             ) : null}

--- a/src/surfaces/SessionPane.tsx
+++ b/src/surfaces/SessionPane.tsx
@@ -3,18 +3,21 @@ import {
   memo,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   useSyncExternalStore,
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import { Composer } from "../chrome/Composer";
+import { TerminalSpinner } from "../chrome/TerminalSpinner";
 import { SessionReview } from "../chrome/SessionReview";
 import type { ApprovalDecision, UserQuestionReply } from "../lib/harness";
 import { looksLikeProject, type RecentProject } from "../lib/recents";
 import {
   sessionDisplayTitle,
   sessionWorkCwd,
+  type AgentRun,
   type Attachment,
   type Block,
   type HarnessId,
@@ -22,6 +25,7 @@ import {
   type Session,
 } from "../lib/session";
 import { AgentTranscript } from "./AgentTranscript";
+import { AgentsPanel } from "./AgentsPanel";
 import { EmptySession } from "./EmptySession";
 import { MOD } from "../lib/platform";
 import { acknowledgeQuoteRequest, ADD_TO_CHAT_EVENT, type AddToChatRequest, type QuoteRequest } from "../lib/quoteDraft";
@@ -84,8 +88,44 @@ type Props = {
     model: string,
   ) => void;
   onNewTerminal: (sessionId: string) => void;
+  onStopAgent?: (sessionId: string, agent: AgentRun) => void;
+  onMessageAgent?: (sessionId: string, agent: AgentRun, text: string) => void;
   onPaneDragStart?: (event: ReactPointerEvent<HTMLElement>) => void;
 };
+
+/**
+ * Sits on the composer while subagents run and leaves when they are done, so
+ * a count that lingers cannot be misread as "still running". Finished runs
+ * stay reachable through the Open on their transcript row.
+ */
+function SubagentStrip({
+  running,
+  activity,
+  onOpen,
+}: {
+  running: number;
+  activity?: string;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="mx-4 mb-1 flex w-[calc(100%-2rem)] min-w-0 items-center gap-2 rounded-md border border-content/10 bg-content/5 px-2.5 py-1.5 text-left font-sans text-xs text-content/70 hover:bg-content/10 hover:text-content"
+    >
+      <TerminalSpinner />
+      <span className="shrink-0">
+        {running === 1 ? "1 subagent running" : `${running} subagents running`}
+      </span>
+      {activity ? (
+        <span className="min-w-0 flex-1 truncate text-content/45">{activity}</span>
+      ) : (
+        <span className="flex-1" />
+      )}
+      <span className="shrink-0 text-content/50">Open</span>
+    </button>
+  );
+}
 
 export const SessionPane = memo(function SessionPane({
   session,
@@ -115,6 +155,8 @@ export const SessionPane = memo(function SessionPane({
   onSecondOpinion,
   onHandoff,
   onNewTerminal,
+  onStopAgent,
+  onMessageAgent,
   onPaneDragStart,
 }: Props) {
   const title = sessionDisplayTitle(session.title, session.harness);
@@ -136,6 +178,21 @@ export const SessionPane = memo(function SessionPane({
   const quoteRequestId = useRef(0);
   const [showJumpToBottom, setShowJumpToBottom] = useState(false);
   const [quoteRequest, setQuoteRequest] = useState<QuoteRequest>();
+  const [agentsOpen, setAgentsOpen] = useState(false);
+  const [selectedAgentId, setSelectedAgentId] = useState<string>();
+  const agents = session.agents ?? [];
+  const runningAgents = agents.filter(
+    (agent) => agent.status === "running",
+  ).length;
+  const agentCallIds = useMemo(
+    () => new Set(agents.flatMap((agent) => (agent.callId ? [agent.callId] : []))),
+    [agents],
+  );
+
+  const openAgents = useCallback((agentId?: string) => {
+    if (agentId) setSelectedAgentId(agentId);
+    setAgentsOpen(true);
+  }, []);
   const onJumpToBottomReady = useCallback((jump: () => void) => {
     jumpToBottomRef.current = jump;
   }, []);
@@ -325,7 +382,29 @@ export const SessionPane = memo(function SessionPane({
               }
               onJumpToBottomChange={setShowJumpToBottom}
               onJumpToBottomReady={onJumpToBottomReady}
+              onOpenAgent={agents.length > 0 ? openAgents : undefined}
+              agentCallIds={agentCallIds}
             />
+            {agentsOpen ? (
+              <AgentsPanel
+                agents={agents}
+                cwd={workCwd}
+                live={!!session.busy || runningAgents > 0}
+                selectedId={selectedAgentId}
+                onSelect={setSelectedAgentId}
+                onClose={() => setAgentsOpen(false)}
+                onStop={
+                  onStopAgent
+                    ? (agent) => onStopAgent(session.id, agent)
+                    : undefined
+                }
+                onMessage={
+                  onMessageAgent
+                    ? (agent, text) => onMessageAgent(session.id, agent, text)
+                    : undefined
+                }
+              />
+            ) : null}
             {showJumpToBottom ? (
               <div className="pointer-events-none absolute inset-x-0 bottom-2 z-30 flex justify-center">
                 <button
@@ -344,7 +423,20 @@ export const SessionPane = memo(function SessionPane({
         )}
       </div>
       {dockComposer ? (
-        <div className="mx-auto w-full max-w-4xl shrink-0">{composer}</div>
+        <div className="mx-auto w-full max-w-4xl shrink-0">
+          {runningAgents > 0 && !agentsOpen ? (
+            <SubagentStrip
+              running={runningAgents}
+              activity={
+                agents.find(
+                  (agent) => agent.status === "running" && agent.activity,
+                )?.activity
+              }
+              onOpen={() => openAgents()}
+            />
+          ) : null}
+          {composer}
+        </div>
       ) : null}
     </div>
   );


### PR DESCRIPTION
Claude Code runs subagents, but MonoCode only ever showed them as a collapsed "Running 2 subagents" line: no way to see what each one was doing, read what it wrote, or stop one. This adds a subagents panel for Claude sessions, on top of a harness-neutral run model so other harnesses can plug in later.

**Scope: Claude Code only.** Codex, Cursor, OpenCode and the rest keep their current behaviour; the panel never appears for them because nothing emits run events yet. See "Other harnesses" below for what it takes.

## What the user gets

- **Strip above the composer** while subagents run: spinner, "N subagents running", the current activity of the first one, and Open. It disappears when nothing runs, so a stale count can no longer read as "still running".
- **Subagents panel** (right drawer): runs as a tree (nested spawns indented under their parent), each with activity, tokens and elapsed time; finished runs dimmed with done / stopped / failed. Selecting a run shows its brief, its own transcript (text, thinking, tool calls) and a reply box.
- **Stop / Stop all**, with the CLI's verdict read back. While a stop is in flight the button reads "Stopping…" and is disabled; a refusal is written into the transcript instead of vanishing.
- **Turn footer** shows how many subagents that turn spawned ("Worked for 21s · 19:21 · 3 subagents"); clicking it opens the panel on the first one.
- **Open** on the transcript row of any real subagent call.

## Protocol work, measured against CLI 2.1.258

The initialize request now declares `forwardSubagentText`, `agentProgressSummaries` and `perTaskStopAffordance`. Forwarded frames carry `parent_tool_use_id`, which is the only id a subagent's output ever names; a run is therefore keyed by the spawning Agent tool call, with the task id attached when `task_started` arrives.

Things the CLI does that shaped the code:

- `background_tasks_changed` arrives *before* `task_started` for the same task, so nothing is keyed from it; the earlier code minted a second row there, which is where the "6 rows for 3 agents" bug came from.
- `task_progress.description` is the agent's current activity ("Reading src/App.tsx"), not its name. It now feeds the detail line; the name stays what the spawn said.
- `stop_task` works on foreground and background agents, but does **not** stop a killed agent's own children. Stops cascade leaves-first.
- With `perTaskStopAffordance` declared, `interrupt` spares background agents, so the session Stop now sends `stop_task` for every live run before the interrupt.
- The SendMessage address in the Agent tool result is the task id, so a run only ever seen through forwarded frames still has a stop handle.

Two bugs in the previous Stop path were the cause of every "did not answer in time": after Stop the harness muted its whole stream, including `control_response`, and the app dropped every event for the old turn generation, including "run stopped". The mute now covers only the cancelled turn's own trailing output, and agent lifecycle events pass the generation guard, since subagents legitimately outlive the turn.

## Messaging a subagent

There is no host-to-subagent channel in the CLI's control protocol; the only address a subagent answers on is the model's SendMessage tool. The panel's reply box therefore sends the main agent a relay instruction ("forward this to subagent X, do not act on it"). It works, but it is indirect, and worth knowing before relying on it.

## Other harnesses

The run model (`AgentRun`, the `agent.*` harness events, the reducer, the panel, strip and footer) is harness-neutral. A harness joins by emitting `agent.started` / `agent.updated` / `agent.output` / `agent.tool` from its own stream and, optionally, implementing the two new adapter hooks `stopAgent` and `agentRelayPrompt`. Codex already exposes `subAgentActivity` items with an agent path, so it would be a mapping job in `codexProtocol.ts`, not new UI.

Subagent transcripts live in memory for the session; they are not persisted yet.

## Testing

`npm run check:web` - 1084 tests pass (26 new across the run reducer, protocol parsers and a mocked live CLI: identity across `background_tasks_changed`/`task_started`, cascade stops, refused stops, stops after cancel, stale-run settling, one row per agent). `tsc --noEmit` clean, `npm run build` OK. The lifecycle claims above were checked with probe scripts against the real CLI.
