### PR TITLE
Let wrapped inline code grow and keep list markers beside it

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -185,6 +185,13 @@ input,
     color-mix(in srgb, var(--color-content) 20%, transparent);
 }
 
+.agent-markdown [data-streamdown="ordered-list"],
+.agent-markdown [data-streamdown="unordered-list"] {
+  list-style-position: outside;
+  padding-left: 0;
+  padding-inline-start: 1.5rem;
+}
+
 .agent-markdown li > [data-streamdown="ordered-list"],
 .agent-markdown li > [data-streamdown="unordered-list"] {
   padding-left: 0;

--- a/src/surfaces/AgentMarkdown.test.ts
+++ b/src/surfaces/AgentMarkdown.test.ts
@@ -47,3 +47,22 @@ describe("AgentMarkdown text direction", () => {
     expect(markup).toContain('class="markdown-code-shell" dir="ltr"');
   });
 });
+
+describe("AgentMarkdown inline code", () => {
+  it("lets a long inline code span grow instead of clipping to a fixed height", () => {
+    const markup = renderToStaticMarkup(
+      createElement(AgentMarkdown, {
+        text: "1. `Before I refactor the transcript rendering, summarize how turns are grouped, in five bullets.`",
+      }),
+    );
+
+    const match = markup.match(/<code dir="ltr" class="([^"]*)"/);
+    expect(match).not.toBeNull();
+    const classes = match![1].split(/\s+/);
+    expect(classes).toContain("inline-flex");
+    expect(classes).toContain("min-h-6");
+    expect(classes).toContain("max-w-full");
+    expect(classes).toContain("[overflow-wrap:anywhere]");
+    expect(classes).not.toContain("h-6");
+  });
+});

--- a/src/surfaces/AgentMarkdown.tsx
+++ b/src/surfaces/AgentMarkdown.tsx
@@ -197,7 +197,7 @@ function MarkdownCode({
       <code
         {...props}
         dir="ltr"
-        className={`inline-flex items-center gap-1 rounded-md bg-content/8 px-1.5 h-6 align-baseline font-mono text-[0.8em] text-content ${
+        className={`inline-flex items-center gap-1 rounded-md bg-content/8 px-1.5 min-h-6 max-w-full [overflow-wrap:anywhere] align-baseline font-mono text-[0.8em] text-content ${
           open ? "cursor-pointer hover:text-sky-300 hover:underline" : ""
         } ${className ?? ""}`}
         role={open ? "link" : undefined}


### PR DESCRIPTION
## What changed

Inline code pills now grow with their text instead of sticking to a fixed height. Lists put the number or bullet in a gutter, so a pill that wraps stays next to its marker.

## Why

A long inline code span inside a numbered list looked broken. The number sat alone on its own line, and the background was a thin band cutting through two lines of text. The pill could not wrap because it is an `inline-flex` box, and `h-6` locked its height.

## UI

Before: 
<img width="930" height="83" alt="Screenshot 2026-09-06 at 20 10 09" src="https://github.com/user-attachments/assets/17df2dd4-9751-4792-a3a3-c781f7697ddd" />
<img width="718" height="66" alt="Screenshot 2026-09-06 at 20 17 28" src="https://github.com/user-attachments/assets/e95de9e2-334c-48eb-a3a3-5ab21d664fec" />

After:
<img width="889" height="70" alt="Screenshot 2026-09-06 at 20 10 18" src="https://github.com/user-attachments/assets/a9aeaba9-e7c7-49b1-8095-ec349ca03d9d" />

<img width="721" height="84" alt="Screenshot 2026-09-06 at 20 18 08" src="https://github.com/user-attachments/assets/65e50405-ae23-4568-b574-0be413e1a03a" />


## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes