### PR TITLE
Move update checks to the version in the status footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5474,18 +5474,13 @@ export default function App({
             onOpenWhatsNew={onOpenWhatsNew}
           />
         ) : null}
-        {searchViewOpen ||
-        inboxViewOpen ||
-        notesViewOpen ||
-        settingsOpen ? null : (
-          <UsageFooter
-            providers={usageProviders}
-            session={usageSession}
-            terminals={runningTerminals}
-            terminalOpen={runningTerminalOpen}
-            onToggleTerminal={onToggleRunningTerminal}
-          />
-        )}
+        <UsageFooter
+          providers={usageProviders}
+          session={usageSession}
+          terminals={runningTerminals}
+          terminalOpen={runningTerminalOpen}
+          onToggleTerminal={onToggleRunningTerminal}
+        />
       </div>
 
       {filePickerOpen ? (

--- a/src/chrome/SidebarUpdate.tsx
+++ b/src/chrome/SidebarUpdate.tsx
@@ -1,12 +1,3 @@
-import { ArrowDownCircle, Loader, RefreshCw } from "./icons";
-import { useCallback, useEffect, useState } from "react";
-import {
-  installPendingUpdate,
-  probeForUpdate,
-  readAppVersion,
-  runUpdateFlow,
-  type UpdaterSnapshot,
-} from "../lib/updater";
 import type { InstalledUpdate } from "../lib/updateNotice";
 import { UpdateRailCard } from "./UpdateRailCard";
 
@@ -19,113 +10,15 @@ export function SidebarUpdateFooter({
   onOpenWhatsNew?: (version: string) => void;
   onDismissUpdate?: () => void;
 }) {
+  if (!update || !onOpenWhatsNew || !onDismissUpdate) return null;
+
   return (
     <div className="flex flex-col gap-1.5 p-2 pb-1">
-      {update && onOpenWhatsNew && onDismissUpdate ? (
-        <UpdateRailCard
-          update={update}
-          onOpen={onOpenWhatsNew}
-          onDismiss={onDismissUpdate}
-        />
-      ) : null}
-      <SidebarUpdate />
+      <UpdateRailCard
+        update={update}
+        onOpen={onOpenWhatsNew}
+        onDismiss={onDismissUpdate}
+      />
     </div>
-  );
-}
-
-export function SidebarUpdate() {
-  const [snapshot, setSnapshot] = useState<UpdaterSnapshot>({
-    phase: "idle",
-    currentVersion: "…",
-  });
-
-  useEffect(() => {
-    let cancelled = false;
-
-    (async () => {
-      const currentVersion = await readAppVersion();
-      if (cancelled) return;
-      setSnapshot({ phase: "checking", currentVersion });
-
-      try {
-        const update = await probeForUpdate();
-        if (cancelled) return;
-        if (update) {
-          setSnapshot({
-            phase: "available",
-            currentVersion,
-            availableVersion: update.version,
-          });
-          return;
-        }
-        setSnapshot({ phase: "current", currentVersion });
-      } catch {
-        if (cancelled) return;
-        setSnapshot({ phase: "idle", currentVersion });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const onClick = useCallback(async () => {
-    if (snapshot.phase === "downloading" || snapshot.phase === "checking") {
-      return;
-    }
-
-    if (snapshot.phase === "available") {
-      await installPendingUpdate(setSnapshot);
-      return;
-    }
-
-    await runUpdateFlow(true, setSnapshot);
-  }, [snapshot.phase]);
-
-  const busy =
-    snapshot.phase === "checking" || snapshot.phase === "downloading";
-  const hasUpdate = snapshot.phase === "available";
-  const label = hasUpdate
-    ? `Update to ${snapshot.availableVersion}`
-    : busy
-      ? snapshot.phase === "downloading"
-        ? `Downloading${snapshot.progress != null ? ` ${snapshot.progress}%` : "…"}`
-        : "Checking…"
-      : "Check for updates";
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={busy}
-      className={`flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left transition-colors ${
-        hasUpdate
-          ? "bg-accent/15 text-content hover:bg-accent/20"
-          : "bg-content/5 text-content/75 hover:bg-content/10 hover:text-content"
-      } disabled:cursor-default disabled:opacity-70`}
-    >
-      <span className="grid size-[18px] shrink-0 place-items-center">
-        {busy ? (
-          <Loader className="size-4 animate-spin opacity-70" aria-hidden />
-        ) : hasUpdate ? (
-          <ArrowDownCircle className="size-4 text-accent" aria-hidden />
-        ) : (
-          <RefreshCw
-            className="size-4 opacity-70"
-            strokeWidth={1.75}
-            aria-hidden
-          />
-        )}
-      </span>
-      <span className="min-w-0 flex-1 flex items-center">
-        <span className="block truncate text-[12px] font-medium leading-tight">
-          {label}
-        </span>
-        <span className="ml-auto block text-[11px] text-content/40">
-          v{snapshot.currentVersion}
-        </span>
-      </span>
-    </button>
   );
 }

--- a/src/chrome/UsageFooter.tsx
+++ b/src/chrome/UsageFooter.tsx
@@ -2,6 +2,7 @@ import { RefreshCw } from "./icons";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { HarnessIcon } from "./HarnessIcon";
 import { Popover } from "./Popover";
+import { VersionUpdate } from "./VersionUpdate";
 import {
   fetchClaudeRateLimits,
   fetchCodexRateLimits,
@@ -118,7 +119,6 @@ export function UsageFooter({
 
   const showUsage = wantClaude || wantCodex;
   const showTerminals = terminals.length > 0;
-  const showRight = showUsage || showTerminals;
   const ariaLabel = showUsage
     ? "Provider usage"
     : showTerminals
@@ -130,17 +130,17 @@ export function UsageFooter({
   return (
     <footer
       aria-label={ariaLabel}
-      className="flex h-7 shrink-0 items-center gap-3 overflow-x-auto border-t border-content/10 px-3 text-[11px] text-content/55"
+      className="flex h-7 shrink-0 items-center gap-3 overflow-hidden border-t border-content/10 px-3 text-[11px] text-content/55"
     >
-      {showUsage ? (
-        <>
-          {wantClaude ? <ProviderChip limits={claude} now={now} /> : null}
-          {wantCodex ? <ProviderChip limits={codex} now={now} /> : null}
-        </>
-      ) : session ? (
-        <SessionChip session={session} />
-      ) : null}
-      {showRight ? (
+      <div className="flex min-w-0 flex-1 items-center gap-3 overflow-x-auto">
+        {showUsage ? (
+          <>
+            {wantClaude ? <ProviderChip limits={claude} now={now} /> : null}
+            {wantCodex ? <ProviderChip limits={codex} now={now} /> : null}
+          </>
+        ) : session ? (
+          <SessionChip session={session} />
+        ) : null}
         <div className="ml-auto flex shrink-0 items-center gap-2">
           {showTerminals ? (
             <RunningTerminalChip
@@ -166,7 +166,8 @@ export function UsageFooter({
             </button>
           ) : null}
         </div>
-      ) : null}
+      </div>
+      <VersionUpdate />
     </footer>
   );
 }

--- a/src/chrome/VersionUpdate.test.ts
+++ b/src/chrome/VersionUpdate.test.ts
@@ -1,0 +1,129 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UpdaterSnapshot } from "../lib/updater";
+import { VersionUpdate, VersionUpdateButton } from "./VersionUpdate";
+import { SidebarUpdateFooter } from "./SidebarUpdate";
+
+const mocks = vi.hoisted(() => ({
+  snapshot: { phase: "current", currentVersion: "0.1.40" } as UpdaterSnapshot,
+  setSnapshot: vi.fn(),
+  inFlight: { current: false },
+  effects: [] as (() => (() => void) | void)[],
+  readAppVersion: vi.fn(),
+  probeForUpdate: vi.fn(),
+  runUpdateFlow: vi.fn(),
+}));
+
+vi.mock("react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react")>()),
+  useState: () => [mocks.snapshot, mocks.setSnapshot],
+  useRef: () => mocks.inFlight,
+  useCallback: (callback: unknown) => callback,
+  useEffect: (effect: () => (() => void) | void) => mocks.effects.push(effect),
+}));
+vi.mock("../lib/updater", () => ({
+  readAppVersion: mocks.readAppVersion,
+  probeForUpdate: mocks.probeForUpdate,
+  runUpdateFlow: mocks.runUpdateFlow,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.effects = [];
+  mocks.inFlight.current = false;
+  mocks.snapshot = { phase: "current", currentVersion: "0.1.40" };
+  mocks.readAppVersion.mockResolvedValue("0.1.40");
+  mocks.probeForUpdate.mockResolvedValue(null);
+  mocks.runUpdateFlow.mockResolvedValue(mocks.snapshot);
+});
+
+describe("version update control", () => {
+  it.each(["idle", "current", "available", "error"] as const)(
+    "shows the installed version as the clickable label (%s)",
+    (phase) => {
+      const markup = renderToStaticMarkup(
+        createElement(VersionUpdateButton, {
+          snapshot: {
+            phase,
+            currentVersion: "0.1.40",
+            availableVersion: "0.1.41",
+          },
+          onClick: vi.fn(),
+        }),
+      );
+      expect(markup).toContain(">v0.1.40</button>");
+      expect(markup).toContain("Check for updates");
+      expect(markup).not.toContain('disabled=""');
+    },
+  );
+
+  it.each(["checking", "downloading"] as const)(
+    "keeps the version visible and disables clicks while %s",
+    (phase) => {
+      const markup = renderToStaticMarkup(
+        createElement(VersionUpdateButton, {
+          snapshot: { phase, currentVersion: "0.1.40", progress: 25 },
+          onClick: vi.fn(),
+        }),
+      );
+      expect(markup).toContain(">v0.1.40</button>");
+      expect(markup).toContain('disabled=""');
+      expect(markup).toContain('aria-busy="true"');
+      mocks.snapshot.phase = phase;
+      VersionUpdate().props.onClick();
+      expect(mocks.runUpdateFlow).not.toHaveBeenCalled();
+    },
+  );
+
+  it("manually checks and prompts even when an update was previously detected", async () => {
+    mocks.snapshot.phase = "available";
+    await VersionUpdate().props.onClick();
+    expect(mocks.runUpdateFlow).toHaveBeenCalledExactlyOnceWith(
+      true,
+      mocks.setSnapshot,
+    );
+  });
+
+  it("prevents duplicate clicks before the updater reports progress", async () => {
+    let finish!: () => void;
+    mocks.runUpdateFlow.mockReturnValue(
+      new Promise<void>((resolve) => {
+        finish = resolve;
+      }),
+    );
+    const button = VersionUpdate();
+    const first = button.props.onClick();
+    await button.props.onClick();
+    expect(mocks.runUpdateFlow).toHaveBeenCalledOnce();
+    finish();
+    await first;
+    expect(mocks.inFlight.current).toBe(false);
+  });
+
+  it("reads the app version and preserves the automatic update probe", async () => {
+    VersionUpdate();
+    const cleanup = mocks.effects[0]();
+    await vi.waitFor(() => {
+      expect(mocks.setSnapshot).toHaveBeenLastCalledWith({
+        phase: "current",
+        currentVersion: "0.1.40",
+      });
+    });
+    expect(mocks.probeForUpdate).toHaveBeenCalledOnce();
+    cleanup?.();
+  });
+
+  it("removes the persistent sidebar control while keeping the release notice", () => {
+    expect(renderToStaticMarkup(createElement(SidebarUpdateFooter))).toBe("");
+    const markup = renderToStaticMarkup(
+      createElement(SidebarUpdateFooter, {
+        update: { version: "0.1.40" },
+        onOpenWhatsNew: vi.fn(),
+        onDismissUpdate: vi.fn(),
+      }),
+    );
+    expect(markup).toContain("Updated to 0.1.40");
+    expect(markup).not.toContain("Check for updates");
+  });
+});

--- a/src/chrome/VersionUpdate.tsx
+++ b/src/chrome/VersionUpdate.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  probeForUpdate,
+  readAppVersion,
+  runUpdateFlow,
+  type UpdaterSnapshot,
+} from "../lib/updater";
+
+export function VersionUpdate() {
+  const inFlight = useRef(false);
+  const [snapshot, setSnapshot] = useState<UpdaterSnapshot>({
+    phase: "checking",
+    currentVersion: "…",
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const currentVersion = await readAppVersion();
+      if (cancelled) return;
+      setSnapshot({ phase: "checking", currentVersion });
+
+      try {
+        const update = await probeForUpdate();
+        if (cancelled) return;
+        if (update) {
+          setSnapshot({
+            phase: "available",
+            currentVersion,
+            availableVersion: update.version,
+          });
+          return;
+        }
+        setSnapshot({ phase: "current", currentVersion });
+      } catch {
+        if (cancelled) return;
+        setSnapshot({ phase: "idle", currentVersion });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onClick = useCallback(async () => {
+    if (
+      inFlight.current ||
+      snapshot.phase === "downloading" ||
+      snapshot.phase === "checking"
+    ) {
+      return;
+    }
+
+    inFlight.current = true;
+    try {
+      await runUpdateFlow(true, setSnapshot);
+    } finally {
+      inFlight.current = false;
+    }
+  }, [snapshot.phase]);
+
+  return <VersionUpdateButton snapshot={snapshot} onClick={onClick} />;
+}
+
+export function VersionUpdateButton({
+  snapshot,
+  onClick,
+}: {
+  snapshot: UpdaterSnapshot;
+  onClick: () => void;
+}) {
+  const busy =
+    snapshot.phase === "checking" || snapshot.phase === "downloading";
+  const available = snapshot.phase === "available";
+  let action = "Check for updates";
+  if (snapshot.phase === "checking") action = "Checking for updates…";
+  if (snapshot.phase === "downloading") {
+    action =
+      snapshot.progress == null
+        ? "Downloading update…"
+        : `Downloading update: ${snapshot.progress}%`;
+  }
+  if (available)
+    action = `Update ${snapshot.availableVersion} available. Check for updates`;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy}
+      aria-busy={busy}
+      aria-label={`MonoCode ${snapshot.currentVersion}. ${action}`}
+      title={action}
+      className={`shrink-0 rounded px-1 py-0.5 font-mono text-[10px] tabular-nums hover:bg-content/10 hover:text-content focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-default disabled:opacity-50 ${available ? "text-accent" : "text-content/40"}`}
+    >
+      v{snapshot.currentVersion}
+    </button>
+  );
+}


### PR DESCRIPTION
## What changed

Replace the persistent sidebar **Check for updates** button with the installed version at the bottom right of the usage footer. Clicking the version runs the existing manual update check and confirmation flow. The version stays visible during checks and downloads, with progress in its tooltip and accessible label.

Keep the footer mounted across app surfaces and pin the version beside the scrollable usage controls. Preserve automatic update detection and the dismissible sidebar release notice.

## Why

Make the app version and update check available without reserving a permanent button in the sidebar.

## UI

Before: a persistent sidebar update button. After: a compact `v0.1.40` control at the footer's right edge, highlighted when an update is available. Verified the real footer component in a browser preview, including clicking through a mocked native update check. Native desktop/update-service integration remains unverified because desktop automation access was denied.

## Validation

Focused coverage verifies version labels, busy states, manual checks, duplicate-click prevention, automatic probing, and the retained release notice. The full frontend suite passes (1,407 tests), as do TypeScript and the production build. Rust formatting, Clippy, and 218 Rust tests pass on the identical native-code baseline. No dependencies added.

## Checklist

- [x] I ran `npm run check` (web and Rust halves separately; Vitest limited to two workers)
- [x] This PR is small and focused
- [x] I did not mix unrelated changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added version information and update controls to the usage footer.
  - Users can check for and start available application updates directly from the footer.
  - Update controls indicate checking, downloading, current, and error states.

- **Improvements**
  - The usage footer remains visible across search, inbox, notes, and settings views.
  - Removed the separate persistent sidebar update control; release notifications remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->