### PR TITLE
Cancel in-progress CI when a PR is updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     strategy:


### PR DESCRIPTION
## What changed

Added a workflow-level `concurrency` group to `.github/workflows/ci.yml` so a new push to a pull request cancels the previous CI run instead of letting both finish.

Non-PR runs (including `main`) use `github.run_id` as the group fallback, so they are not canceled and cannot share a group with a PR.

## Why

Saves GitHub Actions minutes when iterating on a PR: the superseded run is canceled as soon as the next commit starts CI. Release workflow is unchanged.

## UI

N/A — CI config only.

## Checklist

- [ ] I ran `npm run check` (not applicable — YAML-only CI config)
- [x] This PR is small and focused
- [x] I did not mix unrelated changes