### PR TITLE
Make toggle sidebar hide the full sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,8 +21,10 @@ import { UsageFooter } from "./chrome/UsageFooter";
 import { useProjectBranches } from "./hooks/useProjectBranches";
 import {
   loadProjectRailOpen,
+  loadSidebarOpen,
   loadSidebarTabOrder,
   saveProjectRailOpen,
+  saveSidebarOpen,
   type SidebarTabId,
 } from "./lib/appearance";
 import { HAS_NATIVE_GLASS, IS_MAC } from "./lib/platform";
@@ -601,6 +603,7 @@ export default function App({
     [],
   );
   const [projectRailOpen, setProjectRailOpen] = useState(loadProjectRailOpen);
+  const [sidebarOpen, setSidebarOpen] = useState(loadSidebarOpen);
   const tabCloseScope = "project" as const;
   const currentProjectDock = findProjectTerminal(projectTerminals, projectCwd);
   const dockVisible = !!currentProjectDock?.open;
@@ -4559,11 +4562,11 @@ export default function App({
   );
 
   const onToggleSidebar = useCallback(() => {
-    setProjectRailOpen((open) => {
-      const next = !open;
-      saveProjectRailOpen(next);
-      return next;
-    });
+    setSidebarOpen((open) => {
+      const next = !open
+      saveSidebarOpen(next)
+      return next
+    })
   }, []);
 
   const onToggleProjectRail = useCallback(() => {
@@ -5145,7 +5148,7 @@ export default function App({
       <Sidebar
         cwd={sidebarCwd}
         gitCwd={gitCwd}
-        open
+        open={sidebarOpen}
         tab={sidebarTab}
         onTabChange={setSidebarTab}
         filesSearchOpen={filesSearchOpen}

--- a/src/chrome/Sidebar.tsx
+++ b/src/chrome/Sidebar.tsx
@@ -487,7 +487,7 @@ function SidebarComponent({
   const showProjectRail = Boolean(onSelectProject && onOpenProject);
   // Settings live in the rail slot, so they keep it visible even when the
   // project rail itself is collapsed.
-  const railVisible = showProjectRail && (projectRailOpen || settingsOpen);
+  const railVisible = showProjectRail && ((open && projectRailOpen) || settingsOpen);
   const inProject = looksLikeProject(cwd);
   const showSidebarFooter = !projectRailOpen;
   // A blank session has no project to browse, so the shell stands alone until

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -7,6 +7,7 @@ const THEME_SATURATION_KEY = "monocode.themeSaturation";
 const OPACITY_KEY = "monocode.sidebarOpacity";
 const BLUR_KEY = "monocode.sidebarBlur";
 const PROJECT_RAIL_OPEN_KEY = "monocode.projectRailOpen";
+const SIDEBAR_OPEN_KEY = "monocode.sidebarOpen";
 const BODY_KEY = "monocode.bodyGlass";
 const SCHEME_KEY = "monocode.colorScheme";
 const SIDEBAR_TAB_ORDER_KEY = "monocode.sidebarTabOrder";
@@ -427,6 +428,14 @@ function isSidebarTabId(value: unknown): value is SidebarTabId {
     value === "changes" ||
     value === "inbox"
   );
+}
+
+export function loadSidebarOpen(): boolean {
+  return readFlag(SIDEBAR_OPEN_KEY) ?? true
+}
+
+export function saveSidebarOpen(value: boolean) {
+  writeFlag(SIDEBAR_OPEN_KEY, value)
 }
 
 export function loadProjectRailOpen(): boolean {


### PR DESCRIPTION
Cmd/Ctrl+B and View > Toggle Sidebar previously only collapsed the project rail (duplicating the rail's own toggle). This wires the command to hide the entire sidebar instead.

- New persisted `monocode.sidebarOpen` flag in `appearance.ts` with load/save helpers
- `App.tsx` tracks `sidebarOpen` state and passes it to `Sidebar` via the previously hardcoded `open` prop
- Project rail visibility now also respects `open`, with settings still forcing the rail slot visible since they render there

Rail collapse via its own button is unchanged. Menu item, accelerator, and keybindings entry already existed, so no changes there.

Verified with `vitest` (1397 passing) and `tsc --noEmit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar open/closed state is now saved and restored between sessions.
  * The project rail and settings rail are hidden when the sidebar is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->