### PR TITLE
Auto-collapse thinking and tool activity after turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Finished turns fold thinking and tool activity into one expandable summary above the final answer. The behavior is enabled by default and can be changed under Settings → General; failed or rejected calls remain counted in the folded header. In #79.
+
 ## [0.1.34] - 2026-09-05
 
 ### Added

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  AUTO_COLLAPSE_ACTIVITY_DEFAULT,
   COMPOSER_RUNNER_DEFAULT,
   DIFF_VIEWER_DEFAULT,
   FOLLOW_UP_BEHAVIOR_DEFAULT,
@@ -7,6 +8,7 @@ import {
   KEYBINDINGS,
   LIVE_AGENTS_ENABLED_DEFAULT,
   loadComposerRunner,
+  loadAutoCollapseActivity,
   loadDiffViewer,
   loadFollowUpBehavior,
   loadGridArcadeEnabled,
@@ -14,6 +16,7 @@ import {
   loadNotesEnabled,
   NOTES_ENABLED_DEFAULT,
   saveComposerRunner,
+  saveAutoCollapseActivity,
   saveDiffViewer,
   saveFollowUpBehavior,
   saveGridArcadeEnabled,
@@ -27,6 +30,22 @@ const LIVE_AGENTS_KEY = "monocode.liveAgentsEnabled";
 const GRID_ARCADE_KEY = "monocode.gridArcadeEnabled";
 const DIFF_VIEWER_KEY = "monocode.diffViewer";
 const FOLLOW_UP_BEHAVIOR_KEY = "monocode.followUpBehavior";
+const AUTO_COLLAPSE_ACTIVITY_KEY = "monocode.autoCollapseActivity";
+
+describe("auto-collapse activity setting", () => {
+  beforeEach(mockLocalStorage);
+  afterEach(() => {
+    localStorage.removeItem(AUTO_COLLAPSE_ACTIVITY_KEY);
+  });
+
+  it("defaults to on and persists an off switch", () => {
+    expect(AUTO_COLLAPSE_ACTIVITY_DEFAULT).toBe(true);
+    expect(loadAutoCollapseActivity()).toBe(true);
+    saveAutoCollapseActivity(false);
+    expect(localStorage.getItem(AUTO_COLLAPSE_ACTIVITY_KEY)).toBe("0");
+    expect(loadAutoCollapseActivity()).toBe(false);
+  });
+});
 
 describe("follow-up behavior setting", () => {
   beforeEach(mockLocalStorage);

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -80,6 +80,48 @@ const COMPOSER_RUNNER_KEY = "monocode.composerRunner";
 
 const FOLLOW_UP_BEHAVIOR_KEY = "monocode.followUpBehavior";
 
+const AUTO_COLLAPSE_ACTIVITY_KEY = "monocode.autoCollapseActivity";
+
+export const AUTO_COLLAPSE_ACTIVITY_DEFAULT = true;
+
+/** Fired on `window` when settled transcript activity compactness changes. */
+export const AUTO_COLLAPSE_ACTIVITY_CHANGE_EVENT =
+  "monocode:auto-collapse-activity-change";
+
+export function loadAutoCollapseActivity(): boolean {
+  try {
+    const raw = localStorage.getItem(AUTO_COLLAPSE_ACTIVITY_KEY);
+    if (raw == null) return AUTO_COLLAPSE_ACTIVITY_DEFAULT;
+    return raw === "1" || raw === "true";
+  } catch {
+    return AUTO_COLLAPSE_ACTIVITY_DEFAULT;
+  }
+}
+
+export function saveAutoCollapseActivity(value: boolean) {
+  try {
+    localStorage.setItem(AUTO_COLLAPSE_ACTIVITY_KEY, value ? "1" : "0");
+  } catch {
+    // private mode / quota
+  }
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<boolean>(AUTO_COLLAPSE_ACTIVITY_CHANGE_EVENT, {
+      detail: value,
+    }),
+  );
+}
+
+export function subscribeAutoCollapseActivity(onStoreChange: () => void) {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener(AUTO_COLLAPSE_ACTIVITY_CHANGE_EVENT, onStoreChange);
+  return () =>
+    window.removeEventListener(
+      AUTO_COLLAPSE_ACTIVITY_CHANGE_EVENT,
+      onStoreChange,
+    );
+}
+
 export type FollowUpBehavior = "steer" | "queue";
 
 export const FOLLOW_UP_BEHAVIOR_DEFAULT: FollowUpBehavior = "steer";

--- a/src/surfaces/AgentTranscript.tsx
+++ b/src/surfaces/AgentTranscript.tsx
@@ -13,6 +13,7 @@ import {
   X,
 } from "../chrome/icons";
 import {
+  Fragment,
   memo,
   useCallback,
   useEffect,
@@ -149,6 +150,9 @@ export function AgentTranscript({
   const wasVisible = useRef(false);
   const [scrollerEl, setScrollerEl] = useState<HTMLDivElement | null>(null);
   const [visibleTurnCount, setVisibleTurnCount] = useState(INITIAL_TURNS);
+  const [expandedActivityTurns, setExpandedActivityTurns] = useState<
+    Set<string>
+  >(() => new Set());
   // Stretch the last turn after a send while this tab stays open. Closing
   // the tab is a new visit: the remount uses the true transcript height so
   // the latest reply sits on the composer instead of a hole of empty space.
@@ -365,6 +369,17 @@ export function AgentTranscript({
                 item.type === "activity" ? item.blocks : [],
               )
             : [];
+          const turnId = turn[0].id;
+          const compactActivityExpanded =
+            compactActivity && expandedActivityTurns.has(turnId);
+          const toggleCompactActivity = () => {
+            setExpandedActivityTurns((current) => {
+              const next = new Set(current);
+              if (next.has(turnId)) next.delete(turnId);
+              else next.add(turnId);
+              return next;
+            });
+          };
           const turnHarness = harness
             ? harnessForTurn(blocks, turn, harness)
             : undefined;
@@ -382,18 +397,26 @@ export function AgentTranscript({
               {items.map((item, itemIndex) =>
                 item.type === "activity" ? (
                   compactActivity ? (
-                    itemIndex === foldedAt ? (
-                      <ActivityPhases
-                        key={item.blocks[0].id}
-                        blocks={compactActivityBlocks}
-                        cwd={cwd}
-                        done
-                        compact
-                        onApproval={onApproval}
-                        onOpenFile={onOpenFile}
-                        onOpenDiff={onOpenDiff}
-                      />
-                    ) : null
+                    <Fragment key={item.blocks[0].id}>
+                      {compactActivityExpanded ? (
+                        <ActivityPhases
+                          blocks={item.blocks}
+                          cwd={cwd}
+                          done
+                          defaultOpen
+                          onApproval={onApproval}
+                          onOpenFile={onOpenFile}
+                          onOpenDiff={onOpenDiff}
+                        />
+                      ) : null}
+                      {itemIndex === foldedAt ? (
+                        <ActivitySummary
+                          blocks={compactActivityBlocks}
+                          expanded={compactActivityExpanded}
+                          onToggle={toggleCompactActivity}
+                        />
+                      ) : null}
+                    </Fragment>
                   ) : itemIndex === initialThinkingAt ? (
                     <InitialThinking key={item.blocks[0].id} live={!settled} />
                   ) : (
@@ -945,7 +968,7 @@ function ActivityPhases({
   blocks,
   cwd,
   done,
-  compact = false,
+  defaultOpen = false,
   onApproval,
   onOpenFile,
   onOpenDiff,
@@ -953,52 +976,12 @@ function ActivityPhases({
   blocks: Block[];
   cwd?: string;
   done?: boolean;
-  compact?: boolean;
+  defaultOpen?: boolean;
   onApproval?: (requestId: number, decision: ApprovalDecision) => void;
   onOpenFile?: (path: string) => void;
   onOpenDiff?: (path: string) => void;
 }) {
   const phases = useMemo(() => buildActivityPhases(blocks), [blocks]);
-  const [expanded, setExpanded] = useState(false);
-
-  if (compact) {
-    const summary = activitySummary(blocks);
-    return (
-      <div className="flex min-w-0 flex-col px-4">
-        <button
-          type="button"
-          aria-expanded={expanded}
-          aria-label={expanded ? "Hide activity" : `Show activity: ${summary}`}
-          onClick={() => setExpanded((value) => !value)}
-          className="group flex w-full min-w-0 items-center gap-1.5 py-1 text-left"
-        >
-          <ChevronRight
-            className={`size-3.5 shrink-0 text-content/45 transition-transform duration-200 ${expanded ? "rotate-90" : ""}`}
-            strokeWidth={1.75}
-          />
-          <span className="min-w-0 flex-1 truncate font-sans text-sm text-content/50 transition-colors duration-200 group-hover:text-content/80">
-            {summary}
-          </span>
-        </button>
-        {expanded ? (
-          <div className="flex min-w-0 flex-col gap-1">
-            {phases.map((phase) => (
-              <ActivityPhaseGroup
-                key={phase.id}
-                phase={phase}
-                cwd={cwd}
-                active={false}
-                defaultOpen
-                onApproval={onApproval}
-                onOpenFile={onOpenFile}
-                onOpenDiff={onOpenDiff}
-              />
-            ))}
-          </div>
-        ) : null}
-      </div>
-    );
-  }
 
   return (
     <div className="flex min-w-0 flex-col gap-1 px-4">
@@ -1008,11 +991,43 @@ function ActivityPhases({
           phase={phase}
           cwd={cwd}
           active={!done && index === phases.length - 1}
+          defaultOpen={defaultOpen}
           onApproval={onApproval}
           onOpenFile={onOpenFile}
           onOpenDiff={onOpenDiff}
         />
       ))}
+    </div>
+  );
+}
+
+function ActivitySummary({
+  blocks,
+  expanded,
+  onToggle,
+}: {
+  blocks: Block[];
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const summary = activitySummary(blocks);
+  return (
+    <div className="flex min-w-0 flex-col px-4">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-label={expanded ? "Hide activity" : `Show activity: ${summary}`}
+        onClick={onToggle}
+        className="group flex w-full min-w-0 items-center gap-1.5 py-1 text-left"
+      >
+        <ChevronRight
+          className={`size-3.5 shrink-0 text-content/45 transition-transform duration-200 ${expanded ? "rotate-90" : ""}`}
+          strokeWidth={1.75}
+        />
+        <span className="min-w-0 flex-1 truncate font-sans text-sm text-content/50 transition-colors duration-200 group-hover:text-content/80">
+          {summary}
+        </span>
+      </button>
     </div>
   );
 }

--- a/src/surfaces/AgentTranscript.tsx
+++ b/src/surfaces/AgentTranscript.tsx
@@ -20,6 +20,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import { AttachmentChip } from "../chrome/AttachmentChip";
 import { FilePreview } from "../chrome/FilePreview";
@@ -61,10 +62,16 @@ import { useTranscriptLayout } from "../hooks/useTranscriptLayout";
 import { useTranscriptAnchor } from "../hooks/useTranscriptAnchor";
 import { useTranscriptSelection } from "../hooks/useTranscriptSelection";
 import type { TranscriptLayout } from "../lib/appearance";
+import {
+  AUTO_COLLAPSE_ACTIVITY_DEFAULT,
+  loadAutoCollapseActivity,
+  subscribeAutoCollapseActivity,
+} from "../lib/settings";
 import { AgentMarkdown } from "./AgentMarkdown";
 import { TranscriptSelectionMenu } from "./TranscriptSelectionMenu";
 import {
   activityPhaseTitle,
+  activitySummary,
   activityStillRunning,
   buildActivityPhases,
   editVerb,
@@ -152,6 +159,11 @@ export function AgentTranscript({
   );
   const transcriptLayout = useTranscriptLayout();
   const promptAnchor = useTranscriptAnchor();
+  const autoCollapseActivity = useSyncExternalStore(
+    subscribeAutoCollapseActivity,
+    loadAutoCollapseActivity,
+    () => AUTO_COLLAPSE_ACTIVITY_DEFAULT,
+  );
   const lastUserId = lastUserBlockId(blocks);
   const seenUserId = useRef(lastUserId);
   if (lastUserId !== seenUserId.current) {
@@ -328,6 +340,9 @@ export function AgentTranscript({
           // Earlier activity groups have already been followed by prose or
           // more work. Only the last one can still be the live group.
           const foldedAt = lastActivityIndex(items);
+          const firstActivityAt = items.findIndex(
+            (item) => item.type === "activity",
+          );
           const initialThinkingAt = initialThinkingIndex(items);
           const startedAt = userBlock?.startedAt;
           // The agent starting its answer is the end of the work: fold the
@@ -341,6 +356,15 @@ export function AgentTranscript({
                 (item) => item.type === "block" && isProseBlock(item.block),
               );
           const workStillRunning = activityStillRunning(turn);
+          const compactActivity =
+            autoCollapseActivity &&
+            firstActivityAt >= 0 &&
+            (settled || (answering && !workStillRunning));
+          const compactActivityBlocks = compactActivity
+            ? items.flatMap((item) =>
+                item.type === "activity" ? item.blocks : [],
+              )
+            : [];
           const turnHarness = harness
             ? harnessForTurn(blocks, turn, harness)
             : undefined;
@@ -357,7 +381,20 @@ export function AgentTranscript({
             >
               {items.map((item, itemIndex) =>
                 item.type === "activity" ? (
-                  itemIndex === initialThinkingAt ? (
+                  compactActivity ? (
+                    itemIndex === foldedAt ? (
+                      <ActivityPhases
+                        key={item.blocks[0].id}
+                        blocks={compactActivityBlocks}
+                        cwd={cwd}
+                        done
+                        compact
+                        onApproval={onApproval}
+                        onOpenFile={onOpenFile}
+                        onOpenDiff={onOpenDiff}
+                      />
+                    ) : null
+                  ) : itemIndex === initialThinkingAt ? (
                     <InitialThinking key={item.blocks[0].id} live={!settled} />
                   ) : (
                     <ActivityPhases
@@ -908,6 +945,7 @@ function ActivityPhases({
   blocks,
   cwd,
   done,
+  compact = false,
   onApproval,
   onOpenFile,
   onOpenDiff,
@@ -915,11 +953,52 @@ function ActivityPhases({
   blocks: Block[];
   cwd?: string;
   done?: boolean;
+  compact?: boolean;
   onApproval?: (requestId: number, decision: ApprovalDecision) => void;
   onOpenFile?: (path: string) => void;
   onOpenDiff?: (path: string) => void;
 }) {
   const phases = useMemo(() => buildActivityPhases(blocks), [blocks]);
+  const [expanded, setExpanded] = useState(false);
+
+  if (compact) {
+    const summary = activitySummary(blocks);
+    return (
+      <div className="flex min-w-0 flex-col px-4">
+        <button
+          type="button"
+          aria-expanded={expanded}
+          aria-label={expanded ? "Hide activity" : `Show activity: ${summary}`}
+          onClick={() => setExpanded((value) => !value)}
+          className="group flex w-full min-w-0 items-center gap-1.5 py-1 text-left"
+        >
+          <ChevronRight
+            className={`size-3.5 shrink-0 text-content/45 transition-transform duration-200 ${expanded ? "rotate-90" : ""}`}
+            strokeWidth={1.75}
+          />
+          <span className="min-w-0 flex-1 truncate font-sans text-sm text-content/50 transition-colors duration-200 group-hover:text-content/80">
+            {summary}
+          </span>
+        </button>
+        {expanded ? (
+          <div className="flex min-w-0 flex-col gap-1">
+            {phases.map((phase) => (
+              <ActivityPhaseGroup
+                key={phase.id}
+                phase={phase}
+                cwd={cwd}
+                active={false}
+                defaultOpen
+                onApproval={onApproval}
+                onOpenFile={onOpenFile}
+                onOpenDiff={onOpenDiff}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-w-0 flex-col gap-1 px-4">
@@ -1005,6 +1084,7 @@ function ActivityPhaseGroup({
   phase,
   cwd,
   active,
+  defaultOpen = false,
   onApproval,
   onOpenFile,
   onOpenDiff,
@@ -1012,13 +1092,14 @@ function ActivityPhaseGroup({
   phase: ActivityPhase;
   cwd?: string;
   active: boolean;
+  defaultOpen?: boolean;
   onApproval?: (requestId: number, decision: ApprovalDecision) => void;
   onOpenFile?: (path: string) => void;
   onOpenDiff?: (path: string) => void;
 }) {
   const [override, setOverride] = useState<boolean | null>(null);
   const waiting = phase.steps.some(needsApproval);
-  const open = waiting || (override ?? active);
+  const open = waiting || (override ?? (defaultOpen || active));
   const [liveScroller, setLiveScroller] = useState<HTMLDivElement | null>(null);
   useLivePhaseScroll(liveScroller, active && open, phase.steps);
   const title = activityPhaseTitle(phase, active);

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -115,6 +115,7 @@ import { loadTabGroupLabels, resolveTabGroupLabel } from "../lib/tabGroups";
 import {
   filterKeybindings,
   KEYBINDINGS,
+  loadAutoCollapseActivity,
   loadClaudeHooks,
   loadComposerRunner,
   loadDiffViewer,
@@ -123,6 +124,7 @@ import {
   loadLiveAgentsEnabled,
   loadNotesEnabled,
   saveClaudeHooks,
+  saveAutoCollapseActivity,
   saveComposerRunner,
   saveDiffViewer,
   saveFollowUpBehavior,
@@ -264,6 +266,9 @@ function GeneralPage({
     useState<TranscriptLayout>(loadTranscriptLayout);
   const [transcriptAnchor, setTranscriptAnchor] =
     useState(loadTranscriptAnchor);
+  const [autoCollapseActivity, setAutoCollapseActivity] = useState(
+    loadAutoCollapseActivity,
+  );
   const [diffViewer, setDiffViewer] = useState<DiffViewer>(loadDiffViewer);
   const [followUpBehavior, setFollowUpBehavior] =
     useState<FollowUpBehavior>(loadFollowUpBehavior);
@@ -296,6 +301,11 @@ function GeneralPage({
   const onTranscriptAnchor = (next: boolean) => {
     saveTranscriptAnchor(next);
     setTranscriptAnchor(next);
+  };
+
+  const onAutoCollapseActivity = (next: boolean) => {
+    saveAutoCollapseActivity(next);
+    setAutoCollapseActivity(next);
   };
 
   const onDiffViewer = (next: DiffViewer) => {
@@ -380,6 +390,16 @@ function GeneralPage({
             { value: "steer", label: "Steer" },
           ]}
           onChange={onFollowUpBehavior}
+        />
+      </Row>
+      <Row
+        label="Auto-collapse activity"
+        description="Keep thinking and tool activity open while a turn runs, then fold it into one summary above the final answer. Click the summary to read the full trail."
+      >
+        <Toggle
+          label="Auto-collapse activity"
+          on={autoCollapseActivity}
+          onChange={onAutoCollapseActivity}
         />
       </Row>
       <Row

--- a/src/surfaces/transcriptActivity.test.ts
+++ b/src/surfaces/transcriptActivity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Block } from "../lib/session";
 import {
+  activitySummary,
   activityPhaseTitle,
   activityStillRunning,
   buildActivityPhases,
@@ -81,6 +82,27 @@ function note(id: string, text: string): Block {
 function thought(id: string, text = "Weighing the options."): Block {
   return { id, role: "reasoning", text };
 }
+
+describe("activitySummary", () => {
+  it("summarizes tool calls and unique edited files", () => {
+    expect(
+      activitySummary([
+        thought("thinking"),
+        read("read"),
+        edit("edit-a"),
+        edit("edit-a-again"),
+        edit("edit-b", "src/index.css"),
+      ]),
+    ).toBe("4 tool calls · 2 files edited");
+  });
+
+  it("keeps failed activity visible in the folded summary", () => {
+    expect(activitySummary([shell("failed", "failed")])).toBe(
+      "1 tool call · 1 failed/rejected",
+    );
+    expect(activitySummary([thought("thinking")])).toBe("Thought");
+  });
+});
 
 describe("groupTurnItems", () => {
   it("keeps consecutive shell calls in one activity stack", () => {

--- a/src/surfaces/transcriptActivity.ts
+++ b/src/surfaces/transcriptActivity.ts
@@ -512,6 +512,40 @@ function fileLabel(paths: Set<string>): string {
   return `${paths.size} files`;
 }
 
+/** One-line tally for a settled turn's folded thinking and tool activity. */
+export function activitySummary(blocks: Block[]): string {
+  const tools = blocks.filter(isToolBlock);
+  if (tools.length === 0) return "Thought";
+
+  const edits = new Set<string>();
+  let problems = 0;
+  for (const block of tools) {
+    if (
+      isEditTool(
+        block.tool?.kind,
+        block.text || block.tool?.title,
+        block.tool?.preview,
+      )
+    ) {
+      edits.add(
+        block.tool?.preview?.path ?? block.tool?.preview?.fileName ?? block.id,
+      );
+    }
+    if (toolCallState(block) === "rejected") problems += 1;
+  }
+
+  const parts = [
+    `${tools.length} tool ${tools.length === 1 ? "call" : "calls"}`,
+  ];
+  if (edits.size > 0) {
+    parts.push(`${edits.size} ${edits.size === 1 ? "file" : "files"} edited`);
+  }
+  if (problems > 0) {
+    parts.push(`${problems} failed/rejected`);
+  }
+  return parts.join(" · ");
+}
+
 /**
  * The group's header. The agent's own line if it wrote one, otherwise what the
  * calls add up to — in the present tense while the group is still running, so


### PR DESCRIPTION
## What changed

Finished turns now fold all thinking and tool activity into one expandable summary above the final response. A persisted Settings → General toggle keeps the behavior optional, while live turns remain expanded and failed or rejected calls stay visible in the summary count.

## Why

Long agent runs currently leave several process phases above the final answer, making completed conversations difficult to scan. This implements the compact settled state requested in #79 without changing the live monitoring experience.

## UI

No screenshot attached. The change uses the existing transcript phase styling and adds the `Auto-collapse activity` toggle under Settings → General.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes

Closes #79
