### PR TITLE
Keep track of last opened session when moving between projects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -220,6 +220,7 @@ import {
   filterTabsForProject,
   planWorkspaceTabClose,
   workspaceTabCwd,
+  focusedWorkspaceTabCwd,
 } from "./lib/workspaceTabGroups";
 import { runSessionRemoval } from "./lib/sessionRemoval";
 import {
@@ -1401,15 +1402,10 @@ export default function App({
     }
 
     if (tab) {
-      const focusedSession = nextFocusedId
-        ? sessionsRef.current.find((session) => session.id === nextFocusedId)
-        : undefined;
       const focusedTab = nextFocusedId
         ? { ...tab, focusedId: nextFocusedId }
         : tab;
-      const cwd =
-        focusedSession?.cwd ??
-        (focusedTab ? workspaceTabCwd(focusedTab, sessionsRef.current) : null);
+      const cwd = focusedWorkspaceTabCwd(focusedTab, sessionsRef.current);
       if (cwd && looksLikeProject(cwd)) {
         const normalized = normalizeProjectPath(cwd);
         if (!sameProjectPath(normalized, projectCwdRef.current)) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1379,9 +1379,27 @@ export default function App({
     );
   }, [sessions, tabs, persistSession, liveAgentsEnabled]);
 
-  const activateTab = useCallback((id: string) => {
-    setActiveTabId(id);
+  const activateTab = useCallback((id: string, paneId?: string) => {
     const tab = tabsRef.current.find((entry) => entry.id === id);
+    const nextFocusedId =
+      tab && paneId &&
+      (leafIds(tab.layout).includes(paneId) ||
+        tab.editorPanes.some((entry) => entry.id === paneId) ||
+        (tab.terminalPanes ?? []).some((entry) => entry.id === paneId))
+        ? paneId
+        : tab?.focusedId;
+
+    setActiveTabId(id);
+    if (tab && nextFocusedId && nextFocusedId !== tab.focusedId) {
+      setTabs((prev) =>
+        prev.map((entry) =>
+          entry.id === id
+            ? { ...entry, focusedId: nextFocusedId, diffFocused: false }
+            : entry,
+        ),
+      );
+    }
+
     if (tab) {
       const cwd = workspaceTabCwd(tab, sessionsRef.current);
       if (cwd && looksLikeProject(cwd)) {
@@ -1393,8 +1411,8 @@ export default function App({
       }
     }
     setComposerFocused(
-      !!tab &&
-        sessionsRef.current.some((session) => session.id === tab.focusedId),
+      !!nextFocusedId &&
+        sessionsRef.current.some((session) => session.id === nextFocusedId),
     );
   }, []);
 
@@ -3248,7 +3266,7 @@ export default function App({
         case "activate":
           setProjectCwd(normalized);
           setRecents(rememberProject(normalized));
-          activateTab(decision.tabId);
+          activateTab(decision.tabId, decision.paneId);
           return;
         case "create":
           break;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1401,7 +1401,15 @@ export default function App({
     }
 
     if (tab) {
-      const cwd = workspaceTabCwd(tab, sessionsRef.current);
+      const focusedSession = nextFocusedId
+        ? sessionsRef.current.find((session) => session.id === nextFocusedId)
+        : undefined;
+      const focusedTab = nextFocusedId
+        ? { ...tab, focusedId: nextFocusedId }
+        : tab;
+      const cwd =
+        focusedSession?.cwd ??
+        (focusedTab ? workspaceTabCwd(focusedTab, sessionsRef.current) : null);
       if (cwd && looksLikeProject(cwd)) {
         const normalized = normalizeProjectPath(cwd);
         if (!sameProjectPath(normalized, projectCwdRef.current)) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -218,7 +218,6 @@ import {
 import {
   applyPlaceSessionOnPane,
   filterTabsForProject,
-  findTabForProject,
   planWorkspaceTabClose,
   workspaceTabCwd,
 } from "./lib/workspaceTabGroups";
@@ -363,6 +362,12 @@ import {
   inFlightSnapshotKey,
   shouldWriteInFlightSnapshot,
 } from "./lib/inFlight";
+import {
+  isBlankSession,
+  planProjectReturn,
+  reconcileProjectReturn,
+  type ProjectReturnMemory,
+} from "./lib/projectReturn";
 import {
   collectWorkspaceSnapshot,
   workspaceSnapshotKey,
@@ -704,6 +709,22 @@ export default function App({
     if (!notesEnabled) setNotesViewOpen(false);
   }, [notesEnabled]);
 
+  const projectReturnRef = useRef<ProjectReturnMemory>(
+    resumed?.projectReturnMemory ?? new Map(),
+  );
+  const readProjectReturnMemory = useCallback(() => {
+    projectReturnRef.current = reconcileProjectReturn({
+      memory: projectReturnRef.current,
+      tabs: tabsRef.current,
+      sessions: sessionsRef.current,
+      activeTabId: activeTabIdRef.current,
+    });
+    return projectReturnRef.current;
+  }, []);
+  useEffect(() => {
+    readProjectReturnMemory();
+  }, [activeTabId, tabs, sessions, readProjectReturnMemory]);
+
   const tabVisitRef = useRef(emptyTabVisitHistory(activeTabId));
   const tabVisitFromHistoryRef = useRef(false);
   const [tabVisitNav, setTabVisitNav] = useState({
@@ -831,6 +852,7 @@ export default function App({
         tabsRef.current,
         activeTabIdRef.current,
         projectCwdRef.current,
+        readProjectReturnMemory(),
         "unload",
         projectTerminalsRef.current,
       ).finally(() => {
@@ -850,7 +872,7 @@ export default function App({
       cancelScheduledFlush(harnessFlush.current);
       harnessFlush.current = null;
     };
-  }, [resumed]);
+  }, [resumed, readProjectReturnMemory]);
 
   useEffect(() => {
     void probeHarnessAvailability();
@@ -1076,6 +1098,7 @@ export default function App({
       () => activeTabIdRef.current,
       () => projectCwdRef.current,
       () => projectTerminalsRef.current,
+      readProjectReturnMemory,
       flushHarnessEvents,
     );
     void getCurrentWindow()
@@ -1098,6 +1121,7 @@ export default function App({
           tabsRef.current,
           activeTabIdRef.current,
           projectCwdRef.current,
+          readProjectReturnMemory(),
           "unload",
           projectTerminalsRef.current,
         ).finally(() => {
@@ -1111,7 +1135,7 @@ export default function App({
       releaseQuit();
       unlistenClose?.();
     };
-  }, [flushHarnessEvents]);
+  }, [flushHarnessEvents, readProjectReturnMemory]);
 
   const refreshHistory = useCallback(async (cwd: string) => {
     if (!cwd || cwd === "~") return;
@@ -1269,6 +1293,12 @@ export default function App({
       sessions,
       activeTabId,
       projectCwd,
+      reconcileProjectReturn({
+        memory: projectReturnRef.current,
+        tabs,
+        sessions,
+        activeTabId,
+      }),
       projectTerminals,
     );
     const key = workspaceSnapshotKey(snapshot);
@@ -3202,26 +3232,30 @@ export default function App({
             (session) => session.id === activeWorkspace.focusedId,
           )
         : undefined;
-      const currentCwd =
-        current?.cwd ??
-        (activeWorkspace ? focusedFileTab(activeWorkspace)?.cwd : undefined);
-      if (currentCwd && sameProjectPath(currentCwd, normalized)) return;
-
-      if (current && isBlankSession(current)) {
-        onCwdChange(current.id, normalized);
-        return;
-      }
-
-      const match = findTabForProject(
-        tabsRef.current,
-        sessionsRef.current,
-        normalized,
-      );
-      if (match) {
-        setProjectCwd(normalized);
-        setRecents(rememberProject(normalized));
-        activateTab(match.id);
-        return;
+      const decision = planProjectReturn({
+        memory: readProjectReturnMemory(),
+        tabs: tabsRef.current,
+        sessions: sessionsRef.current,
+        activeTabId: activeTabIdRef.current,
+        projectPath: normalized,
+      });
+      switch (decision.action) {
+        case "keep":
+          return;
+        case "reuse-blank":
+          onCwdChange(decision.sessionId, normalized);
+          return;
+        case "activate":
+          setProjectCwd(normalized);
+          setRecents(rememberProject(normalized));
+          activateTab(decision.tabId);
+          return;
+        case "create":
+          break;
+        default: {
+          const exhaustive: never = decision;
+          return exhaustive;
+        }
       }
 
       const seed = current ?? sessionsRef.current[0];
@@ -3240,7 +3274,7 @@ export default function App({
       setActiveTabId(tab.id);
       setComposerFocused(true);
     },
-    [activateTab, appendTab, onCwdChange],
+    [activateTab, appendTab, onCwdChange, readProjectReturnMemory],
   );
 
   const pickProject = useCallback(async () => {
@@ -5689,11 +5723,6 @@ function lastUserBlockId(session: Session): string | undefined {
     if (session.blocks[i]?.role === "user") return session.blocks[i]?.id;
   }
   return undefined;
-}
-
-function isBlankSession(session: Session | undefined): boolean {
-  if (!session || session.busy) return false;
-  return !session.blocks.some((block) => block.role === "user");
 }
 
 function selectedChangePath(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3263,6 +3263,8 @@ export default function App({
       });
       switch (decision.action) {
         case "keep":
+          setProjectCwd(normalized);
+          setRecents(rememberProject(normalized));
           return;
         case "reuse-blank":
           onCwdChange(decision.sessionId, normalized);

--- a/src/lib/appLifecycle.test.ts
+++ b/src/lib/appLifecycle.test.ts
@@ -56,8 +56,8 @@ describe("project choices through lifecycle saves", () => {
       id: `tab-${session.id}`,
     }));
     const memory = new Map([
-      ["/alpha", "tab-a2"],
-      ["/beta", "tab-b2"],
+      ["/alpha", "a2"],
+      ["/beta", "b2"],
     ]);
     return {
       sessions,
@@ -139,8 +139,8 @@ describe("project choices through lifecycle saves", () => {
     );
     try {
       await handleQuitRequested();
-      expect(lastSavedMemory()?.get("/alpha")).toBe("tab-a1");
-      expect(lastSavedMemory()?.get("/beta")).toBe("tab-b2");
+      expect(lastSavedMemory()?.get("/alpha")).toBe("a1");
+      expect(lastSavedMemory()?.get("/beta")).toBe("b2");
     } finally {
       release();
     }

--- a/src/lib/appLifecycle.test.ts
+++ b/src/lib/appLifecycle.test.ts
@@ -5,6 +5,13 @@ import { forgetHarnessSession, killAllChildren } from "./harness";
 import { newSession } from "./session";
 import { newTab } from "./layout";
 import { closeBusyWindow, setQuitWorkspace } from "./appLifecycle";
+import {
+  collectWorkspaceSnapshot,
+  hydrateWorkspaceSnapshot,
+  parseWorkspaceSnapshot,
+} from "./workspaceSnapshot";
+import { loadWorkspaceSnapshot, saveWorkspaceSnapshot } from "./sessionStore";
+import { reconcileProjectReturn } from "./projectReturn";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(undefined),
@@ -12,12 +19,184 @@ vi.mock("@tauri-apps/api/core", () => ({
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   ask: vi.fn().mockResolvedValue(true),
 }));
+vi.mock("./windowTransferBootstrap", () => ({
+  loadWindowTransfer: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("./sessionStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./sessionStore")>();
+  return {
+    ...actual,
+    loadWorkspaceSnapshot: vi.fn().mockResolvedValue(null),
+    listInFlightSessions: vi.fn().mockResolvedValue([]),
+    listSessionsByProject: vi.fn().mockResolvedValue([]),
+    getSession: vi.fn().mockResolvedValue(null),
+  };
+});
 vi.mock("./harness", () => ({
   bindHarnessSession: vi.fn(),
   isLiveHarness: vi.fn(),
   forgetHarnessSession: vi.fn().mockResolvedValue(undefined),
   killAllChildren: vi.fn().mockResolvedValue(undefined),
 }));
+
+describe("project choices through lifecycle saves", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(ask).mockResolvedValue(true);
+    vi.mocked(loadWorkspaceSnapshot).mockResolvedValue(null);
+  });
+
+  function workspace() {
+    const sessions = ["a1", "a2", "b1", "b2"].map((id) => ({
+      ...newSession("cursor", id.startsWith("a") ? "/alpha" : "/beta"),
+      id,
+    }));
+    const tabs = sessions.map((session) => ({
+      ...newTab(session.id),
+      id: `tab-${session.id}`,
+    }));
+    const memory = new Map([
+      ["/alpha", "tab-a2"],
+      ["/beta", "tab-b2"],
+    ]);
+    return {
+      sessions,
+      tabs,
+      memory,
+      activeTabId: "tab-b2",
+      projectCwd: "/beta",
+    };
+  }
+
+  function lastSavedMemory() {
+    const call = vi
+      .mocked(invoke)
+      .mock.calls.filter(([command]) => command === "workspace_set_snapshot")
+      .at(-1);
+    const args = call?.[1];
+    const snapshot =
+      args && typeof args === "object" && "snapshot" in args
+        ? parseWorkspaceSnapshot(args.snapshot)
+        : null;
+    expect(snapshot).not.toBeNull();
+    return snapshot
+      ? hydrateWorkspaceSnapshot(snapshot, new Map())?.projectReturnMemory
+      : undefined;
+  }
+
+  it("keeps both project choices in the final quit save after autosave", async () => {
+    const state = workspace();
+    const { handleQuitRequested, setQuitWorkspace } =
+      await import("./appLifecycle");
+    await saveWorkspaceSnapshot(
+      collectWorkspaceSnapshot(
+        state.tabs,
+        state.sessions,
+        state.activeTabId,
+        state.projectCwd,
+        state.memory,
+      ),
+    );
+    const release = setQuitWorkspace(
+      () => state.sessions,
+      () => state.tabs,
+      () => state.activeTabId,
+      () => state.projectCwd,
+      () => [],
+      () => state.memory,
+      vi.fn(),
+    );
+    try {
+      await handleQuitRequested();
+      expect([...(lastSavedMemory() ?? [])]).toEqual([...state.memory]);
+      expect(
+        vi
+          .mocked(invoke)
+          .mock.calls.filter(
+            ([command]) => command === "workspace_set_snapshot",
+          ),
+      ).toHaveLength(2);
+    } finally {
+      release();
+    }
+  });
+
+  it("reads committed selection from live getters before autosave", async () => {
+    const state = workspace();
+    const { handleQuitRequested, setQuitWorkspace } =
+      await import("./appLifecycle");
+    state.activeTabId = "tab-a1";
+    state.projectCwd = "/alpha";
+    const readMemory = () => reconcileProjectReturn(state);
+    const release = setQuitWorkspace(
+      () => state.sessions,
+      () => state.tabs,
+      () => state.activeTabId,
+      () => state.projectCwd,
+      () => [],
+      readMemory,
+      vi.fn(),
+    );
+    try {
+      await handleQuitRequested();
+      expect(lastSavedMemory()?.get("/alpha")).toBe("tab-a1");
+      expect(lastSavedMemory()?.get("/beta")).toBe("tab-b2");
+    } finally {
+      release();
+    }
+  });
+
+  it("preserves choices through unload persistence used by idle close", async () => {
+    const state = workspace();
+    const { persistQuitState } = await import("./appLifecycle");
+    await persistQuitState(
+      state.sessions,
+      state.tabs,
+      state.activeTabId,
+      state.projectCwd,
+      state.memory,
+      "unload",
+    );
+    expect([...(lastSavedMemory() ?? [])]).toEqual([...state.memory]);
+  });
+
+  it("preserves choices when closing a busy window", async () => {
+    const state = workspace();
+    state.sessions[3].busy = true;
+    const release = setQuitWorkspace(
+      () => state.sessions,
+      () => state.tabs,
+      () => state.activeTabId,
+      () => state.projectCwd,
+      () => [],
+      () => state.memory,
+      vi.fn(),
+    );
+    try {
+      await closeBusyWindow();
+      expect([...(lastSavedMemory() ?? [])]).toEqual([...state.memory]);
+      expect(invoke).toHaveBeenCalledWith("destroy_window");
+    } finally {
+      release();
+    }
+  });
+
+  it("preserves resumed choices when quitting before App registers live getters", async () => {
+    const state = workspace();
+    vi.mocked(loadWorkspaceSnapshot).mockResolvedValue(
+      collectWorkspaceSnapshot(
+        state.tabs,
+        state.sessions,
+        state.activeTabId,
+        state.projectCwd,
+        state.memory,
+      ),
+    );
+    const { handleQuitRequested } = await import("./appLifecycle");
+    await handleQuitRequested();
+    expect([...(lastSavedMemory() ?? [])]).toEqual([...state.memory]);
+  });
+});
 
 describe("closing a busy window", () => {
   beforeEach(() => {
@@ -36,6 +215,7 @@ describe("closing a busy window", () => {
       () => tab.id,
       () => session.cwd,
       () => [],
+      () => new Map(),
       vi.fn(),
     );
     return { session, release };

--- a/src/lib/appLifecycle.ts
+++ b/src/lib/appLifecycle.ts
@@ -43,6 +43,7 @@ import {
 import { loadWindowTransfer } from "./windowTransferBootstrap";
 import type { WindowTransferPayload } from "./windowTransfer";
 import { lastProjectPath, normalizeProjectPath, sameProjectPath } from "./recents";
+import type { ProjectReturnMemory } from "./projectReturn";
 
 export type { ResumedWorkspace };
 export { hasInFlightSessions };
@@ -66,6 +67,7 @@ let liveWorkspace: {
   activeTabId: () => string;
   projectCwd: () => string;
   projectTerminals: () => ProjectTerminalDock[];
+  projectReturnMemory: () => ProjectReturnMemory;
   flush: () => void;
 } | null = null;
 
@@ -79,6 +81,7 @@ export function setQuitWorkspace(
   activeTabId: () => string,
   projectCwd: () => string,
   projectTerminals: () => ProjectTerminalDock[],
+  projectReturnMemory: () => ProjectReturnMemory,
   flush: () => void,
 ): () => void {
   liveWorkspace = {
@@ -87,6 +90,7 @@ export function setQuitWorkspace(
     activeTabId,
     projectCwd,
     projectTerminals,
+    projectReturnMemory,
     flush,
   };
   bootingResumed = null;
@@ -103,6 +107,7 @@ export async function handleQuitRequested(): Promise<void> {
       liveWorkspace.tabs(),
       liveWorkspace.activeTabId(),
       liveWorkspace.projectCwd(),
+      liveWorkspace.projectReturnMemory(),
       liveWorkspace.projectTerminals(),
     );
     return;
@@ -127,8 +132,13 @@ export async function closeBusyWindow(): Promise<void> {
   if (!liveWorkspace) return;
   liveWorkspace.flush();
   await confirmQuitAndExit(
-    liveWorkspace.sessions(), liveWorkspace.tabs(), liveWorkspace.activeTabId(),
-    liveWorkspace.projectCwd(), liveWorkspace.projectTerminals(), true,
+    liveWorkspace.sessions(),
+    liveWorkspace.tabs(),
+    liveWorkspace.activeTabId(),
+    liveWorkspace.projectCwd(),
+    liveWorkspace.projectReturnMemory(),
+    liveWorkspace.projectTerminals(),
+    true,
   );
 }
 
@@ -292,6 +302,7 @@ export async function persistQuitState(
   tabs: WorkspaceTab[],
   activeTabId: string,
   projectCwd: string,
+  memory: ProjectReturnMemory,
   mode: "quit" | "unload" = "quit",
   projectTerminals: ProjectTerminalDock[] = [],
 ): Promise<void> {
@@ -312,6 +323,7 @@ export async function persistQuitState(
       sessions,
       activeTabId,
       projectCwd,
+      memory,
       projectTerminals,
     ),
   ).catch(() => undefined);
@@ -334,6 +346,7 @@ async function persistBootingResume(workspace: ResumedWorkspace): Promise<void> 
       workspace.sessions,
       workspace.activeTabId,
       workspace.projectCwd,
+      workspace.projectReturnMemory ?? new Map(),
       workspace.projectTerminals ?? [],
     ),
   ).catch(() => undefined);
@@ -352,6 +365,7 @@ async function confirmQuitAndExit(
   tabs: WorkspaceTab[],
   activeTabId: string,
   projectCwd: string,
+  memory: ProjectReturnMemory,
   projectTerminals: ProjectTerminalDock[] = [],
   closeWindow = false,
 ): Promise<void> {
@@ -376,6 +390,7 @@ async function confirmQuitAndExit(
         tabs,
         activeTabId,
         projectCwd,
+        memory,
         "quit",
         projectTerminals,
       );

--- a/src/lib/inFlight.ts
+++ b/src/lib/inFlight.ts
@@ -2,6 +2,7 @@ import { leafIds, newTab, type WorkspaceTab } from "./layout";
 import type { ProjectTerminalDock } from "./projectTerminal";
 import { sessionNeedsInput, type Session } from "./session";
 import { stopStreaming } from "./harness/apply";
+import type { ProjectReturnMemory } from "./projectReturn";
 
 export const INTERRUPT_MESSAGE =
   "Turn interrupted when MonoCode quit.";
@@ -19,6 +20,7 @@ export type ResumedWorkspace = {
   activeTabId: string;
   projectCwd: string;
   projectTerminals?: ProjectTerminalDock[];
+  projectReturnMemory?: ProjectReturnMemory;
 };
 
 /** A turn or approval that would be lost if this webview died. */

--- a/src/lib/inboxAsk.test.ts
+++ b/src/lib/inboxAsk.test.ts
@@ -112,6 +112,7 @@ describe("inbox sessions", () => {
       [project, session],
       tab.id,
       project.cwd,
+      new Map(),
     );
     expect(snapshot.sessions.map((entry) => entry.id)).toEqual([project.id]);
     const restored = hydrateWorkspaceSnapshot(
@@ -139,11 +140,16 @@ describe("inbox sessions", () => {
       activeTabId: askTab.id,
       projectCwd: project.cwd,
       projectTerminals: [],
+      projectReturnTargets: [{ projectPath: project.cwd, tabId: askTab.id }],
     };
     const parsed = parseWorkspaceSnapshot(legacy)!;
     expect(parsed.tabs).toEqual([tab]);
     expect(parsed.activeTabId).toBe(tab.id);
     expect(parsed.sessions.map((entry) => entry.id)).toEqual([project.id]);
+    expect(parsed.projectReturnTargets).toEqual([]);
+    expect(
+      hydrateWorkspaceSnapshot(parsed, new Map())?.projectReturnMemory?.get(project.cwd),
+    ).toBe(tab.id);
     expect(
       parseWorkspaceSnapshot({
         ...legacy,

--- a/src/lib/inboxAsk.test.ts
+++ b/src/lib/inboxAsk.test.ts
@@ -149,7 +149,7 @@ describe("inbox sessions", () => {
     expect(parsed.projectReturnTargets).toEqual([]);
     expect(
       hydrateWorkspaceSnapshot(parsed, new Map())?.projectReturnMemory?.get(project.cwd),
-    ).toBe(tab.id);
+    ).toBe(project.id);
     expect(
       parseWorkspaceSnapshot({
         ...legacy,

--- a/src/lib/projectReturn.test.ts
+++ b/src/lib/projectReturn.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from "vitest";
+import { newFileTab, newTab, placePane, type WorkspaceTab } from "./layout";
+import { newSession, type Session } from "./session";
+import { planProjectReturn, reconcileProjectReturn } from "./projectReturn";
+import {
+  emptyTabVisitHistory,
+  recordTabVisit,
+  tabVisitBack,
+} from "./tabVisitHistory";
+import { removeSessionFromWorkspace } from "./sessionWorkspaceLifecycle";
+import { applyPlaceSessionOnPane } from "./workspaceTabGroups";
+
+function chat(id: string, cwd: string): Session {
+  return {
+    ...newSession("cursor", cwd),
+    id,
+    blocks: [{ id: `${id}-user`, role: "user", text: id }],
+  };
+}
+
+function workspace() {
+  const sessions = [
+    chat("a1", "/alpha"),
+    chat("a2", "/alpha"),
+    chat("b1", "/beta"),
+    chat("b2", "/beta"),
+  ];
+  const tabs = sessions.map((session) => ({
+    ...newTab(session.id),
+    id: `tab-${session.id}`,
+  }));
+  return {
+    sessions,
+    tabs,
+    activeTabId: "tab-b2",
+    memory: new Map<string, string>(),
+  };
+}
+
+describe("project return memory", () => {
+  it("records visits independently and changes on explicit selection or Back", () => {
+    const state = workspace();
+    const alpha = reconcileProjectReturn({ ...state, activeTabId: "tab-a2" });
+    const beta = reconcileProjectReturn({ ...state, memory: alpha });
+    expect([...beta]).toEqual([
+      ["/alpha", "tab-a2"],
+      ["/beta", "tab-b2"],
+    ]);
+    const changed = reconcileProjectReturn({
+      ...state,
+      memory: beta,
+      activeTabId: "tab-a1",
+    });
+    expect(changed.get("/alpha")).toBe("tab-a1");
+    const history = recordTabVisit(emptyTabVisitHistory("tab-a2"), "tab-b2");
+    const back = tabVisitBack(history);
+    expect(back).not.toBeNull();
+    const returned = reconcileProjectReturn({
+      ...state,
+      memory: changed,
+      activeTabId: back?.current ?? "",
+    });
+    expect(returned.get("/alpha")).toBe("tab-a2");
+    expect(returned.get("/beta")).toBe("tab-b2");
+    expect(state.memory.size).toBe(0);
+    expect(alpha.size).toBe(1);
+  });
+
+  it("does not change identity for repeated observation or streaming updates", () => {
+    const state = workspace();
+    const memory = reconcileProjectReturn(state);
+    state.sessions[0].blocks.push({
+      id: "response",
+      role: "assistant",
+      text: "working",
+    });
+    state.sessions[0].busy = true;
+    expect(reconcileProjectReturn({ ...state, memory })).toBe(memory);
+  });
+
+  it("prunes removed and retargeted tabs without changing the input map", () => {
+    const state = workspace();
+    const memory = new Map([
+      ["/alpha", "tab-a2"],
+      ["/gone", "missing"],
+      ["/beta", "tab-b2"],
+    ]);
+    state.sessions[1].cwd = "/gamma";
+    expect([...reconcileProjectReturn({ ...state, memory })]).toEqual([
+      ["/beta", "tab-b2"],
+    ]);
+    expect(memory.size).toBe(3);
+  });
+
+  it("records editor-only tabs and keeps the selected file pane", () => {
+    const file = newFileTab("/gamma/readme.md", "/gamma");
+    const tab = {
+      ...newTab("editor"),
+      id: "files",
+      editorPanes: [{ id: "editor", files: [file], activeFileId: file.id }],
+    };
+    const state = workspace();
+    const tabs = [...state.tabs, tab];
+    const memory = reconcileProjectReturn({
+      ...state,
+      tabs,
+      activeTabId: tab.id,
+    });
+    expect(
+      planProjectReturn({ ...state, tabs, memory, projectPath: "/gamma" }),
+    ).toEqual({ action: "activate", tabId: tab.id });
+    expect(tab.focusedId).toBe("editor");
+  });
+
+  it("records canonical Windows keys and does not combine matching display names", () => {
+    const state = workspace();
+    state.sessions[1].cwd = "C:/Work/Alpha/";
+    const memory = reconcileProjectReturn({ ...state, activeTabId: "tab-a2" });
+    expect(memory.get("c:/work/alpha")).toBe("tab-a2");
+    expect(
+      planProjectReturn({ ...state, memory, projectPath: "c:\\work\\ALPHA" }),
+    ).toEqual({ action: "activate", tabId: "tab-a2" });
+    expect(
+      planProjectReturn({ ...state, memory, projectPath: "/elsewhere/Alpha" }),
+    ).toEqual({ action: "create" });
+  });
+
+  it("validates the result of actual session removal and preserves close replacement", () => {
+    const state = workspace();
+    const memory = new Map([
+      ["/alpha", "tab-a2"],
+      ["/beta", "tab-b2"],
+    ]);
+    const removed = removeSessionFromWorkspace({
+      ...state,
+      sessionId: "a2",
+      scope: "project",
+      createReplacement: (seed) => chat("replacement", seed?.cwd ?? "/alpha"),
+    });
+    const next = reconcileProjectReturn({ ...removed, memory });
+    expect(
+      planProjectReturn({ ...removed, memory: next, projectPath: "/alpha" }),
+    ).toEqual({ action: "activate", tabId: "tab-a1" });
+    const activeRemoved = removeSessionFromWorkspace({
+      ...state,
+      activeTabId: "tab-a2",
+      sessionId: "a2",
+      scope: "project",
+      createReplacement: (seed) => chat("replacement", seed?.cwd ?? "/alpha"),
+    });
+    expect(
+      reconcileProjectReturn({ ...activeRemoved, memory }).get("/alpha"),
+    ).toBe(activeRemoved.activeTabId);
+  });
+
+  it("returns to the focused session after actual pane placement", () => {
+    const state = workspace();
+    const placed = applyPlaceSessionOnPane({
+      tabs: state.tabs,
+      sessions: state.sessions,
+      sessionId: "a2",
+      targetId: "a1",
+      edge: "right",
+      replaceTarget: false,
+      scope: "workspace",
+      createReplacement: (seed) => chat("replacement", seed?.cwd ?? "/alpha"),
+    });
+    expect(placed).not.toBeNull();
+    if (!placed) throw new Error("Expected placed workspace");
+    const memory = reconcileProjectReturn({
+      ...placed,
+      memory: new Map([["/alpha", "tab-a2"]]),
+    });
+    const beta = reconcileProjectReturn({
+      ...placed,
+      memory,
+      activeTabId: "tab-b2",
+    });
+    const decision = planProjectReturn({
+      ...placed,
+      memory: beta,
+      activeTabId: "tab-b2",
+      projectPath: "/alpha",
+    });
+    expect(decision).toEqual({ action: "activate", tabId: "tab-a1" });
+    expect(placed.tabs.find((tab) => tab.id === "tab-a1")?.focusedId).toBe(
+      "a2",
+    );
+  });
+
+  it("drops a removed project's choice rather than reopening it", () => {
+    const state = workspace();
+    const memory = new Map([["/alpha", "tab-a2"]]);
+    const remaining = {
+      ...state,
+      tabs: state.tabs.filter((tab) => tab.id.startsWith("tab-b")),
+    };
+    const next = reconcileProjectReturn({ ...remaining, memory });
+    expect(next.has("/alpha")).toBe(false);
+    expect(
+      planProjectReturn({ ...remaining, memory: next, projectPath: "/alpha" }),
+    ).toEqual({ action: "create" });
+  });
+
+  it("does not record a missing active tab or a projectless tab", () => {
+    const state = workspace();
+    expect(reconcileProjectReturn({ ...state, activeTabId: "missing" })).toBe(
+      state.memory,
+    );
+    state.sessions[3].cwd = "~";
+    expect(reconcileProjectReturn(state)).toBe(state.memory);
+  });
+});
+
+describe("project selection", () => {
+  it.each(["missing", "tab-b1"])("rejects invalid Alpha target %s", (tabId) => {
+    const state = workspace();
+    state.memory.set("/alpha", tabId);
+    expect(planProjectReturn({ ...state, projectPath: "/alpha" })).toEqual({
+      action: "activate",
+      tabId: "tab-a1",
+    });
+  });
+
+  it("keeps the focused project", () => {
+    expect(
+      planProjectReturn({ ...workspace(), projectPath: "/beta/" }),
+    ).toEqual({ action: "keep" });
+  });
+
+  it("selects the first destination tab without a remembered choice", () => {
+    expect(
+      planProjectReturn({ ...workspace(), projectPath: "/alpha" }),
+    ).toEqual({ action: "activate", tabId: "tab-a1" });
+  });
+
+  it("prefers an existing destination over a blank source", () => {
+    const state = workspace();
+    state.sessions[3].blocks = [];
+    expect(planProjectReturn({ ...state, projectPath: "/alpha" })).toEqual({
+      action: "activate",
+      tabId: "tab-a1",
+    });
+  });
+
+  it("returns to A2 and B2 independently of tab order", () => {
+    const state = workspace();
+    state.memory = new Map([
+      ["/alpha", "tab-a2"],
+      ["/beta", "tab-b2"],
+    ]);
+    expect(planProjectReturn({ ...state, projectPath: "/alpha" })).toEqual({
+      action: "activate",
+      tabId: "tab-a2",
+    });
+    expect(
+      planProjectReturn({
+        ...state,
+        activeTabId: "tab-a2",
+        projectPath: "/beta",
+      }),
+    ).toEqual({ action: "activate", tabId: "tab-b2" });
+    expect(
+      planProjectReturn({
+        ...state,
+        tabs: [...state.tabs].reverse(),
+        projectPath: "/alpha",
+      }),
+    ).toEqual({ action: "activate", tabId: "tab-a2" });
+  });
+
+  it("reuses a blank only when the destination has no open tab", () => {
+    const state = workspace();
+    state.sessions[3].blocks = [];
+    expect(planProjectReturn({ ...state, projectPath: "/gamma" })).toEqual({
+      action: "reuse-blank",
+      sessionId: "b2",
+    });
+  });
+
+  it("never reuses a busy session even when it has no user blocks", () => {
+    const state = workspace();
+    state.sessions[3].blocks = [];
+    state.sessions[3].busy = true;
+    expect(planProjectReturn({ ...state, projectPath: "/gamma" })).toEqual({
+      action: "create",
+    });
+  });
+
+  it("creates a session when no destination exists and the current chat is not blank", () => {
+    expect(
+      planProjectReturn({ ...workspace(), projectPath: "/gamma" }),
+    ).toEqual({ action: "create" });
+  });
+
+  it("keeps a focused Beta session in an Alpha-first split", () => {
+    const state = workspace();
+    const first = state.tabs[0];
+    state.tabs[0] = {
+      ...first,
+      layout: placePane(first.layout, "b2", "a1", "right"),
+      focusedId: "b2",
+    };
+    state.tabs = state.tabs.filter((tab) => tab.id !== "tab-b2");
+    expect(
+      planProjectReturn({
+        ...state,
+        activeTabId: first.id,
+        projectPath: "/beta",
+      }),
+    ).toEqual({ action: "keep" });
+  });
+
+  it("keeps a focused file in the selected project", () => {
+    const state = workspace();
+    const file = newFileTab("/gamma/readme.md", "/gamma");
+    const tab: WorkspaceTab = {
+      ...newTab("editor"),
+      id: "files",
+      editorPanes: [{ id: "editor", files: [file], activeFileId: file.id }],
+    };
+    expect(
+      planProjectReturn({
+        ...state,
+        tabs: [...state.tabs, tab],
+        activeTabId: tab.id,
+        projectPath: "/gamma",
+      }),
+    ).toEqual({ action: "keep" });
+  });
+});

--- a/src/lib/projectReturn.test.ts
+++ b/src/lib/projectReturn.test.ts
@@ -43,15 +43,15 @@ describe("project return memory", () => {
     const alpha = reconcileProjectReturn({ ...state, activeTabId: "tab-a2" });
     const beta = reconcileProjectReturn({ ...state, memory: alpha });
     expect([...beta]).toEqual([
-      ["/alpha", "tab-a2"],
-      ["/beta", "tab-b2"],
+      ["/alpha", "a2"],
+      ["/beta", "b2"],
     ]);
     const changed = reconcileProjectReturn({
       ...state,
       memory: beta,
       activeTabId: "tab-a1",
     });
-    expect(changed.get("/alpha")).toBe("tab-a1");
+    expect(changed.get("/alpha")).toBe("a1");
     const history = recordTabVisit(emptyTabVisitHistory("tab-a2"), "tab-b2");
     const back = tabVisitBack(history);
     expect(back).not.toBeNull();
@@ -60,8 +60,8 @@ describe("project return memory", () => {
       memory: changed,
       activeTabId: back?.current ?? "",
     });
-    expect(returned.get("/alpha")).toBe("tab-a2");
-    expect(returned.get("/beta")).toBe("tab-b2");
+    expect(returned.get("/alpha")).toBe("a2");
+    expect(returned.get("/beta")).toBe("b2");
     expect(state.memory.size).toBe(0);
     expect(alpha.size).toBe(1);
   });
@@ -81,13 +81,13 @@ describe("project return memory", () => {
   it("prunes removed and retargeted tabs without changing the input map", () => {
     const state = workspace();
     const memory = new Map([
-      ["/alpha", "tab-a2"],
+      ["/alpha", "a2"],
       ["/gone", "missing"],
-      ["/beta", "tab-b2"],
+      ["/beta", "b2"],
     ]);
     state.sessions[1].cwd = "/gamma";
     expect([...reconcileProjectReturn({ ...state, memory })]).toEqual([
-      ["/beta", "tab-b2"],
+      ["/beta", "b2"],
     ]);
     expect(memory.size).toBe(3);
   });
@@ -108,7 +108,7 @@ describe("project return memory", () => {
     });
     expect(
       planProjectReturn({ ...state, tabs, memory, projectPath: "/gamma" }),
-    ).toEqual({ action: "activate", tabId: tab.id });
+    ).toEqual({ action: "activate", tabId: tab.id, paneId: "editor" });
     expect(tab.focusedId).toBe("editor");
   });
 
@@ -116,10 +116,10 @@ describe("project return memory", () => {
     const state = workspace();
     state.sessions[1].cwd = "C:/Work/Alpha/";
     const memory = reconcileProjectReturn({ ...state, activeTabId: "tab-a2" });
-    expect(memory.get("c:/work/alpha")).toBe("tab-a2");
+    expect(memory.get("c:/work/alpha")).toBe("a2");
     expect(
       planProjectReturn({ ...state, memory, projectPath: "c:\\work\\ALPHA" }),
-    ).toEqual({ action: "activate", tabId: "tab-a2" });
+    ).toEqual({ action: "activate", tabId: "tab-a2", paneId: "a2" });
     expect(
       planProjectReturn({ ...state, memory, projectPath: "/elsewhere/Alpha" }),
     ).toEqual({ action: "create" });
@@ -128,8 +128,8 @@ describe("project return memory", () => {
   it("validates the result of actual session removal and preserves close replacement", () => {
     const state = workspace();
     const memory = new Map([
-      ["/alpha", "tab-a2"],
-      ["/beta", "tab-b2"],
+      ["/alpha", "a2"],
+      ["/beta", "b2"],
     ]);
     const removed = removeSessionFromWorkspace({
       ...state,
@@ -140,7 +140,7 @@ describe("project return memory", () => {
     const next = reconcileProjectReturn({ ...removed, memory });
     expect(
       planProjectReturn({ ...removed, memory: next, projectPath: "/alpha" }),
-    ).toEqual({ action: "activate", tabId: "tab-a1" });
+    ).toEqual({ action: "activate", tabId: "tab-a1", paneId: "a1" });
     const activeRemoved = removeSessionFromWorkspace({
       ...state,
       activeTabId: "tab-a2",
@@ -150,7 +150,7 @@ describe("project return memory", () => {
     });
     expect(
       reconcileProjectReturn({ ...activeRemoved, memory }).get("/alpha"),
-    ).toBe(activeRemoved.activeTabId);
+    ).toBe("a1");
   });
 
   it("returns to the focused session after actual pane placement", () => {
@@ -169,7 +169,7 @@ describe("project return memory", () => {
     if (!placed) throw new Error("Expected placed workspace");
     const memory = reconcileProjectReturn({
       ...placed,
-      memory: new Map([["/alpha", "tab-a2"]]),
+      memory: new Map([["/alpha", "a2"]]),
     });
     const beta = reconcileProjectReturn({
       ...placed,
@@ -182,7 +182,7 @@ describe("project return memory", () => {
       activeTabId: "tab-b2",
       projectPath: "/alpha",
     });
-    expect(decision).toEqual({ action: "activate", tabId: "tab-a1" });
+    expect(decision).toEqual({ action: "activate", tabId: "tab-a1", paneId: "a2" });
     expect(placed.tabs.find((tab) => tab.id === "tab-a1")?.focusedId).toBe(
       "a2",
     );
@@ -190,7 +190,7 @@ describe("project return memory", () => {
 
   it("drops a removed project's choice rather than reopening it", () => {
     const state = workspace();
-    const memory = new Map([["/alpha", "tab-a2"]]);
+    const memory = new Map([["/alpha", "a2"]]);
     const remaining = {
       ...state,
       tabs: state.tabs.filter((tab) => tab.id.startsWith("tab-b")),
@@ -219,6 +219,7 @@ describe("project selection", () => {
     expect(planProjectReturn({ ...state, projectPath: "/alpha" })).toEqual({
       action: "activate",
       tabId: "tab-a1",
+      paneId: "a1",
     });
   });
 
@@ -231,7 +232,7 @@ describe("project selection", () => {
   it("selects the first destination tab without a remembered choice", () => {
     expect(
       planProjectReturn({ ...workspace(), projectPath: "/alpha" }),
-    ).toEqual({ action: "activate", tabId: "tab-a1" });
+    ).toEqual({ action: "activate", tabId: "tab-a1", paneId: "a1" });
   });
 
   it("prefers an existing destination over a blank source", () => {
@@ -240,18 +241,20 @@ describe("project selection", () => {
     expect(planProjectReturn({ ...state, projectPath: "/alpha" })).toEqual({
       action: "activate",
       tabId: "tab-a1",
+      paneId: "a1",
     });
   });
 
   it("returns to A2 and B2 independently of tab order", () => {
     const state = workspace();
     state.memory = new Map([
-      ["/alpha", "tab-a2"],
-      ["/beta", "tab-b2"],
+      ["/alpha", "a2"],
+      ["/beta", "b2"],
     ]);
     expect(planProjectReturn({ ...state, projectPath: "/alpha" })).toEqual({
       action: "activate",
       tabId: "tab-a2",
+      paneId: "a2",
     });
     expect(
       planProjectReturn({
@@ -259,14 +262,14 @@ describe("project selection", () => {
         activeTabId: "tab-a2",
         projectPath: "/beta",
       }),
-    ).toEqual({ action: "activate", tabId: "tab-b2" });
+    ).toEqual({ action: "activate", tabId: "tab-b2", paneId: "b2" });
     expect(
       planProjectReturn({
         ...state,
         tabs: [...state.tabs].reverse(),
         projectPath: "/alpha",
       }),
-    ).toEqual({ action: "activate", tabId: "tab-a2" });
+    ).toEqual({ action: "activate", tabId: "tab-a2", paneId: "a2" });
   });
 
   it("reuses a blank only when the destination has no open tab", () => {

--- a/src/lib/projectReturn.ts
+++ b/src/lib/projectReturn.ts
@@ -1,0 +1,83 @@
+import { focusedFileTab, type WorkspaceTab } from "./layout";
+import { pathKey } from "./paths";
+import { sameProjectPath } from "./recents";
+import type { Session } from "./session";
+import { findTabForProject, workspaceTabCwd } from "./workspaceTabGroups";
+
+export type ProjectReturnMemory = ReadonlyMap<string, WorkspaceTab["id"]>;
+
+type ProjectReturnContext = {
+  memory: ProjectReturnMemory;
+  tabs: WorkspaceTab[];
+  sessions: Session[];
+  activeTabId: string;
+};
+
+export type ProjectReturnDecision =
+  | { action: "keep" }
+  | { action: "activate"; tabId: string }
+  | { action: "reuse-blank"; sessionId: string }
+  | { action: "create" };
+
+export function isBlankSession(session: Session | undefined): boolean {
+  if (!session || session.busy) return false;
+  return !session.blocks.some((block) => block.role === "user");
+}
+
+export function reconcileProjectReturn({
+  memory,
+  tabs,
+  sessions,
+  activeTabId,
+}: Omit<ProjectReturnContext, "sessions"> & {
+  sessions: readonly Pick<Session, "id" | "cwd">[];
+}): ProjectReturnMemory {
+  const projects = new Map<string, string>();
+  for (const tab of tabs) {
+    const cwd = workspaceTabCwd(tab, sessions);
+    if (cwd) projects.set(tab.id, pathKey(cwd));
+  }
+  const next = new Map(
+    [...memory].filter(([project, tabId]) => projects.get(tabId) === project),
+  );
+  const activeProject = projects.get(activeTabId);
+  if (activeProject) next.set(activeProject, activeTabId);
+  if (
+    next.size === memory.size &&
+    [...next].every(([project, id]) => memory.get(project) === id)
+  )
+    return memory;
+  return next;
+}
+
+export function planProjectReturn({
+  memory,
+  tabs,
+  sessions,
+  activeTabId,
+  projectPath,
+}: ProjectReturnContext & { projectPath: string }): ProjectReturnDecision {
+  const active = tabs.find((tab) => tab.id === activeTabId);
+  const current =
+    active && sessions.find((session) => session.id === active.focusedId);
+  const currentCwd =
+    current?.cwd ?? (active ? focusedFileTab(active)?.cwd : undefined);
+  if (currentCwd && sameProjectPath(currentCwd, projectPath))
+    return { action: "keep" };
+  const remembered = tabs.find(
+    (tab) => tab.id === memory.get(pathKey(projectPath)),
+  );
+  const rememberedCwd = remembered && workspaceTabCwd(remembered, sessions);
+  if (
+    remembered &&
+    rememberedCwd &&
+    sameProjectPath(rememberedCwd, projectPath)
+  ) {
+    return { action: "activate", tabId: remembered.id };
+  }
+  const match = findTabForProject(tabs, sessions, projectPath);
+  if (match) return { action: "activate", tabId: match.id };
+  return current && isBlankSession(current)
+    ? { action: "reuse-blank", sessionId: current.id }
+    : { action: "create" };
+}

--- a/src/lib/projectReturn.ts
+++ b/src/lib/projectReturn.ts
@@ -1,10 +1,9 @@
-import { focusedFileTab, type WorkspaceTab } from "./layout";
+import { leafIds, type WorkspaceTab } from "./layout";
+import type { Session } from "./session";
 import { pathKey } from "./paths";
 import { sameProjectPath } from "./recents";
-import type { Session } from "./session";
-import { findTabForProject, workspaceTabCwd } from "./workspaceTabGroups";
 
-export type ProjectReturnMemory = ReadonlyMap<string, WorkspaceTab["id"]>;
+export type ProjectReturnMemory = ReadonlyMap<string, string>;
 
 type ProjectReturnContext = {
   memory: ProjectReturnMemory;
@@ -13,15 +12,90 @@ type ProjectReturnContext = {
   activeTabId: string;
 };
 
+type PaneProject = Map<string, string>;
+
 export type ProjectReturnDecision =
   | { action: "keep" }
-  | { action: "activate"; tabId: string }
+  | { action: "activate"; tabId: string; paneId?: string }
   | { action: "reuse-blank"; sessionId: string }
   | { action: "create" };
 
 export function isBlankSession(session: Session | undefined): boolean {
   if (!session || session.busy) return false;
   return !session.blocks.some((block) => block.role === "user");
+}
+
+function paneProjects(
+  tabs: readonly WorkspaceTab[],
+  sessions: readonly Pick<Session, "id" | "cwd">[],
+): PaneProject {
+  const cwdBySession = new Map(
+    sessions.map((session) => [session.id, session.cwd]),
+  );
+  const result = new Map<string, string>();
+
+  for (const tab of tabs) {
+    for (const paneId of leafIds(tab.layout)) {
+      const cwd = cwdBySession.get(paneId);
+      if (cwd && cwd !== "~") {
+        result.set(paneId, pathKey(cwd));
+      }
+    }
+
+    for (const pane of tab.editorPanes) {
+      const active = pane.files.find((file) => file.id === pane.activeFileId);
+      if (active && active.cwd !== "~") {
+        result.set(pane.id, pathKey(active.cwd));
+      }
+    }
+
+    for (const pane of tab.terminalPanes ?? []) {
+      const active = pane.files.find((file) => file.id === pane.activeFileId);
+      if (active && active.cwd !== "~") {
+        result.set(pane.id, pathKey(active.cwd));
+      }
+    }
+  }
+
+  return result;
+}
+
+function tabFocusedPaneById(tabs: readonly WorkspaceTab[]): Map<string, string> {
+  return new Map(tabs.map((tab) => [tab.id, tab.focusedId]));
+}
+
+function paneBelongsToProject(
+  paneId: string,
+  target: string,
+  paneById: PaneProject,
+): boolean {
+  const project = paneById.get(paneId);
+  return !!project && sameProjectPath(project, target);
+}
+
+function paneForProjectInTab(
+  tab: WorkspaceTab,
+  target: string,
+  paneById: PaneProject,
+): string | undefined {
+  for (const paneId of leafIds(tab.layout)) {
+    if (paneById.get(paneId) === target) return paneId;
+  }
+  for (const pane of tab.editorPanes) {
+    if (paneById.get(pane.id) === target) return pane.id;
+  }
+  for (const pane of tab.terminalPanes ?? []) {
+    if (paneById.get(pane.id) === target) return pane.id;
+  }
+  return undefined;
+}
+
+function tabContainsPane(tab: WorkspaceTab, paneId: string): boolean {
+  return (
+    leafIds(tab.layout).includes(paneId) ||
+    tab.editorPanes.some((pane) => pane.id === paneId) ||
+    (tab.terminalPanes ?? []).some((pane) => pane.id === paneId)
+  );
 }
 
 export function reconcileProjectReturn({
@@ -32,16 +106,29 @@ export function reconcileProjectReturn({
 }: Omit<ProjectReturnContext, "sessions"> & {
   sessions: readonly Pick<Session, "id" | "cwd">[];
 }): ProjectReturnMemory {
-  const projects = new Map<string, string>();
-  for (const tab of tabs) {
-    const cwd = workspaceTabCwd(tab, sessions);
-    if (cwd) projects.set(tab.id, pathKey(cwd));
+  const activeTab = tabs.find((tab) => tab.id === activeTabId);
+  const byPane = paneProjects(tabs, sessions);
+  const byTab = tabFocusedPaneById(tabs);
+
+  const next = new Map<string, string>();
+  for (const [project, saved] of memory) {
+    const asPane = byPane.get(saved);
+    if (asPane === project) {
+      next.set(project, saved);
+      continue;
+    }
+
+    const focused = byTab.get(saved);
+    if (!focused) continue;
+    if (paneBelongsToProject(focused, project, byPane)) {
+      next.set(project, focused);
+    }
   }
-  const next = new Map(
-    [...memory].filter(([project, tabId]) => projects.get(tabId) === project),
-  );
-  const activeProject = projects.get(activeTabId);
-  if (activeProject) next.set(activeProject, activeTabId);
+
+  const activePaneId = activeTab?.focusedId;
+  const activeProject = activePaneId ? byPane.get(activePaneId) : undefined;
+  if (activeProject && activePaneId) next.set(activeProject, activePaneId);
+
   if (
     next.size === memory.size &&
     [...next].every(([project, id]) => memory.get(project) === id)
@@ -57,26 +144,38 @@ export function planProjectReturn({
   activeTabId,
   projectPath,
 }: ProjectReturnContext & { projectPath: string }): ProjectReturnDecision {
+  const target = pathKey(projectPath);
+  const byPane = paneProjects(tabs, sessions);
   const active = tabs.find((tab) => tab.id === activeTabId);
-  const current =
-    active && sessions.find((session) => session.id === active.focusedId);
-  const currentCwd =
-    current?.cwd ?? (active ? focusedFileTab(active)?.cwd : undefined);
-  if (currentCwd && sameProjectPath(currentCwd, projectPath))
+
+  if (active?.focusedId && paneBelongsToProject(active.focusedId, target, byPane)) {
     return { action: "keep" };
-  const remembered = tabs.find(
-    (tab) => tab.id === memory.get(pathKey(projectPath)),
-  );
-  const rememberedCwd = remembered && workspaceTabCwd(remembered, sessions);
-  if (
-    remembered &&
-    rememberedCwd &&
-    sameProjectPath(rememberedCwd, projectPath)
-  ) {
-    return { action: "activate", tabId: remembered.id };
   }
-  const match = findTabForProject(tabs, sessions, projectPath);
-  if (match) return { action: "activate", tabId: match.id };
+
+  const remembered = memory.get(target);
+  if (remembered) {
+    const rememberedTab = tabs.find((tab) => tabContainsPane(tab, remembered));
+    if (
+      rememberedTab &&
+      paneBelongsToProject(remembered, target, byPane)
+    ) {
+      return {
+        action: "activate",
+        tabId: rememberedTab.id,
+        paneId: remembered,
+      };
+    }
+  }
+
+  for (const tab of tabs) {
+    const paneId = paneForProjectInTab(tab, target, byPane);
+    if (!paneId) continue;
+    return { action: "activate", tabId: tab.id, paneId };
+  }
+
+  const current =
+    active?.focusedId &&
+    sessions.find((session) => session.id === active.focusedId);
   return current && isBlankSession(current)
     ? { action: "reuse-blank", sessionId: current.id }
     : { action: "create" };

--- a/src/lib/workspaceSnapshot.test.ts
+++ b/src/lib/workspaceSnapshot.test.ts
@@ -26,6 +26,125 @@ function chat(id: string, cwd: string): Session {
   return session;
 }
 
+describe("project return snapshots", () => {
+  function saved() {
+    const sessions = [
+      chat("a1", "/alpha"),
+      chat("a2", "/alpha"),
+      chat("b1", "/beta"),
+      chat("b2", "/beta"),
+    ];
+    const tabs = sessions.map((session) => ({
+      ...newTab(session.id),
+      id: `tab-${session.id}`,
+    }));
+    return {
+      ...collectWorkspaceSnapshot(tabs, sessions, "tab-b2", "/beta", new Map()),
+      projectReturnTargets: [
+        { projectPath: "/alpha", tabId: "tab-a2" },
+        { projectPath: "/beta", tabId: "tab-b2" },
+      ],
+    };
+  }
+
+  it("collects and round-trips choices while rejecting stale references", () => {
+    const sessions = [
+      chat("a1", "/alpha"),
+      chat("a2", "/alpha"),
+      chat("b2", "/beta"),
+    ];
+    const tabs = sessions.map((session) => ({
+      ...newTab(session.id),
+      id: `tab-${session.id}`,
+    }));
+    const memory = new Map([
+      ["/alpha", "tab-a2"],
+      ["/beta", "tab-b2"],
+      ["/gone", "missing"],
+    ]);
+    const snapshot = collectWorkspaceSnapshot(
+      tabs,
+      sessions,
+      "tab-b2",
+      "/beta",
+      memory,
+    );
+    const restored = hydrateWorkspaceSnapshot(snapshot, new Map());
+    expect([...(restored?.projectReturnMemory ?? [])]).toEqual([
+      ["/alpha", "tab-a2"],
+      ["/beta", "tab-b2"],
+    ]);
+    expect(memory.size).toBe(3);
+  });
+
+  it("restores both project choices, not just the active tab", () => {
+    const restored = hydrateWorkspaceSnapshot(saved(), new Map());
+    expect(restored?.projectReturnMemory?.get("/alpha")).toBe("tab-a2");
+    expect(restored?.projectReturnMemory?.get("/beta")).toBe("tab-b2");
+  });
+
+  it("loads old snapshots and seeds only the active project", () => {
+    const { projectReturnTargets: _targets, ...old } = saved();
+    const restored = hydrateWorkspaceSnapshot(old, new Map());
+    expect([...(restored?.projectReturnMemory ?? [])]).toEqual([
+      ["/beta", "tab-b2"],
+    ]);
+  });
+
+  it("prunes invalid entries and uses the last valid duplicate", () => {
+    const raw = saved();
+    const parsed = parseWorkspaceSnapshot({
+      ...raw,
+      projectReturnTargets: [
+        null,
+        42,
+        {},
+        { projectPath: "/alpha", tabId: 12 },
+        { projectPath: "/alpha/", tabId: "tab-a1" },
+        { projectPath: "/alpha", tabId: "tab-a2" },
+        { projectPath: "/gone", tabId: "missing" },
+        { projectPath: "/beta", tabId: "tab-a1" },
+      ],
+    });
+    expect(parsed?.projectReturnTargets).toEqual([
+      { projectPath: "/alpha", tabId: "tab-a2" },
+    ]);
+  });
+
+  it("lets the restored active tab override inconsistent saved preference", () => {
+    const raw = saved();
+    raw.projectReturnTargets[1].tabId = "tab-b1";
+    expect(
+      hydrateWorkspaceSnapshot(raw, new Map())?.projectReturnMemory?.get(
+        "/beta",
+      ),
+    ).toBe("tab-b2");
+  });
+
+  it.each([null, "broken", {}])(
+    "ignores a malformed choice list: %j",
+    (projectReturnTargets) => {
+      const restored = hydrateWorkspaceSnapshot(
+        { ...saved(), projectReturnTargets },
+        new Map(),
+      );
+      expect(restored?.tabs).toHaveLength(4);
+      expect([...(restored?.projectReturnMemory ?? [])]).toEqual([
+        ["/beta", "tab-b2"],
+      ]);
+    },
+  );
+
+  it("rechecks project membership against loaded sessions", () => {
+    const restored = hydrateWorkspaceSnapshot(
+      saved(),
+      new Map([["a2", chat("a2", "/moved")]]),
+    );
+    expect(restored?.projectReturnMemory?.has("/alpha")).toBe(false);
+    expect(restored?.projectReturnMemory?.get("/beta")).toBe("tab-b2");
+  });
+});
+
 describe("collectWorkspaceSnapshot", () => {
   it("stores tabs, stubs, and the focused tab — not transcripts", () => {
     const session = chat("s1", "/tmp/a");
@@ -36,7 +155,13 @@ describe("collectWorkspaceSnapshot", () => {
       id: "t1",
       editorPanes: [{ id: "e1", files: [file], activeFileId: file.id }],
     };
-    const snapshot = collectWorkspaceSnapshot([tab], [session], "t1", "/tmp/a");
+    const snapshot = collectWorkspaceSnapshot(
+      [tab],
+      [session],
+      "t1",
+      "/tmp/a",
+      new Map(),
+    );
     expect(snapshot.activeTabId).toBe("t1");
     expect(snapshot.tabs[0]?.editorPanes[0]?.files[0]?.path).toBe(
       "/tmp/a/README.md",
@@ -59,7 +184,13 @@ describe("collectWorkspaceSnapshot", () => {
       id: "t1",
       editorPanes: [{ id: "e1", files: [file], activeFileId: file.id }],
     };
-    const snapshot = collectWorkspaceSnapshot([tab], [], "t1", "/tmp/a");
+    const snapshot = collectWorkspaceSnapshot(
+      [tab],
+      [],
+      "t1",
+      "/tmp/a",
+      new Map(),
+    );
     const workspace = hydrateWorkspaceSnapshot(snapshot, new Map());
     const restored = workspace?.tabs[0]?.editorPanes[0]?.files[0];
     expect(restored?.changes).toBe(true);
@@ -79,7 +210,13 @@ describe("collectWorkspaceSnapshot", () => {
       id: "t1",
       editorPanes: [{ id: "e1", files: [file], activeFileId: file.id }],
     };
-    const snapshot = collectWorkspaceSnapshot([tab], [], "t1", "/tmp/a");
+    const snapshot = collectWorkspaceSnapshot(
+      [tab],
+      [],
+      "t1",
+      "/tmp/a",
+      new Map(),
+    );
     const restored = hydrateWorkspaceSnapshot(snapshot, new Map())?.tabs[0]
       ?.editorPanes[0]?.files[0];
     expect(restored?.sessionChanges).toEqual({ sessionId: "session-a" });
@@ -98,7 +235,13 @@ describe("collectWorkspaceSnapshot", () => {
       id: "t1",
       editorPanes: [{ id: "e1", files: [file], activeFileId: file.id }],
     };
-    const snapshot = collectWorkspaceSnapshot([tab], [], "t1", "/tmp/a");
+    const snapshot = collectWorkspaceSnapshot(
+      [tab],
+      [],
+      "t1",
+      "/tmp/a",
+      new Map(),
+    );
     const workspace = hydrateWorkspaceSnapshot(snapshot, new Map());
     const restored = workspace?.tabs[0]?.editorPanes[0]?.files[0];
     expect(restored?.commit).toEqual({
@@ -110,7 +253,13 @@ describe("collectWorkspaceSnapshot", () => {
 
   it("round-trips a release-note descriptor", () => {
     const tab = newReleaseNotesWorkspaceTab({ version: "0.1.22" });
-    const snapshot = collectWorkspaceSnapshot([tab], [], tab.id, "~");
+    const snapshot = collectWorkspaceSnapshot(
+      [tab],
+      [],
+      tab.id,
+      "~",
+      new Map(),
+    );
     const workspace = hydrateWorkspaceSnapshot(snapshot, new Map());
 
     expect(workspace?.tabs[0]?.editorPanes[0]?.files[0]?.releaseNotes).toEqual({
@@ -127,6 +276,7 @@ describe("collectWorkspaceSnapshot", () => {
       [],
       "t1",
       "/tmp/a",
+      new Map(),
       [dock],
     );
     expect(snapshot.projectTerminals).toEqual([
@@ -245,6 +395,7 @@ describe("hydrateWorkspaceSnapshot", () => {
       [left, right],
       "t1",
       "/tmp/a",
+      new Map(),
     );
     const loaded = new Map([
       [
@@ -281,6 +432,7 @@ describe("hydrateWorkspaceSnapshot", () => {
       [open, parked],
       "t1",
       "/tmp/a",
+      new Map(),
     );
     const workspace = hydrateWorkspaceSnapshot(
       snapshot,
@@ -308,7 +460,13 @@ describe("hydrateWorkspaceSnapshot", () => {
       editorPanes: [],
       terminalPanes: [{ id: "p1", files: [term], activeFileId: term.id }],
     };
-    const snapshot = collectWorkspaceSnapshot([tab], [], "t1", "/tmp/a");
+    const snapshot = collectWorkspaceSnapshot(
+      [tab],
+      [],
+      "t1",
+      "/tmp/a",
+      new Map(),
+    );
     const workspace = hydrateWorkspaceSnapshot(snapshot, new Map());
     expect(workspace?.tabs[0]?.terminalPanes[0]?.files[0]?.terminal).toBe(true);
   });
@@ -326,6 +484,7 @@ describe("hydrateWorkspaceSnapshot", () => {
       [],
       "t1",
       "/tmp/a",
+      new Map(),
       [dock],
     );
     const workspace = hydrateWorkspaceSnapshot(snapshot, new Map());

--- a/src/lib/workspaceSnapshot.test.ts
+++ b/src/lib/workspaceSnapshot.test.ts
@@ -41,8 +41,8 @@ describe("project return snapshots", () => {
     return {
       ...collectWorkspaceSnapshot(tabs, sessions, "tab-b2", "/beta", new Map()),
       projectReturnTargets: [
-        { projectPath: "/alpha", tabId: "tab-a2" },
-        { projectPath: "/beta", tabId: "tab-b2" },
+        { projectPath: "/alpha", tabId: "a2" },
+        { projectPath: "/beta", tabId: "b2" },
       ],
     };
   }
@@ -58,8 +58,8 @@ describe("project return snapshots", () => {
       id: `tab-${session.id}`,
     }));
     const memory = new Map([
-      ["/alpha", "tab-a2"],
-      ["/beta", "tab-b2"],
+      ["/alpha", "a2"],
+      ["/beta", "b2"],
       ["/gone", "missing"],
     ]);
     const snapshot = collectWorkspaceSnapshot(
@@ -71,23 +71,23 @@ describe("project return snapshots", () => {
     );
     const restored = hydrateWorkspaceSnapshot(snapshot, new Map());
     expect([...(restored?.projectReturnMemory ?? [])]).toEqual([
-      ["/alpha", "tab-a2"],
-      ["/beta", "tab-b2"],
+      ["/alpha", "a2"],
+      ["/beta", "b2"],
     ]);
     expect(memory.size).toBe(3);
   });
 
   it("restores both project choices, not just the active tab", () => {
     const restored = hydrateWorkspaceSnapshot(saved(), new Map());
-    expect(restored?.projectReturnMemory?.get("/alpha")).toBe("tab-a2");
-    expect(restored?.projectReturnMemory?.get("/beta")).toBe("tab-b2");
+    expect(restored?.projectReturnMemory?.get("/alpha")).toBe("a2");
+    expect(restored?.projectReturnMemory?.get("/beta")).toBe("b2");
   });
 
   it("loads old snapshots and seeds only the active project", () => {
     const { projectReturnTargets: _targets, ...old } = saved();
     const restored = hydrateWorkspaceSnapshot(old, new Map());
     expect([...(restored?.projectReturnMemory ?? [])]).toEqual([
-      ["/beta", "tab-b2"],
+      ["/beta", "b2"],
     ]);
   });
 
@@ -100,14 +100,14 @@ describe("project return snapshots", () => {
         42,
         {},
         { projectPath: "/alpha", tabId: 12 },
-        { projectPath: "/alpha/", tabId: "tab-a1" },
-        { projectPath: "/alpha", tabId: "tab-a2" },
+        { projectPath: "/alpha/", tabId: "a1" },
+        { projectPath: "/alpha", tabId: "a2" },
         { projectPath: "/gone", tabId: "missing" },
-        { projectPath: "/beta", tabId: "tab-a1" },
+        { projectPath: "/beta", tabId: "a1" },
       ],
     });
     expect(parsed?.projectReturnTargets).toEqual([
-      { projectPath: "/alpha", tabId: "tab-a2" },
+      { projectPath: "/alpha", tabId: "a2" },
     ]);
   });
 
@@ -118,7 +118,7 @@ describe("project return snapshots", () => {
       hydrateWorkspaceSnapshot(raw, new Map())?.projectReturnMemory?.get(
         "/beta",
       ),
-    ).toBe("tab-b2");
+    ).toBe("b2");
   });
 
   it.each([null, "broken", {}])(
@@ -130,7 +130,7 @@ describe("project return snapshots", () => {
       );
       expect(restored?.tabs).toHaveLength(4);
       expect([...(restored?.projectReturnMemory ?? [])]).toEqual([
-        ["/beta", "tab-b2"],
+        ["/beta", "b2"],
       ]);
     },
   );
@@ -141,7 +141,7 @@ describe("project return snapshots", () => {
       new Map([["a2", chat("a2", "/moved")]]),
     );
     expect(restored?.projectReturnMemory?.has("/alpha")).toBe(false);
-    expect(restored?.projectReturnMemory?.get("/beta")).toBe("tab-b2");
+    expect(restored?.projectReturnMemory?.get("/beta")).toBe("b2");
   });
 });
 

--- a/src/lib/workspaceSnapshot.ts
+++ b/src/lib/workspaceSnapshot.ts
@@ -51,7 +51,7 @@ export type WorkspaceSnapshot = {
   activeTabId: string;
   projectCwd: string;
   projectTerminals: ProjectTerminalDock[];
-  projectReturnTargets?: { projectPath: string; tabId: string }[];
+  projectReturnTargets?: { projectPath: string; tabId?: string; paneId?: string }[];
 };
 
 export function collectWorkspaceSnapshot(
@@ -85,9 +85,9 @@ function withProjectReturnTargets(
   });
   return {
     ...snapshot,
-    projectReturnTargets: [...valid].map(([projectPath, tabId]) => ({
+    projectReturnTargets: [...valid].map(([projectPath, paneId]) => ({
       projectPath,
-      tabId,
+      tabId: paneId,
     })),
   };
 }
@@ -97,15 +97,16 @@ function parseProjectReturnTargets(raw: unknown): ProjectReturnMemory {
   if (!Array.isArray(raw)) return memory;
   for (const entry of raw) {
     if (!entry || typeof entry !== "object") continue;
-    if (
-      !("projectPath" in entry) ||
-      typeof entry.projectPath !== "string" ||
-      !entry.projectPath.trim() ||
-      !("tabId" in entry) ||
-      typeof entry.tabId !== "string" ||
-      !entry.tabId.trim()
-    ) continue;
-    memory.set(pathKey(entry.projectPath), entry.tabId);
+    if (!("projectPath" in entry)) continue;
+    const projectPath = (entry as { projectPath?: unknown }).projectPath;
+    if (typeof projectPath !== "string" || !projectPath.trim()) continue;
+
+    const remembered =
+      (entry as { paneId?: unknown }).paneId ??
+      (entry as { tabId?: unknown }).tabId;
+    if (typeof remembered !== "string" || !remembered.trim()) continue;
+
+    memory.set(pathKey(projectPath), remembered.trim());
   }
   return memory;
 }

--- a/src/lib/workspaceSnapshot.ts
+++ b/src/lib/workspaceSnapshot.ts
@@ -19,6 +19,8 @@ import {
   type ProjectTerminalDock,
 } from "./projectTerminal";
 import { normalizeProjectPath } from "./recents";
+import { pathKey } from "./paths";
+import { reconcileProjectReturn, type ProjectReturnMemory } from "./projectReturn";
 import type { InboxAskContext } from "./inboxAsk";
 import {
   HARNESSES,
@@ -49,6 +51,7 @@ export type WorkspaceSnapshot = {
   activeTabId: string;
   projectCwd: string;
   projectTerminals: ProjectTerminalDock[];
+  projectReturnTargets?: { projectPath: string; tabId: string }[];
 };
 
 export function collectWorkspaceSnapshot(
@@ -56,9 +59,10 @@ export function collectWorkspaceSnapshot(
   sessions: Session[],
   activeTabId: string,
   projectCwd: string,
+  memory: ProjectReturnMemory,
   projectTerminals: ProjectTerminalDock[] = [],
 ): WorkspaceSnapshot {
-  return withoutInboxSessions({
+  const snapshot = withoutInboxSessions({
     tabs: tabs.map(sanitizeTab).filter((tab): tab is WorkspaceTab => tab != null),
     sessions: sessions.map(sessionStub).filter((stub): stub is WorkspaceSessionStub => stub != null),
     activeTabId,
@@ -67,6 +71,43 @@ export function collectWorkspaceSnapshot(
       .map(sanitizeProjectTerminal)
       .filter((dock): dock is ProjectTerminalDock => dock != null),
   });
+  return withProjectReturnTargets(snapshot, memory);
+}
+
+function withProjectReturnTargets(
+  snapshot: WorkspaceSnapshot,
+  memory: ProjectReturnMemory,
+): WorkspaceSnapshot {
+  const valid = reconcileProjectReturn({
+    ...snapshot,
+    memory,
+    activeTabId: "",
+  });
+  return {
+    ...snapshot,
+    projectReturnTargets: [...valid].map(([projectPath, tabId]) => ({
+      projectPath,
+      tabId,
+    })),
+  };
+}
+
+function parseProjectReturnTargets(raw: unknown): ProjectReturnMemory {
+  const memory = new Map<string, string>();
+  if (!Array.isArray(raw)) return memory;
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    if (
+      !("projectPath" in entry) ||
+      typeof entry.projectPath !== "string" ||
+      !entry.projectPath.trim() ||
+      !("tabId" in entry) ||
+      typeof entry.tabId !== "string" ||
+      !entry.tabId.trim()
+    ) continue;
+    memory.set(pathKey(entry.projectPath), entry.tabId);
+  }
+  return memory;
 }
 
 /** Also removes tabs saved by the earlier, persistent Inbox implementation. */
@@ -99,6 +140,7 @@ export function parseWorkspaceSnapshot(raw: unknown): WorkspaceSnapshot | null {
     activeTabId?: unknown;
     projectCwd?: unknown;
     projectTerminals?: unknown;
+    projectReturnTargets?: unknown;
   };
   if (!Array.isArray(value.tabs) || typeof value.activeTabId !== "string") {
     return null;
@@ -125,7 +167,12 @@ export function parseWorkspaceSnapshot(raw: unknown): WorkspaceSnapshot | null {
         .filter((dock): dock is ProjectTerminalDock => dock != null)
     : [];
   const snapshot = withoutInboxSessions({ tabs, sessions, activeTabId, projectCwd, projectTerminals });
-  return snapshot.tabs.length > 0 ? snapshot : null;
+  return snapshot.tabs.length > 0
+    ? withProjectReturnTargets(
+        snapshot,
+        parseProjectReturnTargets(value.projectReturnTargets),
+      )
+    : null;
 }
 
 export function workspaceSnapshotKey(snapshot: WorkspaceSnapshot): string {
@@ -210,6 +257,12 @@ export function hydrateWorkspaceSnapshot(
     activeTabId,
     projectCwd,
     projectTerminals: parsed.projectTerminals,
+    projectReturnMemory: reconcileProjectReturn({
+      memory: parseProjectReturnTargets(parsed.projectReturnTargets),
+      tabs,
+      sessions: [...sessions.values()],
+      activeTabId,
+    }),
   };
 }
 

--- a/src/lib/workspaceTabGroups.test.ts
+++ b/src/lib/workspaceTabGroups.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { leafIds, newTab, type WorkspaceTab } from "./layout";
+import {
+  leafIds,
+  newFileTab,
+  newTerminalFile,
+  newTab,
+  splitPane,
+  type WorkspaceTab,
+} from "./layout";
+import { planProjectReturn } from "./projectReturn";
 import type { Session } from "./session";
 import {
   applyPlaceSessionOnPane,
@@ -8,6 +16,8 @@ import {
   planWorkspaceTabClose,
   replaceGroupInTabOrder,
   workspaceTabProject,
+  focusedWorkspaceTabCwd,
+  workspaceTabCwd,
 } from "./workspaceTabGroups";
 
 function session(id: string, cwd: string): Session {
@@ -25,6 +35,67 @@ function session(id: string, cwd: string): Session {
 function tab(id: string, sessionId: string): WorkspaceTab {
   return { ...newTab(sessionId), id };
 }
+
+describe("focusedWorkspaceTabCwd", () => {
+  it.each(["editor", "terminal"] as const)(
+    "uses the restored %s pane's project instead of the first chat's project",
+    (kind) => {
+      const sessions = [session("chat", "/alpha")];
+      const file =
+        kind === "editor"
+          ? newFileTab("/beta/readme.md", "/beta")
+          : newTerminalFile("/beta");
+      const pane = { id: "surface", files: [file], activeFileId: file.id };
+      const mixed: WorkspaceTab = {
+        ...tab("mixed", "chat"),
+        layout: splitPane(newTab("chat").layout, "chat", "h", pane.id),
+        editorPanes: kind === "editor" ? [pane] : [],
+        terminalPanes: kind === "terminal" ? [pane] : [],
+      };
+      const decision = planProjectReturn({
+        tabs: [mixed],
+        sessions,
+        memory: new Map([["/beta", pane.id]]),
+        activeTabId: mixed.id,
+        projectPath: "/beta",
+      });
+      expect(decision).toEqual({
+        action: "activate",
+        tabId: mixed.id,
+        paneId: pane.id,
+      });
+      if (decision.action !== "activate" || !decision.paneId) {
+        throw new Error("Expected pane activation");
+      }
+      const focusedTab = { ...mixed, focusedId: decision.paneId };
+      expect(workspaceTabCwd(focusedTab, sessions)).toBe("/alpha");
+      expect(focusedWorkspaceTabCwd(focusedTab, sessions)).toBe("/beta");
+      expect(mixed.focusedId).toBe("chat");
+    },
+  );
+
+  it("prefers the focused chat over the first chat", () => {
+    const mixed = {
+      ...tab("mixed", "first"),
+      layout: splitPane(newTab("first").layout, "first", "h", "second"),
+      focusedId: "second",
+    };
+    expect(
+      focusedWorkspaceTabCwd(mixed, [
+        session("first", "/alpha"),
+        session("second", "/beta"),
+      ]),
+    ).toBe("/beta");
+  });
+
+  it("retains the tab fallback when the focused pane has no cwd", () => {
+    const mixed = { ...tab("mixed", "chat"), focusedId: "missing" };
+    expect(focusedWorkspaceTabCwd(mixed, [session("chat", "/alpha")])).toBe(
+      "/alpha",
+    );
+    expect(focusedWorkspaceTabCwd(mixed, [])).toBeNull();
+  });
+});
 
 describe("workspaceTabProject", () => {
   it("reads project from the tab session cwd", () => {

--- a/src/lib/workspaceTabGroups.test.ts
+++ b/src/lib/workspaceTabGroups.test.ts
@@ -48,7 +48,7 @@ describe("focusedWorkspaceTabCwd", () => {
       const pane = { id: "surface", files: [file], activeFileId: file.id };
       const mixed: WorkspaceTab = {
         ...tab("mixed", "chat"),
-        layout: splitPane(newTab("chat").layout, "chat", "h", pane.id),
+        layout: splitPane(newTab("chat").layout, "chat", "right", pane.id),
         editorPanes: kind === "editor" ? [pane] : [],
         terminalPanes: kind === "terminal" ? [pane] : [],
       };
@@ -77,7 +77,7 @@ describe("focusedWorkspaceTabCwd", () => {
   it("prefers the focused chat over the first chat", () => {
     const mixed = {
       ...tab("mixed", "first"),
-      layout: splitPane(newTab("first").layout, "first", "h", "second"),
+      layout: splitPane(newTab("first").layout, "first", "right", "second"),
       focusedId: "second",
     };
     expect(

--- a/src/lib/workspaceTabGroups.ts
+++ b/src/lib/workspaceTabGroups.ts
@@ -27,6 +27,16 @@ export function workspaceTabCwd(
   return null;
 }
 
+export function focusedWorkspaceTabCwd(
+  tab: WorkspaceTab,
+  sessions: readonly Pick<Session, "id" | "cwd">[],
+): string | null {
+  const session = sessions.find((entry) => entry.id === tab.focusedId);
+  return (
+    session?.cwd ?? focusedFileTab(tab)?.cwd ?? workspaceTabCwd(tab, sessions)
+  );
+}
+
 export function workspaceTabProject(
   tab: WorkspaceTab,
   sessions: Session[],

--- a/src/lib/workspaceTabGroups.ts
+++ b/src/lib/workspaceTabGroups.ts
@@ -14,7 +14,7 @@ import type { Session } from "./session";
 
 export function workspaceTabCwd(
   tab: WorkspaceTab,
-  sessions: Session[],
+  sessions: readonly Pick<Session, "id" | "cwd">[],
 ): string | null {
   for (const id of leafIds(tab.layout)) {
     const session = sessions.find((entry) => entry.id === id);


### PR DESCRIPTION
## What changed

Navigating between projects now keeps track of sessions that are opened

## Why

Before now, selecting a project always picks the first session.

## UI

<img width="800" height="501" alt="CleanShot 2026-09-09 at 16 46 50" src="https://github.com/user-attachments/assets/26313a3b-4c7b-48f6-af55-e42310fdb3a7" />


## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app remembers the last pane used for each project.
  * Returning to a project restores its remembered pane when available.
  * Project choices persist across autosaves, workspace restores, app quits, and window closes.
  * Project switching can reuse suitable panes or blank sessions, avoid busy sessions, or create a new session when needed.
  * Saved project-return choices are validated, with stale or invalid references discarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->