### PR TITLE
Detect Bun-managed Codex CLI

### DIFF
--- a/src-tauri/src/harness.rs
+++ b/src-tauri/src/harness.rs
@@ -1229,6 +1229,7 @@ fn resolve_codex() -> Option<PathBuf> {
 
     if let Some(home) = &home {
         candidates.push(home.join(".local/bin/codex"));
+        candidates.push(home.join(".bun/bin/codex"));
         candidates.push(home.join(".npm-global/bin/codex"));
         candidates.push(home.join(".cargo/bin/codex"));
         candidates.push(home.join("n/bin/codex"));


### PR DESCRIPTION
## What changed

MonoCode now checks `~/.bun/bin/codex` when resolving the Codex CLI.

## Why

Apps such as T3 can provision Codex in `~/.bun/bin`, while GUI processes may not inherit that directory through `PATH`. MonoCode could therefore report an existing Codex installation as unavailable.

This is the discovery-only slice of #81. Downloading and executing an installer from the application is intentionally excluded and will require a separate review covering Windows support, integrity and update behavior, failure recovery, and the security boundary.

## UI

No UI changes.

## Checklist

- [x] I ran `npm run check:rust`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Codex CLI detection now also supports installations located in the user’s `~/.bun/bin` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->