### PR TITLE
Refresh @ file mentions for new and spaced paths

### DIFF
--- a/src/chrome/Composer.tsx
+++ b/src/chrome/Composer.tsx
@@ -40,6 +40,7 @@ import {
   loadProjectFiles,
   peekProjectFiles,
   recentOpenedFiles,
+  subscribeProjectFiles,
 } from "../lib/fileIndex";
 import {
   buildMentionIndex,
@@ -601,13 +602,21 @@ export function Composer({
 
   useEffect(() => {
     let cancelled = false;
+    const apply = (next: ProjectFile[]) => {
+      if (!cancelled) setFiles(next);
+    };
+    const cached = peekProjectFiles(cwd);
+    if (cached) apply(cached);
     void loadProjectFiles(cwd, mentionOpen)
-      .then((next) => {
-        if (!cancelled) setFiles(next);
-      })
+      .then(apply)
       .catch(() => undefined);
+    const unsub = subscribeProjectFiles(() => {
+      const next = peekProjectFiles(cwd);
+      if (next) apply(next);
+    });
     return () => {
       cancelled = true;
+      unsub();
     };
   }, [cwd, mentionOpen]);
 

--- a/src/lib/fileIndex.test.ts
+++ b/src/lib/fileIndex.test.ts
@@ -1,10 +1,15 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProjectFile } from "./fs";
+import { listProjectFiles } from "./fs";
 import {
   invalidateProjectFiles,
+  loadProjectFiles,
+  peekProjectFiles,
   rememberOpenedFile,
   resolveOpenablePath,
+  subscribeProjectFiles,
 } from "./fileIndex";
+import { notifyDirsChanged } from "./fileTree";
 
 const cwd = "/Users/me/project";
 const files: ProjectFile[] = [
@@ -25,6 +30,12 @@ const files: ProjectFile[] = [
   },
 ];
 
+const extra: ProjectFile = {
+  name: "pasted.ts",
+  path: "/Users/me/project/pasted.ts",
+  relative: "pasted.ts",
+};
+
 vi.mock("./fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./fs")>();
   return {
@@ -33,9 +44,21 @@ vi.mock("./fs", async (importOriginal) => {
   };
 });
 
+const list = vi.mocked(listProjectFiles);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 describe("resolveOpenablePath", () => {
   beforeEach(() => {
-    invalidateProjectFiles(cwd);
+    invalidateProjectFiles();
+    list.mockReset();
+    list.mockResolvedValue(files);
   });
 
   it("maps a basename-only link to the shortest matching project path", async () => {
@@ -52,5 +75,97 @@ describe("resolveOpenablePath", () => {
   it("matches a relative project path", async () => {
     const resolved = await resolveOpenablePath(cwd, "apps/desktop/src/main.tsx");
     expect(resolved).toBe(files[2].path);
+  });
+});
+
+describe("loadProjectFiles", () => {
+  beforeEach(() => {
+    invalidateProjectFiles();
+    list.mockReset();
+    list.mockResolvedValue(files);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    invalidateProjectFiles();
+  });
+
+  it("returns the cached listing until refresh", async () => {
+    await loadProjectFiles(cwd);
+    list.mockResolvedValue([...files, extra]);
+    expect(await loadProjectFiles(cwd)).toEqual(files);
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(await loadProjectFiles(cwd, true)).toEqual([...files, extra]);
+    expect(peekProjectFiles(cwd)).toEqual([...files, extra]);
+  });
+
+  it("does not drop a refresh that arrives while a scan is in flight", async () => {
+    const first = deferred<ProjectFile[]>();
+    const second = deferred<ProjectFile[]>();
+    list.mockImplementationOnce(() => first.promise);
+    list.mockImplementationOnce(() => second.promise);
+
+    const initial = loadProjectFiles(cwd);
+    const refresh = loadProjectFiles(cwd, true);
+    expect(list).toHaveBeenCalledTimes(2);
+
+    first.resolve(files);
+    expect(await initial).toEqual(files);
+    expect(peekProjectFiles(cwd)).toBeNull();
+
+    second.resolve([...files, extra]);
+    expect(await refresh).toEqual([...files, extra]);
+    expect(peekProjectFiles(cwd)).toEqual([...files, extra]);
+  });
+
+  it("reuses the in-flight scan when refresh is not requested", async () => {
+    const pending = deferred<ProjectFile[]>();
+    list.mockImplementationOnce(() => pending.promise);
+
+    const first = loadProjectFiles(cwd);
+    const second = loadProjectFiles(cwd);
+    expect(list).toHaveBeenCalledTimes(1);
+
+    pending.resolve(files);
+    expect(await first).toEqual(files);
+    expect(await second).toEqual(files);
+  });
+
+  it("notifies subscribers when the listing changes", async () => {
+    const onChange = vi.fn();
+    const stop = subscribeProjectFiles(onChange);
+    await loadProjectFiles(cwd);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(peekProjectFiles(cwd)).toEqual(files);
+    stop();
+  });
+
+  it("reloads after a directory change", async () => {
+    vi.useFakeTimers();
+    await loadProjectFiles(cwd);
+    list.mockResolvedValue([...files, extra]);
+
+    const onChange = vi.fn();
+    const stop = subscribeProjectFiles(onChange);
+    onChange.mockClear();
+    notifyDirsChanged();
+
+    await vi.runAllTimersAsync();
+    expect(peekProjectFiles(cwd)).toEqual([...files, extra]);
+    expect(onChange).toHaveBeenCalled();
+    stop();
+  });
+
+  it("does not drop a scan for a different project", async () => {
+    const other = "/Users/me/other";
+    const pending = deferred<ProjectFile[]>();
+    list.mockImplementationOnce(() => pending.promise);
+
+    const scan = loadProjectFiles(other);
+    invalidateProjectFiles(cwd);
+    pending.resolve(files);
+
+    expect(await scan).toEqual(files);
+    expect(peekProjectFiles(other)).toEqual(files);
   });
 });

--- a/src/lib/fileIndex.ts
+++ b/src/lib/fileIndex.ts
@@ -1,4 +1,5 @@
 import { listProjectFiles, type ProjectFile } from "./fs";
+import { subscribeDirsChanged } from "./fileTree";
 import { scorePath, type FuzzyHit } from "./fuzzy";
 import { resolveWorkspacePath } from "./paths";
 import { looksLikeProject } from "./recents";
@@ -6,19 +7,38 @@ import { normalizeEditorPath } from "./search";
 
 const MAX_RECENTS = 30;
 const MAX_RESULTS = 80;
+const REFRESH_MS = 150;
 
 type Cache = {
   cwd: string;
   files: ProjectFile[];
 };
 
+type Listener = () => void;
+
 let cache: Cache | null = null;
 let inflight: { cwd: string; promise: Promise<ProjectFile[]> } | null = null;
+let lastCwd: string | null = null;
 let epoch = 0;
+let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+let refreshing = false;
+let refreshAgain = false;
+const listeners = new Set<Listener>();
 const recentsByCwd = new Map<string, string[]>();
 
 function normCwd(cwd: string): string {
   return cwd.replace(/\/+$/, "") || "/";
+}
+
+function notifyProjectFilesChanged() {
+  for (const listener of listeners) listener();
+}
+
+export function subscribeProjectFiles(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
 }
 
 export function peekProjectFiles(cwd: string): ProjectFile[] | null {
@@ -26,7 +46,51 @@ export function peekProjectFiles(cwd: string): ProjectFile[] | null {
 }
 
 export function invalidateProjectFiles(cwd?: string) {
+  if (cwd && cache?.cwd !== cwd && inflight?.cwd !== cwd) return;
   if (!cwd || cache?.cwd === cwd) cache = null;
+  if (!cwd || inflight?.cwd === cwd) {
+    inflight = null;
+    epoch += 1;
+  }
+  if (!cwd) {
+    lastCwd = null;
+    if (refreshTimer != null) {
+      clearTimeout(refreshTimer);
+      refreshTimer = null;
+    }
+  }
+  notifyProjectFilesChanged();
+}
+
+function scheduleIndexRefresh() {
+  if (!lastCwd) return;
+  if (typeof document !== "undefined" && document.hidden) return;
+  if (refreshTimer != null) return;
+  refreshTimer = setTimeout(() => {
+    refreshTimer = null;
+    void runIndexRefresh();
+  }, REFRESH_MS);
+}
+
+async function runIndexRefresh() {
+  if (refreshing) {
+    refreshAgain = true;
+    return;
+  }
+  const cwd = lastCwd;
+  if (!cwd) return;
+  refreshing = true;
+  try {
+    await loadProjectFiles(cwd, true);
+  } catch {
+    /* next focus / dir change will retry */
+  } finally {
+    refreshing = false;
+    if (refreshAgain) {
+      refreshAgain = false;
+      scheduleIndexRefresh();
+    }
+  }
 }
 
 export function rememberOpenedFile(cwd: string, path: string) {
@@ -53,17 +117,20 @@ export function loadProjectFiles(
   refresh = false,
 ): Promise<ProjectFile[]> {
   if (!looksLikeProject(cwd)) return Promise.resolve([]);
+  lastCwd = cwd;
   if (!refresh && cache?.cwd === cwd) return Promise.resolve(cache.files);
-  if (inflight?.cwd === cwd) return inflight.promise;
+  if (!refresh && inflight?.cwd === cwd) return inflight.promise;
 
   const id = ++epoch;
   const promise = listProjectFiles(cwd)
     .then((files) => {
-      if (id === epoch) cache = { cwd, files };
+      if (id !== epoch) return files;
+      cache = { cwd, files };
+      notifyProjectFilesChanged();
       return files;
     })
     .finally(() => {
-      if (inflight?.cwd === cwd) inflight = null;
+      if (inflight?.promise === promise) inflight = null;
     });
   inflight = { cwd, promise };
   return promise;
@@ -205,4 +272,15 @@ function pickOpenableFile(
   }
 
   return candidates.sort((a, b) => a.relative.length - b.relative.length)[0];
+}
+
+subscribeDirsChanged(scheduleIndexRefresh);
+
+if (typeof document !== "undefined") {
+  window.addEventListener("focus", () => {
+    if (!document.hidden) scheduleIndexRefresh();
+  });
+  document.addEventListener("visibilitychange", () => {
+    if (!document.hidden) scheduleIndexRefresh();
+  });
 }

--- a/src/lib/fileMentions.test.ts
+++ b/src/lib/fileMentions.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProjectFile } from "./fs";
+import { loadProjectFiles } from "./fileIndex";
 import {
+  applyFileMentionsToTurn,
   buildMentionIndex,
   fileMentionParts,
   fileMentionsInText,
@@ -10,6 +12,16 @@ import {
   replaceMentionToken,
   withMentionDirectories,
 } from "./fileMentions";
+
+vi.mock("./fileIndex", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./fileIndex")>();
+  return {
+    ...actual,
+    loadProjectFiles: vi.fn(actual.loadProjectFiles),
+  };
+});
+
+const list = vi.mocked(loadProjectFiles);
 
 const files: ProjectFile[] = [
   {
@@ -77,9 +89,38 @@ describe("buildMentionIndex", () => {
     expect(mentionLabel(files[0], index)).toBe("apps/desktop/src/App.tsx");
   });
 
-  it("skips paths that cannot survive a whitespace-delimited token", () => {
+  it("keeps a spaced path as a single @ token", () => {
+    expect(mentionLabel(files[3], index)).toBe("docs/read-me.md");
+    expect(index.labels.get("docs/read-me.md")).toBe(files[3]);
     expect(index.labels.has("read me.md")).toBe(false);
-    expect(index.labelOf.has(files[3].path)).toBe(false);
+  });
+
+  it("does not steal a token already owned by a real path", () => {
+    const spaced: ProjectFile = {
+      name: "read me.md",
+      path: "/p/notes/read me.md",
+      relative: "notes/read me.md",
+    };
+    const existing: ProjectFile = {
+      name: "read-me.md",
+      path: "/p/notes/read-me.md",
+      relative: "notes/read-me.md",
+    };
+    const mixed = buildMentionIndex([spaced, existing]);
+    expect(mentionLabel(existing, mixed)).toBe("read-me.md");
+    expect(mixed.labels.get("notes/read-me.md")).toBe(existing);
+    expect(mentionLabel(spaced, mixed)).toBe("notes/read-me.md~2");
+    expect(mixed.labels.get("notes/read-me.md~2")).toBe(spaced);
+  });
+
+  it("ignores paths that leave the project or break the tokenizer", () => {
+    const unsafe = buildMentionIndex([
+      { name: "secret", path: "/etc/secret", relative: "../secret" },
+      { name: "abs", path: "/tmp/abs", relative: "/tmp/abs" },
+      { name: "at.md", path: "/p/at.md", relative: "see@me.md" },
+      { name: "nul", path: "/p/nul", relative: "bad\0name.md" },
+    ]);
+    expect(unsafe.labels.size).toBe(0);
   });
 
   it("always accepts the relative path as a label", () => {
@@ -116,6 +157,21 @@ describe("buildMentionIndex", () => {
       path: "/p/docs",
       isDir: true,
     });
+  });
+
+  it("inserts a spaced folder as a normal @ token", () => {
+    const cat: ProjectFile = {
+      name: "cat.png",
+      path: "/p/My Photos/cat.png",
+      relative: "My Photos/cat.png",
+    };
+    const photos = buildMentionIndex([cat]);
+    const folder = [...photos.labels.values()].find(
+      (file) => file.relative === "My Photos",
+    );
+    expect(folder).toMatchObject({ isDir: true, relative: "My Photos" });
+    expect(mentionLabel(folder!, photos)).toBe("My-Photos");
+    expect(mentionLabel(cat, photos)).toBe("cat.png");
   });
 });
 
@@ -172,6 +228,14 @@ describe("fileMentionParts", () => {
 });
 
 describe("fileMentionsInText", () => {
+  it("highlights the encoded token for a spaced path", () => {
+    expect(fileMentionParts("see @docs/read-me.md now", index.labels)).toEqual([
+      { text: "see " },
+      { text: "@docs/read-me.md", file: files[3] },
+      { text: " now" },
+    ]);
+  });
+
   it("collects each referenced file once", () => {
     const hits = fileMentionsInText(
       "@Composer.tsx and @apps/web/src/App.tsx and @Composer.tsx",
@@ -190,10 +254,26 @@ describe("rankMentionFiles", () => {
     expect(ranked[0].path).toBe(files[1].path);
   });
 
-  it("fuzzy matches and drops paths with whitespace", () => {
+  it("fuzzy matches spaced names from a space-free query", () => {
     const ranked = rankMentionFiles(files, "read", []);
-    expect(ranked).toEqual([]);
+    expect(ranked[0].path).toBe(files[3].path);
     expect(rankMentionFiles(files, "compo", [])[0].path).toBe(files[2].path);
+  });
+
+  it("lists a folder whose name has spaces", () => {
+    const photos = [
+      {
+        name: "cat.png",
+        path: "/p/My Photos/cat.png",
+        relative: "My Photos/cat.png",
+      },
+    ];
+    expect(
+      rankMentionFiles(photos, "photos", []).some(
+        (file) => file.relative === "My Photos" && file.isDir,
+      ),
+    ).toBe(true);
+    expect(rankMentionFiles(photos, "cat", [])[0].path).toBe(photos[0].path);
   });
 
   it("offers folders alongside files", () => {
@@ -246,6 +326,19 @@ describe("withMentionDirectories", () => {
     expect(withMentionDirectories(entries)).toEqual(entries);
   });
 
+  it("keeps parent folders that contain spaces", () => {
+    const entries = withMentionDirectories([
+      {
+        name: "cat.png",
+        path: "/p/My Photos/cat.png",
+        relative: "My Photos/cat.png",
+      },
+    ]);
+    expect(entries.some((file) => file.relative === "My Photos" && file.isDir)).toBe(
+      true,
+    );
+  });
+
   it("rebuilds folder paths on Windows separators", () => {
     const [dir] = withMentionDirectories([
       {
@@ -259,5 +352,26 @@ describe("withMentionDirectories", () => {
       path: "C:\\p\\apps\\web",
       isDir: true,
     });
+  });
+});
+
+describe("applyFileMentionsToTurn", () => {
+  beforeEach(() => {
+    list.mockReset();
+    list.mockResolvedValue(files);
+  });
+
+  it("maps a spaced-file token to the real relative path on send", async () => {
+    const out = await applyFileMentionsToTurn("look at @docs/read-me.md", "/p");
+    expect(out).toContain("look at @docs/read-me.md");
+    expect(out).toContain("- @docs/read-me.md → docs/read me.md");
+  });
+
+  it("does not invent a path from a token that is not in the index", async () => {
+    const out = await applyFileMentionsToTurn(
+      "look at @notes/read-me.md~2",
+      "/p",
+    );
+    expect(out).toBe("look at @notes/read-me.md~2");
   });
 });

--- a/src/lib/fileMentions.test.ts
+++ b/src/lib/fileMentions.test.ts
@@ -119,6 +119,11 @@ describe("buildMentionIndex", () => {
       { name: "abs", path: "/tmp/abs", relative: "/tmp/abs" },
       { name: "at.md", path: "/p/at.md", relative: "see@me.md" },
       { name: "nul", path: "/p/nul", relative: "bad\0name.md" },
+      { name: "ls.md", path: "/p/ls.md", relative: "docs/read\u2028me.md" },
+      { name: "ps.md", path: "/p/ps.md", relative: "docs/read\u2029me.md" },
+      { name: "nel.md", path: "/p/nel.md", relative: "a\u0085b.md" },
+      { name: "bidi.md", path: "/p/bidi.md", relative: "photo\u202Egpj.md" },
+      { name: "zwsp.ts", path: "/p/zwsp.ts", relative: "file\u200B.ts" },
     ]);
     expect(unsafe.labels.size).toBe(0);
   });

--- a/src/lib/fileMentions.ts
+++ b/src/lib/fileMentions.ts
@@ -308,10 +308,10 @@ function pathDepth(relative: string): number {
   return depth;
 }
 
-/** Workspace-relative only: no absolute paths, `..`, or control characters. */
+/** Workspace-relative only: no absolute paths, `..`, or control / format characters. */
 function isSafeProjectRelative(relative: string): boolean {
   if (!relative || relative.length > MAX_QUERY * 4) return false;
-  if (/[\u0000-\u001f\u007f]/.test(relative)) return false;
+  if (hasUnsafeChars(relative)) return false;
   if (relative.startsWith("/") || relative.startsWith("\\")) return false;
   if (relative.includes("://")) return false;
   for (const part of relative.split("/")) {
@@ -335,8 +335,13 @@ function isTokenSafe(value: string): boolean {
     value.length > 0 &&
     value.length <= MAX_QUERY &&
     !/[\s@\\]/.test(value) &&
-    !/[\u0000-\u001f\u007f]/.test(value)
+    !hasUnsafeChars(value)
   );
+}
+
+/** ASCII/C1 controls, bidi/format marks, and Unicode line/paragraph separators. */
+function hasUnsafeChars(value: string): boolean {
+  return /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u.test(value);
 }
 
 function isMentionableRelative(relative: string): boolean {

--- a/src/lib/fileMentions.ts
+++ b/src/lib/fileMentions.ts
@@ -76,7 +76,9 @@ export function replaceMentionToken(
 }
 
 export function buildMentionIndex(files: ProjectFile[]): MentionIndex {
-  const entries = withMentionDirectories(files);
+  const entries = withMentionDirectories(files).filter((file) =>
+    isMentionableRelative(file.relative),
+  );
   const counts = new Map<string, number>();
   for (const file of entries) {
     counts.set(file.name, (counts.get(file.name) ?? 0) + 1);
@@ -84,14 +86,34 @@ export function buildMentionIndex(files: ProjectFile[]): MentionIndex {
 
   const labels = new Map<string, ProjectFile>();
   const labelOf = new Map<string, string>();
+  const used = new Set<string>();
+
+  const claim = (label: string, file: ProjectFile, preferred = false) => {
+    if (!isTokenSafe(label) || used.has(label)) return false;
+    used.add(label);
+    labels.set(label, file);
+    if (preferred || !labelOf.has(file.path)) labelOf.set(file.path, label);
+    return true;
+  };
+
   for (const file of entries) {
-    if (hasSpace(file.relative)) continue;
     const unique =
-      !file.isDir && counts.get(file.name) === 1 && !hasSpace(file.name);
-    labelOf.set(file.path, unique ? file.name : file.relative);
-    if (!labels.has(file.relative)) labels.set(file.relative, file);
-    if (unique && !labels.has(file.name)) labels.set(file.name, file);
+      !file.isDir && counts.get(file.name) === 1 && isTokenSafe(file.name);
+    if (unique) claim(file.name, file, true);
+    if (isTokenSafe(file.relative)) claim(file.relative, file);
   }
+
+  for (const file of entries) {
+    if (labelOf.has(file.path)) continue;
+    const encoded = encodeMentionToken(file.relative);
+    if (!encoded) continue;
+    let label = encoded;
+    for (let n = 2; used.has(label) && n < 1000; n++) {
+      label = `${encoded}~${n}`;
+    }
+    claim(label, file, true);
+  }
+
   return { labels, labelOf };
 }
 
@@ -106,8 +128,8 @@ export function rankMentionFiles(
   recents: string[],
   limit = MAX_PICKER,
 ): RankedFile[] {
-  const usable = withMentionDirectories(files).filter(
-    (file) => !hasSpace(file.relative),
+  const usable = withMentionDirectories(files).filter((file) =>
+    isMentionableRelative(file.relative),
   );
   const needle = query.replace(/\/+$/, "").trim();
   if (needle) return rankProjectFiles(usable, needle, recents, limit);
@@ -198,15 +220,16 @@ export function withMentionDirectories(files: ProjectFile[]): ProjectFile[] {
   const dirs = new Map<string, ProjectFile>();
   for (const file of files) {
     if (file.isDir) {
-      if (!hasSpace(file.relative)) dirs.set(file.relative, file);
+      if (isSafeProjectRelative(file.relative)) dirs.set(file.relative, file);
       continue;
     }
+    if (!isSafeProjectRelative(file.relative)) continue;
     const parts = file.relative.split("/");
     let rel = "";
     for (let i = 0; i < parts.length - 1; i++) {
       const segment = parts[i]!;
       rel = rel ? `${rel}/${segment}` : segment;
-      if (dirs.has(rel) || hasSpace(rel)) continue;
+      if (dirs.has(rel) || !isSafeProjectRelative(rel)) continue;
       dirs.set(rel, {
         name: segment,
         path: mentionDirPath(file, rel),
@@ -285,8 +308,40 @@ function pathDepth(relative: string): number {
   return depth;
 }
 
-function hasSpace(value: string): boolean {
-  return /\s/.test(value);
+/** Workspace-relative only: no absolute paths, `..`, or control characters. */
+function isSafeProjectRelative(relative: string): boolean {
+  if (!relative || relative.length > MAX_QUERY * 4) return false;
+  if (/[\u0000-\u001f\u007f]/.test(relative)) return false;
+  if (relative.startsWith("/") || relative.startsWith("\\")) return false;
+  if (relative.includes("://")) return false;
+  for (const part of relative.split("/")) {
+    if (!part || part === "." || part === "..") return false;
+  }
+  return true;
+}
+
+/**
+ * `@` tokens are one whitespace-delimited word. Collapse whitespace so a
+ * spaced path still inserts as a normal `@label`; the real relative path is
+ * recovered from the mention index on send.
+ */
+function encodeMentionToken(relative: string): string | null {
+  const encoded = relative.replace(/\s+/g, "-");
+  return isTokenSafe(encoded) ? encoded : null;
+}
+
+function isTokenSafe(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= MAX_QUERY &&
+    !/[\s@\\]/.test(value) &&
+    !/[\u0000-\u001f\u007f]/.test(value)
+  );
+}
+
+function isMentionableRelative(relative: string): boolean {
+  if (!isSafeProjectRelative(relative)) return false;
+  return isTokenSafe(relative) || encodeMentionToken(relative) != null;
 }
 
 function isSpace(ch: string): boolean {


### PR DESCRIPTION
## What changed

The project file index now refreshes on window focus and directory-change notifications, and a refresh is no longer dropped if a scan is already in flight. The composer `@` picker subscribes to those updates.

Paths with spaces are included in `@`. The picker still shows the real name. Picking one inserts a single-word `@` token (spaces become hyphens). On send, the prompt maps that token to the real project-relative path. Paths that leave the workspace or would break the tokenizer are skipped.

## Why

`@` used a stale in-memory `git ls-files` cache. The explorer already reloaded on focus; the mention list did not. Files copied into the project from Finder therefore did not appear until something else forced a full reload.

`@` tokens are one whitespace-delimited word, so spaced names were excluded entirely. They now stay a normal `@label` in the composer, with the real path recovered from the mention index on send rather than decoded from user text.

## UI

Behavior only. Copy a file or a folder (including names with spaces) into the project, return to MonoCode, type `@` plus part of the name, pick it, and confirm it is referenced in the prompt.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes

Fixes #66 