### PR TITLE
Hide the sidebar update control unless an update is available

### DIFF
--- a/src/chrome/ProjectRail.tsx
+++ b/src/chrome/ProjectRail.tsx
@@ -488,7 +488,7 @@ export function ProjectRail({
             onOpenWhatsNew={onOpenWhatsNew}
             onDismissUpdate={onDismissUpdate}
           />
-          <div className="flex shrink-0 flex-col gap-px p-2 pt-0">
+          <div className="flex shrink-0 flex-col gap-px p-2">
             <RailAction
               label="Settings"
               icon={Settings}

--- a/src/chrome/Sidebar.tsx
+++ b/src/chrome/Sidebar.tsx
@@ -1422,7 +1422,7 @@ function SidebarComponent({
               onOpenWhatsNew={onOpenWhatsNew}
               onDismissUpdate={onDismissUpdate}
             />
-            <div className="flex shrink-0 flex-col gap-px p-2 pt-0">
+            <div className="flex shrink-0 flex-col gap-px p-2">
               <RailAction
                 label="Settings"
                 icon={Settings}

--- a/src/chrome/SidebarUpdate.test.ts
+++ b/src/chrome/SidebarUpdate.test.ts
@@ -1,12 +1,16 @@
-import { createElement } from "react";
+import { createElement, type ReactElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
-import type { UpdaterPhase } from "../lib/updater";
+import type { UpdaterPhase, UpdaterSnapshot } from "../lib/updater";
 import {
   SidebarUpdate,
   SidebarUpdateFooter,
   isSidebarUpdateActionable,
 } from "./SidebarUpdate";
+
+const updaterMocks = vi.hoisted(() => ({
+  installPendingUpdate: vi.fn(),
+}));
 
 // The updater module reaches for Tauri plugins at import time; stub them so the
 // component under test can be imported in the plain node environment.
@@ -17,6 +21,34 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
 }));
 vi.mock("@tauri-apps/plugin-process", () => ({ relaunch: vi.fn() }));
 vi.mock("@tauri-apps/plugin-updater", () => ({ check: vi.fn() }));
+vi.mock("../lib/updater", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/updater")>();
+  return {
+    ...actual,
+    installPendingUpdate: (
+      ...args: Parameters<typeof actual.installPendingUpdate>
+    ) => updaterMocks.installPendingUpdate(...args),
+  };
+});
+
+function installButtonClick() {
+  let onClick: (() => void) | undefined;
+  function Capture() {
+    const tree = SidebarUpdate({
+      snapshot: {
+        phase: "available",
+        currentVersion: "0.1.37",
+        availableVersion: "0.1.38",
+      },
+      onSnapshot: vi.fn(),
+    }) as ReactElement<{ onClick: () => void }>;
+    onClick = tree.props.onClick;
+    return tree;
+  }
+  renderToStaticMarkup(createElement(Capture));
+  if (!onClick) throw new Error("expected the install button handler");
+  return onClick;
+}
 
 describe("isSidebarUpdateActionable", () => {
   it("only claims sidebar space for an update the user can act on", () => {
@@ -68,6 +100,34 @@ describe("SidebarUpdate", () => {
 
     expect(markup).toContain("Downloading 42%");
     expect(markup).toContain('disabled=""');
+  });
+
+  it("ignores a second click while readAppVersion is still pending", async () => {
+    // installPendingUpdate awaits readAppVersion before it reports "downloading",
+    // so a second click can still land while `busy` is false. The hanging mock
+    // is that window.
+    let releaseVersionRead!: (snapshot: UpdaterSnapshot) => void;
+    updaterMocks.installPendingUpdate.mockReset();
+    updaterMocks.installPendingUpdate.mockImplementation(
+      () =>
+        new Promise<UpdaterSnapshot>((resolve) => {
+          releaseVersionRead = resolve;
+        }),
+    );
+
+    const onClick = installButtonClick();
+    const first = Promise.resolve(onClick());
+    const second = Promise.resolve(onClick());
+
+    expect(updaterMocks.installPendingUpdate).toHaveBeenCalledOnce();
+
+    releaseVersionRead({
+      phase: "downloading",
+      currentVersion: "0.1.37",
+      availableVersion: "0.1.38",
+    });
+    await Promise.all([first, second]);
+    expect(updaterMocks.installPendingUpdate).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/chrome/SidebarUpdate.test.ts
+++ b/src/chrome/SidebarUpdate.test.ts
@@ -1,0 +1,98 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { UpdaterPhase } from "../lib/updater";
+import {
+  SidebarUpdate,
+  SidebarUpdateFooter,
+  isSidebarUpdateActionable,
+} from "./SidebarUpdate";
+
+// The updater module reaches for Tauri plugins at import time; stub them so the
+// component under test can be imported in the plain node environment.
+vi.mock("@tauri-apps/api/app", () => ({ getVersion: vi.fn() }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  ask: vi.fn(),
+  message: vi.fn(),
+}));
+vi.mock("@tauri-apps/plugin-process", () => ({ relaunch: vi.fn() }));
+vi.mock("@tauri-apps/plugin-updater", () => ({ check: vi.fn() }));
+
+describe("isSidebarUpdateActionable", () => {
+  it("only claims sidebar space for an update the user can act on", () => {
+    const phases: UpdaterPhase[] = [
+      "idle",
+      "checking",
+      "current",
+      "available",
+      "downloading",
+      "error",
+    ];
+    const actionable = phases.filter((phase) =>
+      isSidebarUpdateActionable({ phase, currentVersion: "0.1.37" }),
+    );
+    expect(actionable).toEqual(["available", "downloading"]);
+  });
+});
+
+describe("SidebarUpdate", () => {
+  it("offers the install action for an available version", () => {
+    const markup = renderToStaticMarkup(
+      createElement(SidebarUpdate, {
+        snapshot: {
+          phase: "available",
+          currentVersion: "0.1.37",
+          availableVersion: "0.1.38",
+        },
+        onSnapshot: vi.fn(),
+      }),
+    );
+
+    expect(markup).toContain("Update to 0.1.38");
+    expect(markup).toContain("v0.1.37");
+    expect(markup).not.toContain('disabled=""');
+  });
+
+  it("reports download progress and blocks a second click", () => {
+    const markup = renderToStaticMarkup(
+      createElement(SidebarUpdate, {
+        snapshot: {
+          phase: "downloading",
+          currentVersion: "0.1.37",
+          availableVersion: "0.1.38",
+          progress: 42,
+        },
+        onSnapshot: vi.fn(),
+      }),
+    );
+
+    expect(markup).toContain("Downloading 42%");
+    expect(markup).toContain('disabled=""');
+  });
+});
+
+describe("SidebarUpdateFooter", () => {
+  // renderToStaticMarkup never runs effects, so the automatic probe stays in its
+  // initial `idle` phase here — exactly the state that used to render a
+  // permanent "Check for updates" row.
+  it("stays silent while the automatic probe has nothing to offer", () => {
+    expect(renderToStaticMarkup(createElement(SidebarUpdateFooter, {}))).toBe(
+      "",
+    );
+  });
+
+  it("still shows the post-install card without an update row", () => {
+    const markup = renderToStaticMarkup(
+      createElement(SidebarUpdateFooter, {
+        update: { version: "0.1.37" },
+        onOpenWhatsNew: vi.fn(),
+        onDismissUpdate: vi.fn(),
+      }),
+    );
+
+    expect(markup).toContain("Updated to 0.1.37");
+    expect(markup).toContain("What&#x27;s new");
+    expect(markup).not.toContain("Check for updates");
+    expect(markup).not.toContain("Update to");
+  });
+});

--- a/src/chrome/SidebarUpdate.tsx
+++ b/src/chrome/SidebarUpdate.tsx
@@ -1,14 +1,21 @@
-import { ArrowDownCircle, Loader, RefreshCw } from "./icons";
+import { ArrowDownCircle, Loader } from "./icons";
 import { useCallback, useEffect, useState } from "react";
 import {
   installPendingUpdate,
   probeForUpdate,
   readAppVersion,
-  runUpdateFlow,
   type UpdaterSnapshot,
 } from "../lib/updater";
 import type { InstalledUpdate } from "../lib/updateNotice";
 import { UpdateRailCard } from "./UpdateRailCard";
+
+// The sidebar row only earns its space when there is something to act on: an
+// update waiting to be installed, or one already downloading. Every other phase
+// — including a probe that failed — stays silent, because manual "Check for
+// updates" already lives in Settings and the app menu.
+export function isSidebarUpdateActionable(snapshot: UpdaterSnapshot): boolean {
+  return snapshot.phase === "available" || snapshot.phase === "downloading";
+}
 
 export function SidebarUpdateFooter({
   update,
@@ -19,26 +26,15 @@ export function SidebarUpdateFooter({
   onOpenWhatsNew?: (version: string) => void;
   onDismissUpdate?: () => void;
 }) {
-  return (
-    <div className="flex flex-col gap-1.5 p-2 pb-1">
-      {update && onOpenWhatsNew && onDismissUpdate ? (
-        <UpdateRailCard
-          update={update}
-          onOpen={onOpenWhatsNew}
-          onDismiss={onDismissUpdate}
-        />
-      ) : null}
-      <SidebarUpdate />
-    </div>
-  );
-}
-
-export function SidebarUpdate() {
   const [snapshot, setSnapshot] = useState<UpdaterSnapshot>({
     phase: "idle",
     currentVersion: "…",
   });
 
+  // The automatic probe runs on mount whether or not it ends up rendering
+  // anything, so a newly published version still surfaces on its own. The
+  // snapshot lives here rather than in SidebarUpdate so the footer can drop its
+  // padding entirely when neither child has anything to show.
   useEffect(() => {
     let cancelled = false;
 
@@ -70,29 +66,48 @@ export function SidebarUpdate() {
     };
   }, []);
 
+  const card =
+    update && onOpenWhatsNew && onDismissUpdate ? (
+      <UpdateRailCard
+        update={update}
+        onOpen={onOpenWhatsNew}
+        onDismiss={onDismissUpdate}
+      />
+    ) : null;
+  const actionable = isSidebarUpdateActionable(snapshot);
+
+  if (!card && !actionable) return null;
+
+  // The gap down to the Settings block belongs to that block's own padding, so
+  // the footer can disappear without leaving the sidebar's bottom row flush
+  // against the scrolling list above it.
+  return (
+    <div className="flex flex-col gap-1.5 p-2 pb-0">
+      {card}
+      {actionable ? (
+        <SidebarUpdate snapshot={snapshot} onSnapshot={setSnapshot} />
+      ) : null}
+    </div>
+  );
+}
+
+export function SidebarUpdate({
+  snapshot,
+  onSnapshot,
+}: {
+  snapshot: UpdaterSnapshot;
+  onSnapshot: (next: UpdaterSnapshot) => void;
+}) {
+  const busy = snapshot.phase === "downloading";
+
   const onClick = useCallback(async () => {
-    if (snapshot.phase === "downloading" || snapshot.phase === "checking") {
-      return;
-    }
+    if (busy) return;
+    await installPendingUpdate(onSnapshot);
+  }, [busy, onSnapshot]);
 
-    if (snapshot.phase === "available") {
-      await installPendingUpdate(setSnapshot);
-      return;
-    }
-
-    await runUpdateFlow(true, setSnapshot);
-  }, [snapshot.phase]);
-
-  const busy =
-    snapshot.phase === "checking" || snapshot.phase === "downloading";
-  const hasUpdate = snapshot.phase === "available";
-  const label = hasUpdate
-    ? `Update to ${snapshot.availableVersion}`
-    : busy
-      ? snapshot.phase === "downloading"
-        ? `Downloading${snapshot.progress != null ? ` ${snapshot.progress}%` : "…"}`
-        : "Checking…"
-      : "Check for updates";
+  const label = busy
+    ? `Downloading${snapshot.progress != null ? ` ${snapshot.progress}%` : "…"}`
+    : `Update to ${snapshot.availableVersion}`;
 
   return (
     <button
@@ -100,22 +115,16 @@ export function SidebarUpdate() {
       onClick={onClick}
       disabled={busy}
       className={`flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left transition-colors ${
-        hasUpdate
-          ? "bg-accent/15 text-content hover:bg-accent/20"
-          : "bg-content/5 text-content/75 hover:bg-content/10 hover:text-content"
+        busy
+          ? "bg-content/5 text-content/75 hover:bg-content/10 hover:text-content"
+          : "bg-accent/15 text-content hover:bg-accent/20"
       } disabled:cursor-default disabled:opacity-70`}
     >
       <span className="grid size-[18px] shrink-0 place-items-center">
         {busy ? (
           <Loader className="size-4 animate-spin opacity-70" aria-hidden />
-        ) : hasUpdate ? (
-          <ArrowDownCircle className="size-4 text-accent" aria-hidden />
         ) : (
-          <RefreshCw
-            className="size-4 opacity-70"
-            strokeWidth={1.75}
-            aria-hidden
-          />
+          <ArrowDownCircle className="size-4 text-accent" aria-hidden />
         )}
       </span>
       <span className="min-w-0 flex-1 flex items-center">

--- a/src/chrome/SidebarUpdate.tsx
+++ b/src/chrome/SidebarUpdate.tsx
@@ -1,5 +1,5 @@
 import { ArrowDownCircle, Loader } from "./icons";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   installPendingUpdate,
   probeForUpdate,
@@ -99,10 +99,18 @@ export function SidebarUpdate({
   onSnapshot: (next: UpdaterSnapshot) => void;
 }) {
   const busy = snapshot.phase === "downloading";
+  // `busy` only flips after installPendingUpdate awaits readAppVersion, so a
+  // second click can still land. The ref closes that window immediately.
+  const installing = useRef(false);
 
   const onClick = useCallback(async () => {
-    if (busy) return;
-    await installPendingUpdate(onSnapshot);
+    if (busy || installing.current) return;
+    installing.current = true;
+    try {
+      await installPendingUpdate(onSnapshot);
+    } finally {
+      installing.current = false;
+    }
   }, [busy, onSnapshot]);
 
   const label = busy


### PR DESCRIPTION
## Summary
- The sidebar update probe now lives in `SidebarUpdateFooter`, which only renders when `isSidebarUpdateActionable` is `available` or `downloading`. Idle, checking, and failed probes stay silent, so the wrapper padding disappears too.
- `SidebarUpdate` is presentational: the dead “Check for updates” / “Checking…” labels and the `RefreshCw` action are gone. Settings and app-menu manual checks keep their own snapshots.
- Footer/Settings spacing swapped (`footer` is `p-2 pb-0`, Settings is `p-2`) so Settings does not sit flush against the session list when the update control is hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sidebar updates display available and downloading states, including installation progress.
  - Post-install update information remains available without showing an unnecessary update row.

- **Bug Fixes**
  - Prevented multiple installation attempts when the install action is clicked repeatedly.
  - Standardized spacing around the Settings action in the sidebar.

- **Changes**
  - Removed the manual “Check for updates” action from the sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->