### PR TITLE
Add prompt outline to session transcript

### DIFF
--- a/src/chrome/PromptOutline.tsx
+++ b/src/chrome/PromptOutline.tsx
@@ -1,0 +1,352 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type RefObject,
+} from "react";
+import {
+  activePromptId,
+  barWindow,
+  promptBlocks,
+  promptLabel,
+  type OutlineAnchor,
+  type OutlineBand,
+} from "../lib/promptOutline";
+import type { Block } from "../lib/session";
+import { Popover } from "./Popover";
+
+const OPEN_DELAY_MS = 25;
+const CLOSE_DELAY_MS = 100;
+const SCROLL_INSET_PX = 8;
+const POPOVER_WIDTH = 288;
+const POPOVER_MAX_HEIGHT = 360;
+const MIN_PROMPTS = 2;
+const BAR_HEIGHT_PX = 2;
+const BAR_GAP_PX = 5;
+const BAR_GAP_MIN_PX = 1;
+const BAR_STACK_MAX_PX = 330;
+const BAR_STACK_PANE_SHARE = 0.75;
+const SCROLLER = ".agent-transcript";
+const TURN = ".transcript-turn";
+const ANCHOR = "[data-prompt-anchor]";
+
+type Props = {
+  blocks: Block[];
+  scope: RefObject<HTMLElement | null>;
+  visible?: boolean;
+  /** Renders the turn that holds the block. Returns false when the block is unknown. */
+  revealBlock?: (blockId: string) => boolean;
+};
+
+export function PromptOutline({
+  blocks,
+  scope,
+  visible = true,
+  revealBlock,
+}: Props) {
+  const prompts = useMemo(() => promptBlocks(blocks), [blocks]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [stackBudget, setStackBudget] = useState(BAR_STACK_MAX_PX);
+  const [open, setOpen] = useState(false);
+  const [point, setPoint] = useState<{ x: number; y: number } | null>(null);
+  const trigger = useRef<HTMLButtonElement>(null);
+  const list = useRef<HTMLDivElement>(null);
+  const activeRow = useRef<HTMLButtonElement>(null);
+  const frame = useRef<number | null>(null);
+  const openTimer = useRef<number | null>(null);
+  const closeTimer = useRef<number | null>(null);
+  const reopenBlockedUntilLeave = useRef(false);
+
+  const measure = useCallback(() => {
+    const scroller = scope.current?.querySelector<HTMLElement>(SCROLLER);
+    if (!scroller) {
+      setActiveId(null);
+      return;
+    }
+    const viewport = scroller.getBoundingClientRect();
+    // A hidden tab has zero-size boxes. The rule would then select the last prompt.
+    if (viewport.height === 0) return;
+    setStackBudget(
+      Math.min(
+        BAR_STACK_MAX_PX,
+        Math.floor(viewport.height * BAR_STACK_PANE_SHARE),
+      ),
+    );
+    const anchors: OutlineAnchor[] = [];
+    for (const el of scroller.querySelectorAll<HTMLElement>(ANCHOR)) {
+      const id = el.dataset.promptAnchor;
+      if (id) anchors.push({ id, ...promptBand(el, viewport) });
+    }
+    setActiveId(
+      activePromptId(
+        { top: viewport.top, bottom: viewport.bottom },
+        anchors,
+        scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight,
+      ),
+    );
+  }, [scope]);
+
+  const schedule = useCallback(() => {
+    if (frame.current != null) return;
+    frame.current = window.requestAnimationFrame(() => {
+      frame.current = null;
+      measure();
+    });
+  }, [measure]);
+
+  useEffect(() => {
+    const scroller = scope.current?.querySelector<HTMLElement>(SCROLLER);
+    if (!scroller) return;
+    scroller.addEventListener("scroll", schedule, { passive: true });
+    const observer = new ResizeObserver(schedule);
+    observer.observe(scroller);
+    // Content growth moves the anchors without a scroll event.
+    if (scroller.firstElementChild)
+      observer.observe(scroller.firstElementChild);
+    schedule();
+    return () => {
+      scroller.removeEventListener("scroll", schedule);
+      observer.disconnect();
+      if (frame.current != null) {
+        window.cancelAnimationFrame(frame.current);
+        frame.current = null;
+      }
+    };
+  }, [schedule, scope]);
+
+  useEffect(() => {
+    schedule();
+  }, [schedule, blocks, visible]);
+
+  const cancelOpen = () => {
+    if (openTimer.current == null) return;
+    window.clearTimeout(openTimer.current);
+    openTimer.current = null;
+  };
+  const cancelClose = () => {
+    if (closeTimer.current == null) return;
+    window.clearTimeout(closeTimer.current);
+    closeTimer.current = null;
+  };
+  useEffect(
+    () => () => {
+      cancelOpen();
+      cancelClose();
+    },
+    [],
+  );
+
+  const openNow = () => {
+    cancelOpen();
+    cancelClose();
+    const rect = trigger.current?.getBoundingClientRect();
+    if (!rect) return;
+    // Anchor the list at the top-right corner of the trigger. The list covers
+    // the trigger, so the pointer crosses no gap.
+    setPoint({ x: rect.right, y: rect.top });
+    setOpen(true);
+  };
+  const closeNow = () => {
+    cancelOpen();
+    cancelClose();
+    setOpen(false);
+  };
+  const scheduleClose = () => {
+    cancelClose();
+    closeTimer.current = window.setTimeout(() => {
+      closeTimer.current = null;
+      setOpen(false);
+    }, CLOSE_DELAY_MS);
+  };
+  const enterTrigger = () => {
+    cancelClose();
+    if (open || reopenBlockedUntilLeave.current || openTimer.current != null) {
+      return;
+    }
+    openTimer.current = window.setTimeout(() => {
+      openTimer.current = null;
+      openNow();
+    }, OPEN_DELAY_MS);
+  };
+  const leaveTrigger = () => {
+    reopenBlockedUntilLeave.current = false;
+    cancelOpen();
+    if (open) scheduleClose();
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    // Wait one frame for placement. Then the list has its final height.
+    const id = window.requestAnimationFrame(() => {
+      const row = activeRow.current;
+      const box = list.current;
+      if (!row || !box) return;
+      const top = row.offsetTop;
+      const bottom = top + row.offsetHeight;
+      if (top < box.scrollTop) box.scrollTop = top;
+      else if (bottom > box.scrollTop + box.clientHeight) {
+        box.scrollTop = bottom - box.clientHeight;
+      }
+    });
+    return () => window.cancelAnimationFrame(id);
+  }, [open]);
+
+  const jumpTo = (id: string) => {
+    const scroller = scope.current?.querySelector<HTMLElement>(SCROLLER);
+    if (!scroller) return;
+    // The transcript scrolls to the bottom on each streaming update until a
+    // wheel-up event occurs. Send one, so the jump stays.
+    scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -1 }));
+    const selector = `[data-prompt-anchor="${CSS.escape(id)}"]`;
+    let anchor = scroller.querySelector<HTMLElement>(selector);
+    if (!anchor && revealBlock?.(id)) {
+      anchor = scroller.querySelector<HTMLElement>(selector);
+    }
+    if (!anchor) {
+      scroller.scrollTop = 0;
+      return;
+    }
+    const target = anchor.closest<HTMLElement>(TURN) ?? anchor;
+    const align = () => {
+      const delta =
+        target.getBoundingClientRect().top -
+        scroller.getBoundingClientRect().top -
+        SCROLL_INSET_PX;
+      if (Math.abs(delta) > 2) scroller.scrollTop += delta;
+    };
+    align();
+    // Turns that enter the screen get their real height. That can move the
+    // target.
+    window.requestAnimationFrame(align);
+  };
+
+  const onRowClick = (event: ReactMouseEvent, id: string) => {
+    jumpTo(id);
+    const rect = trigger.current?.getBoundingClientRect();
+    reopenBlockedUntilLeave.current =
+      !!rect &&
+      event.clientX >= rect.left &&
+      event.clientX <= rect.right &&
+      event.clientY >= rect.top &&
+      event.clientY <= rect.bottom;
+    closeNow();
+  };
+
+  if (prompts.length < MIN_PROMPTS) return null;
+
+  const activeIndex = prompts.findIndex((prompt) => prompt.id === activeId);
+  const stack = barStack(
+    prompts.length,
+    activeIndex >= 0 ? activeIndex : null,
+    stackBudget,
+  );
+  const bars = prompts.slice(stack.start, stack.end);
+
+  return (
+    <div
+      className="absolute top-3 right-4 z-30"
+      onMouseEnter={enterTrigger}
+      onMouseLeave={leaveTrigger}
+    >
+      <button
+        ref={trigger}
+        type="button"
+        aria-label="Prompts"
+        aria-expanded={open}
+        onClick={openNow}
+        style={{ gap: stack.gap }}
+        className="flex flex-col items-end rounded-lg p-1 hover:bg-content/6"
+      >
+        {bars.map((prompt) => (
+          <span
+            key={prompt.id}
+            aria-hidden="true"
+            style={{ height: BAR_HEIGHT_PX }}
+            className={`w-5.5 rounded-full ${
+              prompt.id === activeId ? "bg-content/85" : "bg-content/15"
+            }`}
+          />
+        ))}
+      </button>
+      {open && point ? (
+        <Popover
+          anchor={point}
+          side="left"
+          align="start"
+          gap={0}
+          width={POPOVER_WIDTH}
+          maxHeight={POPOVER_MAX_HEIGHT}
+          onDismiss={closeNow}
+          aria-label="Prompts"
+          className="flex flex-col"
+          onMouseEnter={cancelClose}
+          onMouseLeave={scheduleClose}
+        >
+          <div
+            ref={list}
+            className="prompt-outline-list relative flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-none p-1"
+          >
+            {prompts.map((prompt) => {
+              const active = prompt.id === activeId;
+              return (
+                <button
+                  key={prompt.id}
+                  ref={active ? activeRow : undefined}
+                  type="button"
+                  aria-current={active ? "true" : undefined}
+                  onClick={(event) => onRowClick(event, prompt.id)}
+                  className={`block w-full shrink-0 truncate rounded-lg px-3 py-1 text-left font-sans text-sm ${
+                    active
+                      ? "bg-content/10 text-content"
+                      : "text-content/85 hover:bg-content/6"
+                  }`}
+                >
+                  {promptLabel(prompt)}
+                </button>
+              );
+            })}
+          </div>
+        </Popover>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * content-visibility skips off-screen turns. A read inside a skipped turn
+ * forces its layout. Use the turn box for an off-screen turn. Use the exact
+ * prompt box for an on-screen turn.
+ */
+function promptBand(anchor: HTMLElement, viewport: DOMRect): OutlineBand {
+  const turn = anchor.closest<HTMLElement>(TURN) ?? anchor;
+  const turnBox = turn.getBoundingClientRect();
+  const onScreen =
+    turnBox.bottom > viewport.top && turnBox.top < viewport.bottom;
+  const box =
+    turn !== anchor && onScreen ? anchor.getBoundingClientRect() : turnBox;
+  return { top: box.top, bottom: box.bottom };
+}
+
+/** One bar per prompt while the bars fit the budget. The gap shrinks first. Past that, a window slides. */
+function barStack(count: number, activeIndex: number | null, budget: number) {
+  const fit = Math.max(
+    1,
+    Math.floor((budget + BAR_GAP_MIN_PX) / (BAR_HEIGHT_PX + BAR_GAP_MIN_PX)),
+  );
+  const window_ = barWindow(count, activeIndex, fit);
+  const shown = window_.end - window_.start;
+  const gap =
+    shown > 1
+      ? Math.min(
+          BAR_GAP_PX,
+          Math.max(
+            BAR_GAP_MIN_PX,
+            Math.floor((budget - shown * BAR_HEIGHT_PX) / (shown - 1)),
+          ),
+        )
+      : 0;
+  return { ...window_, gap };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -269,6 +269,28 @@ html.is-resizing * {
   scrollbar-width: none;
 }
 
+/* Prompt outline list: a thin thumb, always visible, on all platforms.
+   Replaces the native overlay bar. */
+html .prompt-outline-list::-webkit-scrollbar {
+  width: 12px;
+}
+
+html .prompt-outline-list::-webkit-scrollbar-track {
+  background: transparent;
+  margin-block: 6px;
+}
+
+html .prompt-outline-list::-webkit-scrollbar-thumb {
+  border: 3px solid transparent;
+  border-radius: 9999px;
+  background-color: color-mix(in srgb, var(--color-content) 16%, transparent);
+  background-clip: padding-box;
+}
+
+html .prompt-outline-list::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(in srgb, var(--color-content) 32%, transparent);
+}
+
 [data-tauri-drag-region] button {
   -webkit-app-region: no-drag;
   app-region: no-drag;

--- a/src/lib/promptOutline.test.ts
+++ b/src/lib/promptOutline.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { activePromptId } from "./promptOutline";
+
+const viewport = { top: 100, bottom: 500 };
+
+function anchor(id: string, top: number, bottom: number) {
+  return { id, top, bottom };
+}
+
+describe("activePromptId", () => {
+  it("returns null with no anchors", () => {
+    expect(activePromptId(viewport, [])).toBeNull();
+  });
+
+  it("picks the topmost prompt inside the viewport", () => {
+    const anchors = [
+      anchor("a", 0, 40),
+      anchor("b", 150, 190),
+      anchor("c", 300, 340),
+      anchor("d", 600, 640),
+    ];
+    expect(activePromptId(viewport, anchors)).toBe("b");
+  });
+
+  it("counts a prompt cut by the viewport top as inside", () => {
+    const anchors = [anchor("a", 80, 120), anchor("b", 200, 240)];
+    expect(activePromptId(viewport, anchors)).toBe("a");
+  });
+
+  it("lets a prompt that peeks in at the bottom win over the reply above", () => {
+    const anchors = [anchor("a", 0, 40), anchor("b", 480, 520)];
+    expect(activePromptId(viewport, anchors)).toBe("b");
+  });
+
+  it("falls back to the last prompt above the viewport", () => {
+    const anchors = [
+      anchor("a", 0, 20),
+      anchor("b", 40, 60),
+      anchor("c", 600, 640),
+    ];
+    expect(activePromptId(viewport, anchors)).toBe("b");
+  });
+
+  it("treats a prompt that ends at the viewport top as above", () => {
+    const anchors = [anchor("a", 60, 100), anchor("b", 700, 740)];
+    expect(activePromptId(viewport, anchors)).toBe("a");
+  });
+
+  it("falls back to the first prompt when all sit below", () => {
+    const anchors = [anchor("a", 600, 640), anchor("b", 700, 740)];
+    expect(activePromptId(viewport, anchors)).toBe("a");
+  });
+
+  it("marks the last prompt at the end of the transcript", () => {
+    const anchors = [
+      anchor("a", 120, 160),
+      anchor("b", 260, 300),
+      anchor("c", 400, 440),
+    ];
+    expect(activePromptId(viewport, anchors, 0)).toBe("c");
+    expect(activePromptId(viewport, anchors, 16)).toBe("c");
+  });
+
+  it("keeps the topmost visible prompt while there is room to scroll", () => {
+    const anchors = [anchor("a", 120, 160), anchor("b", 400, 440)];
+    expect(activePromptId(viewport, anchors, 17)).toBe("a");
+  });
+});

--- a/src/lib/promptOutline.ts
+++ b/src/lib/promptOutline.ts
@@ -1,0 +1,76 @@
+import type { Block } from "./session";
+
+/** A vertical span in viewport coordinates. */
+export type OutlineBand = { top: number; bottom: number };
+
+export type OutlineAnchor = OutlineBand & { id: string };
+
+export const NEAR_END_PX = 16;
+
+export function promptBlocks(blocks: Block[]): Block[] {
+  return blocks.filter((block) => block.role === "user");
+}
+
+/**
+ * Selects the topmost prompt inside the viewport. With no prompt inside,
+ * selects the last prompt above the viewport, else the first prompt. Near the
+ * end of the transcript, selects the last prompt: the prompts on the final
+ * screen can not reach the top.
+ */
+export function activePromptId(
+  viewport: OutlineBand,
+  anchors: OutlineAnchor[],
+  distanceToEnd = Number.POSITIVE_INFINITY,
+): string | null {
+  if (anchors.length === 0) return null;
+  if (distanceToEnd <= NEAR_END_PX) return anchors[anchors.length - 1].id;
+  const inside = anchors.find(
+    (anchor) => anchor.bottom > viewport.top && anchor.top < viewport.bottom,
+  );
+  if (inside) return inside.id;
+  let above: OutlineAnchor | undefined;
+  for (const anchor of anchors) {
+    if (anchor.bottom <= viewport.top) above = anchor;
+  }
+  return (above ?? anchors[0]).id;
+}
+
+/** Selects at most `max` prompts. The window slides to keep the active prompt inside. It prefers the newest prompts. */
+export function barWindow(
+  count: number,
+  activeIndex: number | null,
+  max: number,
+): { start: number; end: number } {
+  if (count <= max) return { start: 0, end: count };
+  const newest = count - max;
+  const start =
+    activeIndex == null ? newest : Math.max(0, Math.min(newest, activeIndex));
+  return { start, end: start + max };
+}
+
+export function promptLabel(block: Block): string {
+  const card = block.secondOpinion;
+  const textShown = !card || card.kind === "handoff";
+  const text = textShown ? firstLine(block.text) : "";
+  if (text) return text;
+  if (card) {
+    if (card.kind === "handoff") return "Handoff";
+    const request = firstLine(card.request ?? "");
+    return request ? `Second opinion: ${request}` : "Second opinion";
+  }
+  if (block.noteCard?.title) return block.noteCard.title;
+  const files = block.attachments ?? [];
+  if (files.length > 0) {
+    const [first] = files;
+    return files.length > 1 ? `${first.name} +${files.length - 1}` : first.name;
+  }
+  return "Empty message";
+}
+
+function firstLine(text: string): string {
+  const line = text
+    .split(/\r?\n/)
+    .map((part) => part.trim())
+    .find(Boolean);
+  return (line ?? "").replace(/\s+/g, " ");
+}

--- a/src/surfaces/AgentTranscript.tsx
+++ b/src/surfaces/AgentTranscript.tsx
@@ -22,6 +22,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { flushSync } from "react-dom";
 import { AttachmentChip } from "../chrome/AttachmentChip";
 import { FilePreview } from "../chrome/FilePreview";
 import { FileTypeIcon } from "../chrome/FileTypeIcon";
@@ -116,6 +117,8 @@ type Props = {
   onHandoff?: (harness: HarnessId, turn: Block[], model: string) => void;
   onJumpToBottomChange?: (show: boolean) => void;
   onJumpToBottomReady?: (jump: () => void) => void;
+  /** Passes a function that renders the turn that holds a block. The render completes before the function returns. */
+  onRevealReady?: (reveal: (blockId: string) => boolean) => void;
   /** False while another tab is in front. Hidden tabs stay laid out. */
   visible?: boolean;
 };
@@ -138,6 +141,7 @@ export function AgentTranscript({
   onHandoff,
   onJumpToBottomChange,
   onJumpToBottomReady,
+  onRevealReady,
   visible = true,
 }: Props) {
   const lockOverscroll = useLockOverscroll<HTMLDivElement>();
@@ -293,6 +297,10 @@ export function AgentTranscript({
   const turns = groupTurns(blocks);
   const firstVisibleTurn = Math.max(0, turns.length - visibleTurnCount);
   const visibleTurns = turns.slice(firstVisibleTurn);
+  const turnsRef = useRef(turns);
+  turnsRef.current = turns;
+  const visibleTurnCountRef = useRef(visibleTurnCount);
+  visibleTurnCountRef.current = visibleTurnCount;
 
   useLayoutEffect(() => {
     const previousHeight = prependHeight.current;
@@ -304,21 +312,46 @@ export function AgentTranscript({
       el.scrollHeight - el.scrollTop - el.clientHeight;
   }, [visibleTurnCount]);
 
-  const loadEarlier = () => {
+  const prepareToPrepend = useCallback(() => {
     const el = scroller.current;
     if (el) prependHeight.current = el.scrollHeight;
     stickToBottom.current = false;
+  }, []);
+
+  const loadEarlier = () => {
+    prepareToPrepend();
     setVisibleTurnCount((count) =>
       Math.min(turns.length, count + TURN_PAGE_SIZE),
     );
   };
+
+  const revealBlock = useCallback(
+    (blockId: string): boolean => {
+      const all = turnsRef.current;
+      const index = all.findIndex((turn) =>
+        turn.some((block) => block.id === blockId),
+      );
+      if (index < 0) return false;
+      const needed = all.length - index;
+      if (needed <= visibleTurnCountRef.current) return true;
+      prepareToPrepend();
+      // Synchronous. The caller finds the turn in the DOM after this call.
+      flushSync(() => setVisibleTurnCount(needed));
+      return true;
+    },
+    [prepareToPrepend],
+  );
+
+  useEffect(() => {
+    onRevealReady?.(revealBlock);
+  }, [revealBlock, onRevealReady]);
 
   return (
     <div
       ref={setScroller}
       className="agent-transcript h-full overflow-y-auto overscroll-none [overflow-anchor:none] font-mono text-[13px] leading-5"
     >
-      <div className="mx-auto flex w-full min-w-0 max-w-4xl flex-col gap-1 pb-1">
+      <div className="mx-auto flex w-full min-w-0 max-w-4xl flex-col gap-1 pb-1 @max-[62rem]:pr-11">
         {firstVisibleTurn > 0 ? (
           <div className="flex justify-center px-4 py-3">
             <button
@@ -894,6 +927,7 @@ function UserMessageBlock({
 
   return (
     <div
+      data-prompt-anchor={block.id}
       className={
         chat ? "flex justify-end pt-1.5 pr-4 pb-4 pl-14" : "p-1.5 pb-3"
       }

--- a/src/surfaces/SessionPane.tsx
+++ b/src/surfaces/SessionPane.tsx
@@ -11,6 +11,7 @@ import {
 import { Composer } from "../chrome/Composer";
 import { DiscussionEmpty } from "../chrome/DiscussionEmpty";
 import { SessionReview } from "../chrome/SessionReview";
+import { PromptOutline } from "../chrome/PromptOutline";
 import {
   canCompactHarnessContext,
   type ApprovalDecision,
@@ -180,6 +181,7 @@ export const SessionPane = memo(function SessionPane({
     [onBuildPlan, session.id],
   );
   const jumpToBottomRef = useRef<(() => void) | null>(null);
+  const transcriptScope = useRef<HTMLDivElement>(null);
   const quoteRequestId = useRef(0);
   const [showJumpToBottom, setShowJumpToBottom] = useState(false);
   const astraWelcomeSequence = useRef(0);
@@ -192,6 +194,14 @@ export const SessionPane = memo(function SessionPane({
   const onJumpToBottomReady = useCallback((jump: () => void) => {
     jumpToBottomRef.current = jump;
   }, []);
+  const revealBlockRef = useRef<((blockId: string) => boolean) | null>(null);
+  const onRevealReady = useCallback((reveal: (blockId: string) => boolean) => {
+    revealBlockRef.current = reveal;
+  }, []);
+  const revealBlock = useCallback(
+    (blockId: string) => revealBlockRef.current?.(blockId) ?? false,
+    [],
+  );
   const addSelectionToChat = useCallback(
     (text: string, mode?: QuoteRequest["mode"]) => {
       quoteRequestId.current += 1;
@@ -387,7 +397,7 @@ export const SessionPane = memo(function SessionPane({
           </button>
         </div>
       ) : null}
-      <div className="relative min-h-0 flex-1">
+      <div ref={transcriptScope} className="@container relative min-h-0 flex-1">
         {isEmpty ? (
           session.inboxAsk ? (
             <div className="scrollbar-none h-full min-h-0 overflow-y-auto">
@@ -430,6 +440,13 @@ export const SessionPane = memo(function SessionPane({
               }
               onJumpToBottomChange={setShowJumpToBottom}
               onJumpToBottomReady={onJumpToBottomReady}
+              onRevealReady={onRevealReady}
+            />
+            <PromptOutline
+              blocks={session.blocks}
+              scope={transcriptScope}
+              visible={visible}
+              revealBlock={revealBlock}
             />
             {showJumpToBottom ? (
               <div className="pointer-events-none absolute inset-x-0 bottom-2 z-30 flex justify-center">


### PR DESCRIPTION
## What changed

Adds a prompt outline to the session transcript: a stack of bars at the top right, one per user prompt, with the current one bright. Hover opens a list of prompts; a click scrolls the transcript to that prompt.

## Why

A long session gives no sense of where you are and no way back to an earlier prompt except scrolling. The outline does both.

Critical parts for review:

- `src/lib/promptOutline.ts` holds the active-row rule and its helpers as pure functions, covered by unit tests.
- `AgentTranscript` gains one attribute per user message and an `onRevealReady` prop, so a click can render a turn older than the rendered window before scrolling to it. The reveal uses `flushSync`.
- A row click sends a synthetic wheel-up to the transcript, so a streaming update does not pull the view back to the bottom. This relies on the transcript's existing wheel listener.
- On panes narrower than 62rem the transcript column keeps a right gutter for the widget.

## UI
Before:
<img width="1796" height="1147" alt="Screenshot 2026-09-06 at 19 29 12" src="https://github.com/user-attachments/assets/f3e7082b-abab-43c8-b33c-d79897f6213b" />
After:
<img width="1840" height="1191" alt="Screenshot 2026-09-06 at 19 29 57" src="https://github.com/user-attachments/assets/96e626b6-9858-4ba4-b0c0-eb047fede66a" />
<img width="1840" height="1191" alt="Screenshot 2026-09-06 at 19 30 04" src="https://github.com/user-attachments/assets/eca0851e-80a1-4206-b617-6de6d0bb098b" />
<img width="1840" height="1191" alt="Screenshot 2026-09-06 at 19 30 14" src="https://github.com/user-attachments/assets/bfe4b0c1-447e-4bde-82f7-60915569ac3d" />


## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes