### PR TITLE
Fix the reversed `Sounds` switch cue

### DIFF
--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -1487,8 +1487,8 @@ function Toggle({
       aria-label={label}
       aria-checked={on}
       onClick={() => {
-        playCue("switch");
         onChange(!on);
+        playCue("switch");
       }}
       className={`relative h-5 w-9 shrink-0 rounded-full transition-colors ${
         on ? "bg-accent" : "bg-content/20"


### PR DESCRIPTION
## What changed

`Toggle` in `src/surfaces/SettingsView.tsx` now commits the new state before it plays the `switch` cue. The Sounds switch plays its cue when it turns on and stays silent when it turns off. Every other switch keeps its cue in both directions.

## Why

The Sounds switch had its cue reversed. Turning it on played no sound, and turning it off played one.
`Toggle` fired the cue before `onChange`, so `playCue` still read the previous state: "off" when turning on, "on" when turning off.

## UI

No chrome or layout change. The switch looks the same.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes