### PR TITLE
Treat search include globs as pathspecs, not git grep flags

### DIFF
--- a/src-tauri/src/search.rs
+++ b/src-tauri/src/search.rs
@@ -85,6 +85,9 @@ fn git_grep(root: &Path, options: &SearchOptions, query: &str) -> Option<SearchR
     }
     cmd.arg("-e").arg(query);
 
+    // Terminate option parsing so an include glob starting with `-` is treated
+    // as a pathspec instead of a git grep flag.
+    cmd.arg("--");
     for spec in pathspecs(&options.include, &options.exclude) {
         cmd.arg(spec);
     }


### PR DESCRIPTION
## What changed

`git_grep` in `src-tauri/src/search.rs` now passes `--` after the search pattern, so every `include`/`exclude` token that follows is unambiguously a pathspec.

## Why

The tokens from the search panel's "files to include" field were appended directly onto the `git grep` argument list with no `--` separator. Anything a user typed there that started with `-` was therefore parsed by git as an *option* rather than a pathspec.

That matters more than a normal glob-parsing bug, because `git grep` has options that spawn a process — `-O` / `--open-files-in-pager` runs a command on the matched files. So a value pasted into that field could execute an arbitrary command with the privileges of whoever is running MonoCode. Since MonoCode is a desktop app with full filesystem and process access, this is worth closing off.

`--` fixes the whole category structurally rather than filtering particular flag names. That's deliberate: the short `-O<command>` spelling (no `=`) triggers the same behavior, so a name-based filter would be incomplete, and it would also need updating whenever git grows new flags. Terminating option parsing removes the ambiguity at the source.

Two notes for reviewers:

- **No behavior change for legitimate input.** I checked ordinary globs (`*.ts`), the `:(exclude)…` tokens this function builds itself, and the empty-pathspec case — all identical with `--` in place.
- `--` stops flag parsing but doesn't disable git's pathspec *magic*; an include of `:(top)` or `:/` still searches from the repo root rather than the opened directory. Git refuses pathspecs outside the repository, so that's scope-widening rather than arbitrary file read. I left it alone since fixing it would collide with the `:(exclude)` construction here, but happy to follow up if you'd like it handled.

## UI

No UI change.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDamTDovK8dArJULC8b5VH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed search behavior for include patterns beginning with a hyphen, ensuring they are interpreted correctly as path filters rather than command options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->