### PR TITLE
Filter the Linear inbox by team and project

### DIFF
--- a/src-tauri/src/linear.rs
+++ b/src-tauri/src/linear.rs
@@ -58,6 +58,8 @@ pub struct LinearIssue {
     pub repo: String,
     pub team_id: String,
     pub team_name: String,
+    pub project_id: String,
+    pub project_name: String,
     pub project_path: String,
 }
 
@@ -247,6 +249,7 @@ query InboxIssues($first: Int!, $filter: IssueFilter) {
       updatedAt
       state { name type }
       team { id key name }
+      project { id name }
       labels { nodes { name color } }
       assignee { name displayName avatarUrl }
     }
@@ -435,6 +438,13 @@ fn parse_linear_issue(node: &Value) -> Option<LinearIssue> {
     let team_name = team
         .and_then(|value| string_field(value, "name"))
         .unwrap_or_else(|| team_key.clone());
+    let project = node.get("project");
+    let project_id = project
+        .and_then(|value| string_field(value, "id"))
+        .unwrap_or_default();
+    let project_name = project
+        .and_then(|value| string_field(value, "name"))
+        .unwrap_or_default();
     let state = node.get("state");
     Some(LinearIssue {
         provider: "linear".into(),
@@ -457,6 +467,8 @@ fn parse_linear_issue(node: &Value) -> Option<LinearIssue> {
         repo: team_key,
         team_id,
         team_name,
+        project_id,
+        project_name,
         project_path: String::new(),
     })
 }
@@ -787,6 +799,7 @@ mod tests {
                     "updatedAt": "2026-08-27T10:00:00.000Z",
                     "state": { "name": "In Progress", "type": "started" },
                     "team": { "id": "t1", "key": "ENG", "name": "Engineering" },
+                    "project": { "id": "p1", "name": "Billing" },
                     "labels": { "nodes": [{ "name": "bug", "color": "#eb5757" }] },
                     "assignee": { "displayName": "Maya", "name": "maya", "avatarUrl": "https://uploads.linear.app/maya.png" }
                 }]
@@ -804,6 +817,8 @@ mod tests {
         assert_eq!(item.repo, "ENG");
         assert_eq!(item.team_id, "t1");
         assert_eq!(item.team_name, "Engineering");
+        assert_eq!(item.project_id, "p1");
+        assert_eq!(item.project_name, "Billing");
         assert_eq!(item.labels[0].color, "eb5757");
         assert_eq!(item.assignees[0].login, "Maya");
         assert_eq!(
@@ -811,6 +826,26 @@ mod tests {
             "https://uploads.linear.app/maya.png"
         );
         assert!(item.project_path.is_empty());
+    }
+
+    #[test]
+    fn parse_linear_issues_leaves_project_empty_when_unassigned() {
+        let data = json!({
+            "issues": {
+                "nodes": [{
+                    "id": "issue-2",
+                    "identifier": "ENG-10",
+                    "number": 10,
+                    "title": "Loose issue",
+                    "team": { "id": "t1", "key": "ENG", "name": "Engineering" },
+                    "project": Value::Null
+                }]
+            }
+        });
+        let items = parse_linear_issues(&data).unwrap();
+        assert_eq!(items.len(), 1);
+        assert!(items[0].project_id.is_empty());
+        assert!(items[0].project_name.is_empty());
     }
 
     #[test]

--- a/src/chrome/InboxFiltersMenu.tsx
+++ b/src/chrome/InboxFiltersMenu.tsx
@@ -7,7 +7,9 @@ import {
   type InboxFilters,
   type InboxSource,
   type InboxTimeFilter,
+  type LinearProjectOption,
 } from "../lib/inboxFilters";
+import type { LinearTeam } from "../lib/linear";
 import { Popover } from "./Popover";
 import { ProjectLogoIcon } from "./ProjectLogoIcon";
 
@@ -23,9 +25,14 @@ type Props = {
   x: number;
   y: number;
   projects: ProjectOption[];
+  linearProjects: LinearProjectOption[];
+  linearTeams: LinearTeam[];
+  hiddenLinearTeamIds: string[];
   source: InboxSource;
   filters: InboxFilters;
   onChange: (filters: InboxFilters) => void;
+  /** Shared with Settings → Linear Teams; narrows the fetch, not just the list. */
+  onLinearTeamsChange: (ids: string[]) => void;
   onClose: () => void;
 };
 
@@ -57,13 +64,20 @@ export function InboxFiltersMenu({
   x,
   y,
   projects,
+  linearProjects,
+  linearTeams,
+  hiddenLinearTeamIds,
   source,
   filters,
   onChange,
+  onLinearTeamsChange,
   onClose,
 }: Props) {
   const hiddenProjects = new Set(filters.hiddenProjects);
+  const hiddenLinearProjects = new Set(filters.hiddenLinearProjects);
+  const hiddenTeams = new Set(hiddenLinearTeamIds);
   const hiddenKinds = new Set(filters.hiddenKinds);
+  const teamsActive = source === "linear" && hiddenLinearTeamIds.length > 0;
 
   const toggleAssigned = () => {
     onChange({ ...filters, assignedToMe: !filters.assignedToMe });
@@ -81,6 +95,20 @@ export function InboxFiltersMenu({
     if (next.has(path)) next.delete(path);
     else next.add(path);
     onChange({ ...filters, hiddenProjects: [...next] });
+  };
+
+  const toggleLinearTeam = (id: string) => {
+    const next = new Set(hiddenTeams);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onLinearTeamsChange([...next]);
+  };
+
+  const toggleLinearProject = (id: string) => {
+    const next = new Set(hiddenLinearProjects);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onChange({ ...filters, hiddenLinearProjects: [...next] });
   };
 
   const setTime = (time: InboxTimeFilter) => {
@@ -163,6 +191,34 @@ export function InboxFiltersMenu({
         </>
       ) : null}
 
+      {source === "linear" && linearTeams.length > 0 ? (
+        <>
+          <SectionLabel>Teams</SectionLabel>
+          {linearTeams.map((team) => (
+            <FilterItem
+              key={team.id}
+              label={team.name || team.key}
+              checked={!hiddenTeams.has(team.id)}
+              onClick={() => toggleLinearTeam(team.id)}
+            />
+          ))}
+        </>
+      ) : null}
+
+      {source === "linear" && linearProjects.length > 0 ? (
+        <>
+          <SectionLabel>Projects</SectionLabel>
+          {linearProjects.map((project) => (
+            <FilterItem
+              key={project.id}
+              label={project.name}
+              checked={!hiddenLinearProjects.has(project.id)}
+              onClick={() => toggleLinearProject(project.id)}
+            />
+          ))}
+        </>
+      ) : null}
+
       {source === "github" && projects.length > 0 ? (
         <>
           <SectionLabel>Projects</SectionLabel>
@@ -186,14 +242,17 @@ export function InboxFiltersMenu({
         </>
       ) : null}
 
-      {hasActiveInboxFilters(filters, source) ? (
+      {hasActiveInboxFilters(filters, source, hiddenLinearTeamIds) ? (
         <>
           <div role="separator" className="my-1 h-px bg-content/10" />
           <button
             type="button"
             role="menuitem"
             onMouseDown={(event) => event.preventDefault()}
-            onClick={() => onChange(DEFAULT_INBOX_FILTERS)}
+            onClick={() => {
+              onChange(DEFAULT_INBOX_FILTERS);
+              if (teamsActive) onLinearTeamsChange([]);
+            }}
             className="flex h-7 w-full items-center rounded-lg px-2 text-left text-[13px] leading-none text-content/70 hover:bg-content/5 hover:text-content"
           >
             Clear filters

--- a/src/lib/githubTasks.ts
+++ b/src/lib/githubTasks.ts
@@ -50,6 +50,9 @@ export type InboxItem = Omit<GithubWorkItem, "kind"> & {
   identifier?: string;
   teamId?: string;
   teamName?: string;
+  /** Linear project the issue belongs to. Empty when it sits outside every project. */
+  projectId?: string;
+  projectName?: string;
   stateType?: string;
 };
 
@@ -534,6 +537,8 @@ function linearIssueToInboxItem(issue: LinearIssue): InboxItem {
     repo: issue.repo,
     teamId: issue.teamId,
     teamName: issue.teamName,
+    projectId: issue.projectId || "",
+    projectName: issue.projectName || "",
     projectPath: issue.projectPath || "",
   };
 }
@@ -707,6 +712,7 @@ export function matchesInboxQuery(item: InboxItem, query: string): boolean {
     item.projectPath,
     item.identifier,
     item.teamName,
+    item.projectName,
     kind,
     `#${item.number}`,
     String(item.number),

--- a/src/lib/inboxFilters.test.ts
+++ b/src/lib/inboxFilters.test.ts
@@ -3,12 +3,15 @@ import {
   applyInboxFilters,
   DEFAULT_INBOX_FILTERS,
   filterInboxByKind,
+  filterInboxByLinearProject,
   filterInboxByProject,
   filterInboxByProvider,
   filterInboxByStatus,
   filterInboxByTime,
   hasActiveInboxFilters,
   inboxFetchState,
+  LINEAR_NO_PROJECT,
+  linearProjectOptions,
   pruneInboxFilters,
 } from "./inboxFilters";
 import type { InboxItem } from "./githubTasks";
@@ -56,6 +59,103 @@ describe("filterInboxByProject", () => {
     expect(
       filterInboxByProject(rows, ["/tmp/web"]).map((row) => row.number),
     ).toEqual([9]);
+  });
+});
+
+describe("linearProjectOptions", () => {
+  function linearItem(number: number, project?: { id: string; name: string }) {
+    return item({
+      number,
+      kind: "linear",
+      provider: "linear",
+      projectPath: "",
+      projectId: project?.id ?? "",
+      projectName: project?.name ?? "",
+      updatedAt: "2026-08-27T10:00:00Z",
+    });
+  }
+
+  it("collects distinct projects sorted by name", () => {
+    const rows = [
+      linearItem(1, { id: "p2", name: "Onboarding" }),
+      linearItem(2, { id: "p1", name: "Billing" }),
+      linearItem(3, { id: "p1", name: "Billing" }),
+    ];
+    expect(linearProjectOptions(rows)).toEqual([
+      { id: "p1", name: "Billing" },
+      { id: "p2", name: "Onboarding" },
+    ]);
+  });
+
+  it("appends a No project row when an issue sits outside every project", () => {
+    const rows = [linearItem(1, { id: "p1", name: "Billing" }), linearItem(2)];
+    expect(linearProjectOptions(rows)).toEqual([
+      { id: "p1", name: "Billing" },
+      { id: LINEAR_NO_PROJECT, name: "No project" },
+    ]);
+  });
+
+  it("ignores GitHub items", () => {
+    const rows = [item({ number: 1, updatedAt: "2026-08-27T10:00:00Z" })];
+    expect(linearProjectOptions(rows)).toEqual([]);
+  });
+
+  it("falls back to the id when a project has no name", () => {
+    expect(linearProjectOptions([linearItem(1, { id: "p1", name: "" })])).toEqual(
+      [{ id: "p1", name: "p1" }],
+    );
+  });
+});
+
+describe("filterInboxByLinearProject", () => {
+  const rows = [
+    item({
+      number: 1,
+      kind: "linear",
+      provider: "linear",
+      projectPath: "",
+      projectId: "p1",
+      projectName: "Billing",
+      updatedAt: "2026-08-27T10:00:00Z",
+    }),
+    item({
+      number: 2,
+      kind: "linear",
+      provider: "linear",
+      projectPath: "",
+      projectId: "",
+      projectName: "",
+      updatedAt: "2026-08-27T10:00:00Z",
+    }),
+    item({ number: 3, updatedAt: "2026-08-27T10:00:00Z" }),
+  ];
+
+  it("keeps everything when nothing is hidden", () => {
+    expect(filterInboxByLinearProject(rows, []).map((row) => row.number)).toEqual(
+      [1, 2, 3],
+    );
+  });
+
+  it("hides the selected project", () => {
+    expect(
+      filterInboxByLinearProject(rows, ["p1"]).map((row) => row.number),
+    ).toEqual([2, 3]);
+  });
+
+  it("hides project-less issues via the No project sentinel", () => {
+    expect(
+      filterInboxByLinearProject(rows, [LINEAR_NO_PROJECT]).map(
+        (row) => row.number,
+      ),
+    ).toEqual([1, 3]);
+  });
+
+  it("never hides GitHub items", () => {
+    expect(
+      filterInboxByLinearProject(rows, ["p1", LINEAR_NO_PROJECT]).map(
+        (row) => row.number,
+      ),
+    ).toEqual([3]);
   });
 });
 
@@ -262,6 +362,42 @@ describe("hasActiveInboxFilters", () => {
         "linear",
       ),
     ).toBe(false);
+  });
+
+  it("is true when a Linear project is hidden on the Linear tab", () => {
+    expect(
+      hasActiveInboxFilters(
+        { ...DEFAULT_INBOX_FILTERS, hiddenLinearProjects: ["p1"] },
+        "linear",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores hidden Linear projects on the GitHub tab", () => {
+    expect(
+      hasActiveInboxFilters(
+        { ...DEFAULT_INBOX_FILTERS, hiddenLinearProjects: ["p1"] },
+        "github",
+      ),
+    ).toBe(false);
+  });
+
+  it("is true when a Linear team is hidden on the Linear tab", () => {
+    expect(hasActiveInboxFilters(DEFAULT_INBOX_FILTERS, "linear", ["t1"])).toBe(
+      true,
+    );
+  });
+
+  it("ignores hidden Linear teams on the GitHub tab", () => {
+    expect(hasActiveInboxFilters(DEFAULT_INBOX_FILTERS, "github", ["t1"])).toBe(
+      false,
+    );
+  });
+
+  it("is false on the Linear tab when no team is hidden", () => {
+    expect(hasActiveInboxFilters(DEFAULT_INBOX_FILTERS, "linear", [])).toBe(
+      false,
+    );
   });
 });
 

--- a/src/lib/inboxFilters.ts
+++ b/src/lib/inboxFilters.ts
@@ -23,9 +23,22 @@ export type InboxStatusFilter = {
 export type InboxFilters = {
   assignedToMe: boolean;
   hiddenProjects: string[];
+  /** Linear project ids to hide. `LINEAR_NO_PROJECT` stands for issues outside every project. */
+  hiddenLinearProjects: string[];
   hiddenKinds: InboxKind[];
   time: InboxTimeFilter;
   status: InboxStatusFilter;
+};
+
+/**
+ * Stands in for "issue belongs to no Linear project" so that bucket is as
+ * hideable as a real one. Not a valid Linear id, so it can never collide.
+ */
+export const LINEAR_NO_PROJECT = "~none";
+
+export type LinearProjectOption = {
+  id: string;
+  name: string;
 };
 
 export const DEFAULT_INBOX_STATUS_FILTER: InboxStatusFilter = {
@@ -38,6 +51,7 @@ export const DEFAULT_INBOX_STATUS_FILTER: InboxStatusFilter = {
 export const DEFAULT_INBOX_FILTERS: InboxFilters = {
   assignedToMe: false,
   hiddenProjects: [],
+  hiddenLinearProjects: [],
   hiddenKinds: [],
   time: "all",
   status: DEFAULT_INBOX_STATUS_FILTER,
@@ -75,6 +89,11 @@ export function loadInboxFilters(): InboxFilters {
       hiddenProjects: Array.isArray(parsed.hiddenProjects)
         ? parsed.hiddenProjects.filter(
             (path): path is string => typeof path === "string" && path.length > 0,
+          )
+        : [],
+      hiddenLinearProjects: Array.isArray(parsed.hiddenLinearProjects)
+        ? parsed.hiddenLinearProjects.filter(
+            (id): id is string => typeof id === "string" && id.length > 0,
           )
         : [],
       hiddenKinds: Array.isArray(parsed.hiddenKinds)
@@ -118,6 +137,8 @@ export function pruneInboxFilters(
 export function hasActiveInboxFilters(
   filters: InboxFilters,
   source?: InboxSource,
+  /** Teams live outside InboxFilters — they narrow the fetch and are shared with Settings. */
+  hiddenLinearTeamIds: readonly string[] = [],
 ): boolean {
   const statusActive =
     source === "linear"
@@ -128,7 +149,10 @@ export function hasActiveInboxFilters(
         filters.status.merged;
   return (
     filters.assignedToMe ||
-    (source === "linear" ? false : filters.hiddenProjects.length > 0) ||
+    (source === "linear" && hiddenLinearTeamIds.length > 0) ||
+    (source === "linear"
+      ? filters.hiddenLinearProjects.length > 0
+      : filters.hiddenProjects.length > 0) ||
     (source === "linear" ? false : filters.hiddenKinds.length > 0) ||
     filters.time !== "all" ||
     statusActive
@@ -154,6 +178,45 @@ export function filterInboxByProject(
     const path = normalizeProjectPath(item.projectPath);
     if (!path) return true;
     return !hidden.has(path);
+  });
+}
+
+/**
+ * Every distinct Linear project across `items`, name-sorted, with a trailing
+ * "No project" row when any issue sits outside a project. Derived from the
+ * fetched issues because Linear projects are not fetched separately.
+ */
+export function linearProjectOptions(
+  items: readonly InboxItem[],
+): LinearProjectOption[] {
+  const byId = new Map<string, string>();
+  let unassigned = false;
+  for (const item of items) {
+    if (item.provider !== "linear") continue;
+    const id = item.projectId?.trim() ?? "";
+    if (!id) {
+      unassigned = true;
+      continue;
+    }
+    if (!byId.has(id)) byId.set(id, item.projectName?.trim() || id);
+  }
+  const options = [...byId]
+    .map(([id, name]) => ({ id, name }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  if (unassigned) options.push({ id: LINEAR_NO_PROJECT, name: "No project" });
+  return options;
+}
+
+export function filterInboxByLinearProject(
+  items: readonly InboxItem[],
+  hiddenProjects: Iterable<string>,
+): InboxItem[] {
+  const hidden = new Set(hiddenProjects);
+  if (hidden.size === 0) return [...items];
+  return items.filter((item) => {
+    if (item.provider !== "linear") return true;
+    const id = item.projectId?.trim() || LINEAR_NO_PROJECT;
+    return !hidden.has(id);
   });
 }
 
@@ -216,7 +279,10 @@ export function applyInboxFilters(
     filterInboxByStatus(
       filterInboxByTime(
         filterInboxByKind(
-          filterInboxByProject(scoped, hiddenProjects),
+          filterInboxByLinearProject(
+            filterInboxByProject(scoped, hiddenProjects),
+            filters.hiddenLinearProjects,
+          ),
           hiddenKinds,
         ),
         filters.time,

--- a/src/lib/linear.ts
+++ b/src/lib/linear.ts
@@ -23,6 +23,8 @@ export type LinearIssue = {
   repo: string;
   teamId: string;
   teamName: string;
+  projectId: string;
+  projectName: string;
   projectPath: string;
 };
 

--- a/src/surfaces/InboxView.tsx
+++ b/src/surfaces/InboxView.tsx
@@ -66,6 +66,7 @@ import {
 import {
   applyInboxFilters,
   hasActiveInboxFilters,
+  linearProjectOptions,
   inboxFetchState,
   loadInboxFilters,
   loadInboxSource,
@@ -89,10 +90,13 @@ import {
   linearIssueComment,
   linearIssueDetails,
   linearIssueThread,
+  listLinearTeams,
   loadHiddenLinearTeamIds,
   peekLinearIssueDetails,
   peekLinearIssueThread,
+  saveHiddenLinearTeamIds,
   type LinearIssueThread,
+  type LinearTeam,
 } from "../lib/linear";
 import {
   loadTabGroupColors,
@@ -312,6 +316,7 @@ export function InboxView({
   const [linearHiddenTeamIds, setLinearHiddenTeamIds] = useState(
     loadHiddenLinearTeamIds,
   );
+  const [linearTeams, setLinearTeams] = useState<LinearTeam[]>([]);
   const prevRefresh = useRef(refresh);
 
   const projects = useMemo(
@@ -322,6 +327,7 @@ export function InboxView({
     () => inboxProjectOptions(projects, logos),
     [logos, projects],
   );
+  const linearProjects = useMemo(() => linearProjectOptions(items), [items]);
   const activeFilters = useMemo(
     () =>
       pruneInboxFilters(
@@ -330,7 +336,11 @@ export function InboxView({
       ),
     [filters, projects],
   );
-  const filtersActive = hasActiveInboxFilters(activeFilters, source);
+  const filtersActive = hasActiveInboxFilters(
+    activeFilters,
+    source,
+    linearHiddenTeamIds,
+  );
   const fetchState = inboxFetchState(activeFilters);
   const fetchQuery = useMemo<InboxQuery>(
     () => ({
@@ -375,6 +385,23 @@ export function InboxView({
     window.addEventListener(LINEAR_CHANGE_EVENT, onChange);
     return () => window.removeEventListener(LINEAR_CHANGE_EVENT, onChange);
   }, []);
+
+  // The roster has to come from Linear, not from the fetched issues: hiding a
+  // team drops its issues, so a derived list could never offer it back.
+  useEffect(() => {
+    if (source !== "linear") return;
+    let cancelled = false;
+    void listLinearTeams()
+      .then((teams) => {
+        if (!cancelled) setLinearTeams(teams);
+      })
+      .catch(() => {
+        if (!cancelled) setLinearTeams([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [source, linearHiddenTeamIds]);
 
   useEffect(() => {
     const force = refresh !== prevRefresh.current;
@@ -633,9 +660,13 @@ export function InboxView({
       x={filterMenu.x}
       y={filterMenu.y}
       projects={projectOptions}
+      linearProjects={linearProjects}
+      linearTeams={linearTeams}
+      hiddenLinearTeamIds={linearHiddenTeamIds}
       source={source}
       filters={activeFilters}
       onChange={onFiltersChange}
+      onLinearTeamsChange={saveHiddenLinearTeamIds}
       onClose={() => setFilterMenu(null)}
     />
   ) : null;

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -112,6 +112,7 @@ import type { SessionSummary } from "../lib/sessionStore";
 import { clearInboxCache } from "../lib/githubTasks";
 import {
   disconnectLinear,
+  LINEAR_CHANGE_EVENT,
   linearConnected,
   listLinearTeams,
   loadHiddenLinearTeamIds,
@@ -542,6 +543,13 @@ function LinearSettings() {
       cancelled = true;
     };
   }, [loadTeams]);
+
+  // The inbox filter menu writes the same list, so follow it while both are mounted.
+  useEffect(() => {
+    const onChange = () => setHiddenTeamIds(loadHiddenLinearTeamIds());
+    window.addEventListener(LINEAR_CHANGE_EVENT, onChange);
+    return () => window.removeEventListener(LINEAR_CHANGE_EVENT, onChange);
+  }, []);
 
   const onSave = async () => {
     if (!token.trim() || busy) return;


### PR DESCRIPTION
## What changed

The inbox filter menu now has **Teams** and **Projects** sections on the Linear tab. Teams reuses the existing hidden-team list from Settings; Projects is new, and needs one extra field on the issues query.

## Why

Linear issues could not be narrowed by where they live. Teams were only reachable from Settings → Linear Teams, which is a long way from the list you are looking at, and projects were not fetched at all — so on a workspace with a few active projects the inbox was all-or-nothing.

Two deliberate asymmetries, since the sections look identical but are not:

- **Teams stays fetch-level.** It reads and writes the same `monocode.linearHiddenTeams` the Settings pane uses, so the two stay in sync and unchecking a team still narrows the GraphQL `IssueFilter` rather than just the rendered list. The roster comes from `listLinearTeams()` and not from the fetched issues on purpose: hiding a team drops its issues, so a derived list could never offer that team back.
- **Projects is client-side.** Pushing it into `IssueFilter` would shrink the result window and let unrelated issues slip in under the fetch cap, so the filter hides already-fetched issues instead. A trailing "No project" row (a sentinel id, never a real Linear id) makes unassigned issues as hideable as any project — without it, narrowing to one project still leaves every loose issue on screen.

Hidden projects are deliberately not pruned. `pruneInboxFilters` drops stale local projects against the rail's known paths, which is safe because that list is stable; the Linear project list is derived from whatever the current fetch returned, so pruning against it would silently clear the filter whenever a hidden project happened to have no issues in the window.

Two smaller things that fell out: `Clear filters` also clears hidden teams (otherwise the funnel icon stays lit with no way to reset it from the menu), and `LinearSettings` now follows `LINEAR_CHANGE_EVENT` — it seeded its checkboxes from `localStorage` once, so toggling a team in the inbox left an open Settings pane showing stale state.

Known limitation: the project list only contains projects present in the fetched issues, so a project whose issues all fall outside the window won't offer a row. Fixing that properly means a separate projects query, like `listLinearTeams` does for teams — happy to add it if you'd rather have it upfront.

No CHANGELOG entry, since `Unreleased` entries look like they're written at release time with the PR number attached — glad to add one if you'd prefer it in the PR.

## UI

The Linear filter menu goes from Assigned to me · Status · Time to Assigned to me · Status · Time · Teams · Projects. Happy to attach a screenshot — flagging that I have not exercised this against a live workspace beyond my own, so a second look at the team list matching Settings is worthwhile.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes