### PR TITLE
Fix terminal focus loss after changing directory

### DIFF
--- a/src/surfaces/TerminalView.tsx
+++ b/src/surfaces/TerminalView.tsx
@@ -320,7 +320,7 @@ export function TerminalView({ id, cwd, active, onMetaChange }: Props) {
       termRef.current = null;
       spawned.current = false;
     };
-  }, [id, cwd]);
+  }, [id]);
 
   // Identity-stable: the callers pass an inline arrow, so depending on the
   // prop itself would tear down and re-arm the poll — and re-fork `ps` — on


### PR DESCRIPTION
## Summary

- keep the xterm/PTY lifecycle tied to terminal identity rather than live cwd metadata
- prevent OSC 7 cwd reports from tearing down and recreating an active terminal
- preserve keyboard focus after `cd` updates the terminal tab metadata

Closes #88

## Testing

- `npm run check:web` (124 test files, 1282 tests, and `tsc --noEmit` passed)
- `git diff --check`
- `npm run check:rust` was not run because the local environment does not have `cargo` installed; this change is limited to the React effect dependency list.