### PR TITLE
Bind code block dark theme to the app preference

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,8 @@
 @source "../node_modules/@streamdown/code/dist/*.js";
 @source "../node_modules/@streamdown/mermaid/dist/*.js";
 
+@custom-variant dark (&:where(html:not(.theme-light), html:not(.theme-light) *));
+
 @theme {
   --color-background-base: hsl(
     var(--theme-hue) var(--theme-saturation) var(--background-lightness)


### PR DESCRIPTION
## What changed

Add a Tailwind `@custom-variant dark` in `src/index.css` bound to `html:not(.theme-light)`.

## Why

Streamdown switches shiki token colors with `dark:` utilities. Tailwind's default `dark` variant follows the OS `prefers-color-scheme`, not the app theme class. With the OS in light mode and the app theme set to dark, code blocks got light-palette tokens on a dark background. Identifiers, strings, and punctuation were unreadable. The reverse case (OS dark, app light) had the same defect.

## UI

Before: light shiki palette on dark background (see attached screenshot).
<img width="1467" height="926" alt="image" src="https://github.com/user-attachments/assets/9fa083c3-48ce-4943-a654-44056e1640d7" />

After: dark palette when the app theme is dark, independent of the OS setting.
<img width="1467" height="888" alt="image" src="https://github.com/user-attachments/assets/dc6ddc2c-72e0-4843-a9e2-c3b3144d258c" />



## Checklist

- [x] I ran `npm run check` (web half; Rust untouched)
- [x] This PR is small and focused
- [x] I did not mix unrelated changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dark-mode styling support that applies by default unless light mode is explicitly selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->