### PR TITLE
fix(windows): hide console window when spawning gh

### DIFF
--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -2488,6 +2488,7 @@ fn gh_run(root: &Path, args: &[&str], allow_empty: bool) -> Result<String, Strin
     let program = crate::harness::resolve_gui_binary("gh")
         .ok_or_else(|| "GitHub CLI (`gh`) is not installed.".to_string())?;
     let mut cmd = Command::new(&program);
+    crate::hide_window_console(&mut cmd);
     cmd.current_dir(root)
         .args(args)
         .env("GIT_TERMINAL_PROMPT", "0")


### PR DESCRIPTION
## What changed

`gh_run()` in `src-tauri/src/fs.rs` now calls `crate::hide_window_console()`
before spawning `gh`, the same way `git_cmd()` already does.

## Why

On Windows a console window flashed on screen every ~30 seconds with the app
idle. MonoCode polls GitHub with `gh repo view` / `issue list` / `pr list`, and
without `CREATE_NO_WINDOW` each call spawned a visible `conhost.exe`. `git` was
already covered, `gh` was not.

Fixes #96.

## UI

No UI changes.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes