### PR TITLE
Fix session rename freezing while the agent is working

### DIFF
--- a/src/chrome/Sidebar.tsx
+++ b/src/chrome/Sidebar.tsx
@@ -903,7 +903,6 @@ function SidebarComponent({
       <SessionRenameRow
         session={session}
         isActive={session.id === activeSessionId}
-        busy={busySessionIds.has(session.id)}
         needsApproval={approvalSessionIds.has(session.id)}
         onCommit={(title) => {
           onRenameSession(session.id, title);
@@ -2494,14 +2493,12 @@ function SessionCard({
 function SessionRenameRow({
   session,
   isActive,
-  busy,
   needsApproval,
   onCommit,
   onCancel,
 }: {
   session: SessionSummary;
   isActive: boolean;
-  busy: boolean;
   needsApproval: boolean;
   onCommit: (title: string) => void;
   onCancel: () => void;
@@ -2560,7 +2557,6 @@ function SessionRenameRow({
       <input
         ref={inputRef}
         value={value}
-        disabled={busy}
         onChange={(e) => setValue(e.target.value)}
         onBlur={() => finish(true)}
         onKeyDown={onKeyDown}

--- a/src/chrome/SidebarRename.test.ts
+++ b/src/chrome/SidebarRename.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment happy-dom
+import { act, createElement, type ComponentProps } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatSessionTitle } from "../lib/session";
+import { Sidebar } from "./Sidebar";
+
+// Keep native services out of these menu/input interaction tests.
+vi.mock("../hooks/useInboxUnseen", () => ({ useInboxUnseen: () => false }));
+vi.mock("../hooks/useProjectDiffStats", () => ({
+  useProjectDiffStats: () => null,
+}));
+vi.mock("../hooks/useGitFileStatuses", () => ({
+  useGitFileStatuses: () => ({ files: new Map(), dirs: new Map() }),
+}));
+vi.mock("./SidebarUpdate", () => ({ SidebarUpdateFooter: () => null }));
+vi.mock("./FileTree", () => ({ FileTree: () => null }));
+
+let container: HTMLDivElement;
+let root: Root;
+let props: ComponentProps<typeof Sidebar>;
+
+function render() {
+  root.render(createElement(Sidebar, props));
+}
+
+function card(): HTMLElement {
+  return container.querySelector('[data-session-card="session-1"]')!;
+}
+
+function renameInput(): HTMLInputElement {
+  return container.querySelector("input:not([placeholder])")!;
+}
+
+function pressKey(target: HTMLElement, key: string) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  act(() => target.dispatchEvent(event));
+  return event;
+}
+
+function typeTitle(input: HTMLInputElement, title: string) {
+  // Use the native setter so React sees a user change, not its own value write.
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )!.set!;
+  act(() => {
+    setter.call(input, title);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function startRename() {
+  act(() => {
+    card().dispatchEvent(
+      new MouseEvent("contextmenu", { bubbles: true, cancelable: true }),
+    );
+  });
+  const rename = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
+  ).find((item) => item.textContent?.startsWith("Rename"))!;
+  expect(rename.disabled).toBe(false);
+  act(() => rename.click());
+  return renameInput();
+}
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  const stored = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => stored.get(key) ?? null,
+    setItem: (key: string, value: string) => stored.set(key, value),
+    removeItem: (key: string) => stored.delete(key),
+    clear: () => stored.clear(),
+  });
+  props = {
+    cwd: "/workspace/project",
+    open: true,
+    sessions: [
+      {
+        id: "session-1",
+        cwd: "/workspace/project",
+        harness: "codex",
+        model: "",
+        runtimeMode: "supervised",
+        title: formatSessionTitle("codex", "Original conversation"),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ],
+    busySessionIds: new Set(["session-1"]),
+    approvalSessionIds: new Set(),
+    activeSessionId: "session-1",
+    status: "idle",
+    pending: false,
+    tab: "sessions",
+    filesSearchOpen: false,
+    onSelectSession: vi.fn(),
+    onRenameSession: vi.fn((id: string, title: string) => {
+      props = {
+        ...props,
+        sessions: props.sessions.map((session) =>
+          session.id === id
+            ? { ...session, title: formatSessionTitle(session.harness, title) }
+            : session,
+        ),
+      };
+      render();
+    }),
+    onOpenFile: vi.fn(),
+    onTabChange: vi.fn(),
+    onFilesSearchOpenChange: vi.fn(),
+  };
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe("sidebar session rename", () => {
+  it.each(["idle", "working", "needs approval"])(
+    "renames from the menu and restores navigation (status=%s)",
+    (status) => {
+      if (status === "idle") props.busySessionIds = new Set();
+      if (status === "needs approval") {
+        props.approvalSessionIds = new Set(["session-1"]);
+      }
+      act(() => render());
+      const input = startRename();
+
+      expect(input.disabled).toBe(false);
+      expect(document.activeElement === input).toBe(true);
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe(input.value.length);
+      typeTitle(input, "  Renamed conversation  ");
+      expect(pressKey(input, "Enter").defaultPrevented).toBe(true);
+
+      expect(props.onRenameSession).toHaveBeenCalledExactlyOnceWith(
+        "session-1",
+        "Renamed conversation",
+      );
+      expect(renameInput()).toBeNull();
+      expect(card().textContent).toContain("Renamed conversation");
+      act(() => card().click());
+      expect(props.onSelectSession).toHaveBeenCalledWith("session-1");
+    },
+  );
+
+  it("allows F2 to rename a working conversation", () => {
+    act(() => render());
+    pressKey(card(), "F2");
+    const input = renameInput();
+    expect(input.disabled).toBe(false);
+    expect(document.activeElement === input).toBe(true);
+    typeTitle(input, "Keyboard rename");
+    pressKey(input, "Enter");
+    expect(props.onRenameSession).toHaveBeenCalledExactlyOnceWith(
+      "session-1",
+      "Keyboard rename",
+    );
+  });
+
+  it("cancels with Escape while the agent is working", () => {
+    act(() => render());
+    const input = startRename();
+    expect(document.activeElement === input).toBe(true);
+    typeTitle(input, "Discard this name");
+    expect(pressKey(input, "Escape").defaultPrevented).toBe(true);
+    expect(props.onRenameSession).not.toHaveBeenCalled();
+    expect(renameInput()).toBeNull();
+    expect(card().textContent).toContain("Original conversation");
+  });
+
+  it("commits once on blur while the agent is working", () => {
+    act(() => render());
+    const input = startRename();
+    expect(document.activeElement === input).toBe(true);
+    typeTitle(input, "  Saved on blur  ");
+    act(() => input.blur());
+    expect(props.onRenameSession).toHaveBeenCalledExactlyOnceWith(
+      "session-1",
+      "Saved on blur",
+    );
+    expect(renameInput()).toBeNull();
+  });
+
+  it("cancels an empty name without trapping the conversation in the editor", () => {
+    act(() => render());
+    const input = startRename();
+    expect(document.activeElement === input).toBe(true);
+    typeTitle(input, "   ");
+    pressKey(input, "Enter");
+    expect(props.onRenameSession).not.toHaveBeenCalled();
+    expect(renameInput()).toBeNull();
+    expect(card().textContent).toContain("Original conversation");
+  });
+
+  it("keeps an in-progress rename editable when a turn starts", () => {
+    props.busySessionIds = new Set();
+    act(() => render());
+    const input = startRename();
+    typeTitle(input, "My draft title");
+
+    props = { ...props, busySessionIds: new Set(["session-1"]) };
+    act(() => render());
+    expect(renameInput()).toBe(input);
+    expect(input.disabled).toBe(false);
+    expect(document.activeElement === input).toBe(true);
+    expect(input.value).toBe("My draft title");
+    pressKey(input, "Enter");
+    expect(props.onRenameSession).toHaveBeenCalledExactlyOnceWith(
+      "session-1",
+      "My draft title",
+    );
+  });
+});


### PR DESCRIPTION
## What changed

Keep the sidebar's inline session rename input editable while the agent is working. Remove the unused `busy` prop from `SessionRenameRow` and add eight DOM interaction regression tests.

Fixes #142.

## Why

The context menu and F2 could start Rename for a working session, but the editor immediately rendered `disabled={busy}`. It could not receive focus, typing, Enter, Escape, or the normal blur-to-save interaction. The disabled editor also replaced the clickable session card, blocking navigation through that row during a long-running turn. Starting a turn during an existing rename disabled it as well.

Title changes already have an independent update/persistence path. Removing the input's busy restriction lets the existing save/cancel handlers finish and restore the card.

## Validation

- On upstream `20b78f5`: the new idle test passes; seven working-session/focus/lifecycle tests fail.
- After the fix: all eight pass. Coverage includes context menu and F2 entry, focus/selection, Enter, Escape, blur, blank names, needs-approval state, navigation after saving, and a turn starting during editing.
- `npm run check`: 141 test files / 1433 frontend tests, TypeScript, Rust formatting, Clippy with warnings denied, and 221 Rust tests pass.
- `npm run build` passes, with Vite's mixed-import and large-chunk warnings.

UI interaction tests mount the actual Sidebar/menu and stub unrelated native services. The installed desktop application has not been replaced or verified end to end with this patch.

## UI

The existing inline editor, menu, classes, spacing, colors, and keyboard/mouse behavior are retained. The production change removes four lines; there is no layout or component redesign.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session names can now be edited while a session is busy or a turn is in progress.
  - Renaming remains available across different session states, including working and approval-required states.

- **Tests**
  - Added coverage for context-menu and keyboard-based renaming, cancellation, commit-on-blur, empty names, and editing during an active turn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->