### PR TITLE
Preserve composer draft when opening files from the explorer

### DIFF
--- a/src/chrome/Composer.tsx
+++ b/src/chrome/Composer.tsx
@@ -169,6 +169,7 @@ type Props = {
   onSteerQueuedMessage?: (messageId: string) => void;
   onResumeQueue?: () => void;
   onOpenFile?: (path: string) => void;
+  onDraftChange?: (text: string) => void;
   children?: ReactNode;
 };
 
@@ -414,6 +415,7 @@ export function Composer({
   onSteerQueuedMessage,
   onResumeQueue,
   onOpenFile,
+  onDraftChange,
   children,
 }: Props) {
   const ref = useRef<HTMLTextAreaElement>(null);
@@ -640,9 +642,13 @@ export function Composer({
   useEffect(() => {
     const el = ref.current;
     if (!el || !initialDraft) return;
-    el.value = initialDraft;
+    if (el.value !== initialDraft) el.value = initialDraft;
     resizeTextarea(el);
   }, [initialDraft]);
+
+  useEffect(() => {
+    onDraftChange?.(draft);
+  }, [draft, onDraftChange]);
 
   const syncHighlightScroll = (e: UIEvent<HTMLTextAreaElement>) => {
     const highlight = highlightRef.current;
@@ -858,6 +864,7 @@ export function Composer({
       ref.current.value = "";
       ref.current.style.height = "auto";
       setDraft("");
+      onDraftChange?.("");
       setPlusOpen(false);
       setSlash(null);
       setMention(null);
@@ -878,6 +885,7 @@ export function Composer({
     ref.current.value = "";
     ref.current.style.height = "auto";
     setDraft("");
+    onDraftChange?.("");
     setAttachments([]);
     setPlanSelected(false);
     setPlusOpen(false);

--- a/src/surfaces/SessionPane.tsx
+++ b/src/surfaces/SessionPane.tsx
@@ -236,6 +236,7 @@ export const SessionPane = memo(function SessionPane({
   const isEmpty = session.blocks.length === 0;
   const showDeckProjectPicker = isEmpty && !looksLikeProject(session.cwd);
   const dockComposer = !isEmpty || inSplit;
+  const draftRef = useRef<string | undefined>(undefined);
   const composer = (
     <Composer
       enabled={visible}
@@ -254,10 +255,14 @@ export const SessionPane = memo(function SessionPane({
       context={session.context}
       quoteRequest={quoteRequest}
       initialDraft={
-        session.inboxCard || session.noteCard || session.handoffCard
+        draftRef.current ??
+        (session.inboxCard || session.noteCard || session.handoffCard
           ? undefined
-          : session.composerSeed
+          : session.composerSeed)
       }
+      onDraftChange={(text) => {
+        draftRef.current = text;
+      }}
       inboxCard={session.inboxCard}
       noteCard={session.noteCard}
       handoffCard={session.handoffCard}


### PR DESCRIPTION
## What changed

`Composer` reports its draft to `SessionPane`, which keeps the latest text and passes it back as `initialDraft` when the composer remounts. Submit clears it so a sent message does not reappear.

## Why

Fixes a bug where a draft message disappears from the chat input when you open a file from the explorer. Type a message in a new session, click any file in the sidebar, and the input is empty.

The file opens in a split next to the session. That moves the composer from the empty view into the dock. React remounts it under the new parent and the typed text is lost. The same happens when a terminal opens in an empty session or the file pane closes.

Keeping the draft in `SessionPane`, which survives the split, fixes all three cases without touching the layout.

Not covered: attachments and the plan toggle still reset on that remount.

## UI

No visual change.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes
