### PR TITLE
Add a setting to archive conversations with the close shortcut

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -328,6 +328,7 @@ import { linearIssueDetails, peekLinearIssueDetails } from "./lib/linear";
 import {
   loadLiveAgentsEnabled,
   loadNotesEnabled,
+  loadArchiveOnClose,
   loadDiffViewer,
   loadFollowUpBehavior,
   loadSettingsSection,
@@ -2897,7 +2898,7 @@ export default function App({
   );
 
   const onArchiveFocusedSession = useCallback(
-    (event: KeyboardEvent) => {
+    (event?: KeyboardEvent) => {
       archiveFocusedSession(
         event,
         {
@@ -4841,10 +4842,12 @@ export default function App({
           return;
         }
       }
-      const cmd = tabCommand(e);
+      const cmd = tabCommand(e, loadArchiveOnClose());
       if (cmd) {
         if (cmd === "archive-session") {
-          actions.current.onArchiveFocusedSession(e);
+          run("archive-session", () =>
+            actions.current.onArchiveFocusedSession(e),
+          );
           return;
         }
         const target = e.target instanceof Element ? e.target : null;
@@ -4990,7 +4993,15 @@ export default function App({
       listen("close_other_tabs", () =>
         run("close-others", actions.current.onCloseOtherTabs),
       ),
-      listen("close_tab", () => run("close", actions.current.onClosePane)),
+      listen("close_tab", () => {
+        if (loadArchiveOnClose()) {
+          run("archive-session", () =>
+            actions.current.onArchiveFocusedSession(),
+          );
+        } else {
+          run("close", actions.current.onClosePane);
+        }
+      }),
       listen("next_tab", () => run("next", actions.current.onNext)),
       listen("prev_tab", () => run("prev", actions.current.onPrev)),
       listen("back_tab", () => run("back", actions.current.onVisitBack)),

--- a/src/lib/archiveShortcut.test.ts
+++ b/src/lib/archiveShortcut.test.ts
@@ -17,12 +17,15 @@ afterEach(() => vi.unstubAllGlobals());
 function fixture() {
   const overlays: { selector: string; element: ElementStub }[] = [];
   vi.stubGlobal("Element", ElementStub);
-  vi.stubGlobal("document", {
+  const documentStub = {
+    activeElement: null as ElementStub | null,
+    hasFocus: vi.fn(() => true),
     querySelectorAll: (selector: string) =>
       overlays
         .filter((overlay) => selector.split(", ").includes(overlay.selector))
         .map((overlay) => overlay.element),
-  });
+  };
+  vi.stubGlobal("document", documentStub);
   const style = vi.fn(() => ({ visibility: "visible" }));
   vi.stubGlobal("getComputedStyle", style);
   const context = {
@@ -45,6 +48,8 @@ function fixture() {
     archive,
     overlays,
     style,
+    document: documentStub,
+    runMenu: () => archiveFocusedSession(undefined, context, archive),
     run: () =>
       archiveFocusedSession(
         event as unknown as KeyboardEvent,
@@ -62,6 +67,26 @@ function expectUntouched(f: ReturnType<typeof fixture>) {
 }
 
 describe("archive shortcut routing", () => {
+  it("archives from a native close command in the focused window", () => {
+    const f = fixture();
+    f.runMenu();
+    expect(f.archive).toHaveBeenCalledExactlyOnceWith("session");
+  });
+
+  it("does not archive in another window receiving the native menu event", () => {
+    const f = fixture();
+    f.document.hasFocus.mockReturnValue(false);
+    f.runMenu();
+    expect(f.archive).not.toHaveBeenCalled();
+  });
+
+  it("checks DOM focus for native commands without a keyboard event", () => {
+    const f = fixture();
+    f.document.activeElement = new ElementStub([".cm-editor"]);
+    f.runMenu();
+    expect(f.archive).not.toHaveBeenCalled();
+  });
+
   it("consumes the event before archiving exactly the focused session", () => {
     const f = fixture();
     f.context.tabs[0].focusedId = "other";

--- a/src/lib/archiveShortcut.ts
+++ b/src/lib/archiveShortcut.ts
@@ -8,12 +8,13 @@ type ArchiveContext = {
 
 /** Archive only after confirming that the focused conversation owns the key. */
 export function archiveFocusedSession(
-  event: KeyboardEvent,
+  event: KeyboardEvent | undefined,
   context: ArchiveContext,
   archive: (sessionId: string) => void,
 ): void {
   if (
-    event.defaultPrevented ||
+    event?.defaultPrevented ||
+    (!event && !document.hasFocus()) ||
     context.projectTerminalFocused ||
     context.surfaceOpen
   )
@@ -24,7 +25,8 @@ export function archiveFocusedSession(
   const session = context.sessions.find((entry) => entry.id === tab.focusedId);
   if (!session) return;
 
-  const target = event.target instanceof Element ? event.target : null;
+  const eventTarget = event?.target ?? document.activeElement;
+  const target = eventTarget instanceof Element ? eventTarget : null;
   if (target?.closest(".cm-editor, .monocode-terminal")) return;
   if (
     target?.closest('input, textarea, select, [contenteditable="true"]') &&
@@ -46,7 +48,7 @@ export function archiveFocusedSession(
   );
   if (overlayOpen) return;
 
-  event.preventDefault();
-  event.stopPropagation();
+  event?.preventDefault();
+  event?.stopPropagation();
   archive(session.id);
 }

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  loadArchiveOnClose,
+  saveArchiveOnClose,
   COMPOSER_RUNNER_DEFAULT,
   DIFF_VIEWER_DEFAULT,
   FOLLOW_UP_BEHAVIOR_DEFAULT,
@@ -27,6 +29,23 @@ const LIVE_AGENTS_KEY = "monocode.liveAgentsEnabled";
 const GRID_ARCADE_KEY = "monocode.gridArcadeEnabled";
 const DIFF_VIEWER_KEY = "monocode.diffViewer";
 const FOLLOW_UP_BEHAVIOR_KEY = "monocode.followUpBehavior";
+
+describe("archive on close setting", () => {
+  beforeEach(mockLocalStorage);
+
+  it("defaults to normal closing and ignores unknown saved values", () => {
+    expect(loadArchiveOnClose()).toBe(false);
+    localStorage.setItem("monocode.archiveOnClose", "invalid");
+    expect(loadArchiveOnClose()).toBe(false);
+  });
+
+  it("persists enabling and disabling archive on close", () => {
+    saveArchiveOnClose(true);
+    expect(loadArchiveOnClose()).toBe(true);
+    saveArchiveOnClose(false);
+    expect(loadArchiveOnClose()).toBe(false);
+  });
+});
 
 describe("follow-up behavior setting", () => {
   beforeEach(mockLocalStorage);

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -78,6 +78,24 @@ export function saveSettingsSection(id: SettingsSectionId) {
 
 const COMPOSER_RUNNER_KEY = "monocode.composerRunner";
 
+const ARCHIVE_ON_CLOSE_KEY = "monocode.archiveOnClose";
+
+export function loadArchiveOnClose(): boolean {
+  try {
+    return localStorage.getItem(ARCHIVE_ON_CLOSE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function saveArchiveOnClose(enabled: boolean) {
+  try {
+    localStorage.setItem(ARCHIVE_ON_CLOSE_KEY, String(enabled));
+  } catch {
+    // private mode / quota
+  }
+}
+
 const FOLLOW_UP_BEHAVIOR_KEY = "monocode.followUpBehavior";
 
 export type FollowUpBehavior = "steer" | "queue";
@@ -370,7 +388,12 @@ export const KEYBINDINGS: KeybindingRow[] = [
     keys: `${MOD}${SHIFT}→`,
     when: "!overlay && (!textFocus || emptyComposer)",
   },
-  { command: "Pane: Close", keys: `${MOD}W`, when: "Always" },
+  { command: "Pane: Close", keys: `${MOD}W`, when: "!archiveOnClose" },
+  {
+    command: "Session: Archive with Close Pane",
+    keys: `${MOD}W`,
+    when: "archiveOnClose && sessionFocus && !overlay",
+  },
   { command: "Pane: Split Right", keys: `${MOD}D`, when: "!editorFocus" },
   {
     command: "Pane: Split Down",

--- a/src/lib/tabKeys.test.ts
+++ b/src/lib/tabKeys.test.ts
@@ -39,6 +39,22 @@ function key(
 }
 
 describe("tabCommand", () => {
+  it.each([{ metaKey: true }, { ctrlKey: true }])(
+    "opts the close shortcut into archiving (%j)",
+    (modifiers) => {
+      const close = key({ key: "w", ...modifiers });
+      expect(tabCommand(close)).toBe("close");
+      expect(tabCommand(close, true)).toBe("archive-session");
+      expect(tabCommand(close, false)).toBe("close");
+      expect(
+        tabCommand(key({ key: "w", repeat: true, ...modifiers }), true),
+      ).toBeNull();
+      expect(
+        tabCommand(key({ key: "w", shiftKey: true, ...modifiers }), true),
+      ).toBeNull();
+    },
+  );
+
   it("archives with Cmd+Shift+A or Ctrl+Shift+A", () => {
     expect(
       tabCommand(key({ key: "A", metaKey: true, shiftKey: true })),

--- a/src/lib/tabKeys.ts
+++ b/src/lib/tabKeys.ts
@@ -51,7 +51,10 @@ export type TabCommand =
   | { activate: number }
   | { focus: FocusDir };
 
-export function tabCommand(e: KeyboardEvent): TabCommand | null {
+export function tabCommand(
+  e: KeyboardEvent,
+  archiveOnClose = false,
+): TabCommand | null {
   if (e.isComposing) return null;
 
   const mod = e.metaKey || e.ctrlKey;
@@ -90,7 +93,10 @@ export function tabCommand(e: KeyboardEvent): TabCommand | null {
   }
 
   if (key === "t") return "new";
-  if (key === "w") return "close";
+  if (key === "w") {
+    if (!archiveOnClose) return "close";
+    return e.repeat ? null : "archive-session";
+  }
   if (key === "d") return "split-right";
   if (key === "j") return "toggle-terminal";
   if (e.key === "[" || e.code === "BracketLeft") return "back";

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -112,7 +112,7 @@ import {
   subscribeModels,
 } from "../lib/models";
 import { prettyCwd, projectKey, projectName } from "../lib/paths";
-import { IS_MAC } from "../lib/platform";
+import { IS_MAC, MOD } from "../lib/platform";
 import {
   loadArchivedProjects,
   looksLikeProject,
@@ -147,6 +147,7 @@ import {
   filterKeybindings,
   KEYBINDINGS,
   loadClaudeHooks,
+  loadArchiveOnClose,
   loadComposerRunner,
   loadDiffViewer,
   loadFollowUpBehavior,
@@ -154,6 +155,7 @@ import {
   loadLiveAgentsEnabled,
   loadNotesEnabled,
   saveClaudeHooks,
+  saveArchiveOnClose,
   saveComposerRunner,
   saveDiffViewer,
   saveFollowUpBehavior,
@@ -322,6 +324,7 @@ function GeneralPage({
   const [notificationPermission, setNotificationPermission] =
     useState<NotificationPermission>(cachedNotificationPermission);
   const [claudeHooks, setClaudeHooks] = useState(loadClaudeHooks);
+  const [archiveOnClose, setArchiveOnClose] = useState(loadArchiveOnClose);
 
   // The user may flip the switch in System Settings and come back: re-read
   // the OS state whenever the window regains focus while the toggle is on.
@@ -404,6 +407,19 @@ function GeneralPage({
 
   return (
     <>
+      <Row
+        label="Archive on close shortcut"
+        description={`Make ${MOD}W use the archive action. Conversations remain available in Archive.`}
+      >
+        <Toggle
+          label="Archive on close shortcut"
+          on={archiveOnClose}
+          onChange={(enabled) => {
+            saveArchiveOnClose(enabled);
+            setArchiveOnClose(enabled);
+          }}
+        />
+      </Row>
       <Row
         label="Transcript layout"
         description="Full width keeps user prompts as a spanning card. Chat aligns them to the right with a max width, like a messaging app."


### PR DESCRIPTION
## What changed

Add an opt-in **Archive on close shortcut** toggle in Settings → General. When enabled, Cmd+W / Ctrl+W uses the same archive action as Cmd+Shift+A / Ctrl+Shift+A. The default remains normal pane closing.

Route the keyboard shortcut and macOS native close command through the existing centralized archive eligibility checks. Editors, diffs, terminals, other app surfaces, and visible overlays/popovers remain protected; blocked keyboard events stay untouched. Native commands also require the receiving window to have focus.

## Why

Let users archive finished conversations with their usual close shortcut while keeping them available in Archive.

## UI

The toggle appears in General settings; the keybindings reference documents both modes. Verified the real settings component in a browser preview: default off, enabling persists across reload, and disabling restores normal closing. Native desktop interaction remains unverified because desktop automation access was denied.

## Validation

71 focused settings, key mapping, and archive routing tests pass, including native command focus checks. The full frontend suite passes (1,404 tests), as do TypeScript and the production build. Rust formatting, Clippy, and 218 Rust tests pass on the identical native-code baseline. No dependencies added.

## Checklist

- [x] I ran `npm run check` (web and Rust halves separately; Vitest limited to two workers)
- [x] This PR is small and focused
- [x] I did not mix unrelated changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “Archive on close shortcut” setting in General settings.
  - When enabled, the close-pane shortcut archives the focused session instead of closing it.
  - The shortcut remains available for closing panes when the setting is disabled.
  - Archive-on-close actions now respect window and workspace focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->