### PR TITLE
Replace native Settings model select with Popover picker

### DIFF
--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowDownCircle,
   Check,
+  ChevronDown,
   ImagePlus,
   Loader,
   RefreshCw,
@@ -14,9 +15,11 @@ import {
   useRef,
   useState,
   useSyncExternalStore,
+  type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
 import { HarnessIcon } from "../chrome/HarnessIcon";
+import { Popover } from "../chrome/Popover";
 import { InboxProviderMark } from "../chrome/InboxProviderMark";
 import { RemoveProjectDialog } from "../chrome/RemoveProjectDialog";
 import { WindowControls } from "../chrome/WindowControls";
@@ -1897,19 +1900,125 @@ function Select({
   options: { value: string; label: string }[];
   onChange: (value: string) => void;
 }) {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(() =>
+    Math.max(
+      0,
+      options.findIndex((option) => option.value === value),
+    ),
+  );
+  const root = useRef<HTMLDivElement>(null);
+  const selected = options.find((option) => option.value === value);
+
+  useEffect(() => {
+    if (!open) return;
+    setActive(
+      Math.max(
+        0,
+        options.findIndex((option) => option.value === value),
+      ),
+    );
+  }, [open, value, options]);
+
+  const pick = (next: string) => {
+    onChange(next);
+    setOpen(false);
+  };
+
+  const onMenuKey = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActive((i) => Math.min(options.length - 1, i + 1));
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActive((i) => Math.max(0, i - 1));
+      return;
+    }
+    if (e.key === "Home") {
+      e.preventDefault();
+      setActive(0);
+      return;
+    }
+    if (e.key === "End") {
+      e.preventDefault();
+      setActive(options.length - 1);
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const option = options[active];
+      if (option) pick(option.value);
+    }
+  };
+
   return (
-    <select
-      aria-label={label}
-      value={value}
-      onChange={(event) => onChange(event.target.value)}
-      className="max-w-52 rounded-md border border-content/10 bg-content/5 px-2 py-1 text-[12px] text-content outline-none hover:border-content/20"
-    >
-      {options.map((option) => (
-        <option key={option.value} value={option.value}>
-          {option.label}
-        </option>
-      ))}
-    </select>
+    <div ref={root} className="relative max-w-52">
+      <button
+        type="button"
+        aria-label={label}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex w-full items-center justify-between gap-2 rounded-md border border-content/10 bg-content/5 px-2 py-1 text-left text-[12px] text-content outline-none hover:border-content/20"
+      >
+        <span className="min-w-0 flex-1 truncate">
+          {selected ? selected.label : value}
+        </span>
+        <ChevronDown
+          className={`size-3.5 shrink-0 text-content/50 transition-transform ${open ? "rotate-180" : ""}`}
+          strokeWidth={1.75}
+        />
+      </button>
+      {open ? (
+        <Popover
+          anchor={root}
+          side="bottom"
+          align="end"
+          width={280}
+          maxHeight={320}
+          autoFocus
+          onDismiss={() => setOpen(false)}
+          role="listbox"
+          aria-label={label}
+          tabIndex={-1}
+          onKeyDown={onMenuKey}
+          className="overflow-y-auto overscroll-contain p-1"
+        >
+          {options.map((option, index) => {
+            const isSelected = option.value === value;
+            const highlighted = index === active;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                onMouseDown={(e) => e.preventDefault()}
+                onMouseEnter={() => setActive(index)}
+                onClick={() => pick(option.value)}
+                className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[12px] ${
+                  highlighted || isSelected
+                    ? "bg-content/10 text-content"
+                    : "text-content hover:bg-content/5"
+                }`}
+              >
+                <span className="min-w-0 flex-1 truncate">
+                  {option.label}
+                </span>
+                {isSelected ? (
+                  <Check
+                    className="size-3.5 shrink-0"
+                    strokeWidth={2.25}
+                  />
+                ) : null}
+              </button>
+            );
+          })}
+        </Popover>
+      ) : null}
+    </div>
   );
 }
 

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -1911,6 +1911,7 @@ function Select({
   );
   const root = useRef<HTMLDivElement>(null);
   const trigger = useRef<HTMLButtonElement>(null);
+  const activeOption = useRef<HTMLButtonElement>(null);
   const listId = useId();
   const selected = options.find((option) => option.value === value);
   const activeId =
@@ -1925,6 +1926,11 @@ function Select({
       ),
     );
   }, [open, value, options]);
+
+  useEffect(() => {
+    if (!open) return;
+    activeOption.current?.scrollIntoView({ block: "nearest" });
+  }, [active, open]);
 
   const pick = (next: string) => {
     onChange(next);
@@ -1953,6 +1959,13 @@ function Select({
       setActive(options.length - 1);
       return;
     }
+    if (e.key === "Tab") {
+      const option = options[active];
+      if (option && option.value !== value) onChange(option.value);
+      setOpen(false);
+      trigger.current?.focus();
+      return;
+    }
     if (e.key === "Enter") {
       e.preventDefault();
       const option = options[active];
@@ -1965,7 +1978,7 @@ function Select({
       <button
         type="button"
         ref={trigger}
-        aria-label={label}
+        aria-label={`${label}: ${selected?.label ?? value}`}
         aria-expanded={open}
         aria-haspopup="listbox"
         onClick={() => setOpen((prev) => !prev)}
@@ -2004,6 +2017,7 @@ function Select({
             return (
               <button
                 key={option.value}
+                ref={highlighted ? activeOption : undefined}
                 type="button"
                 id={`${listId}-opt-${index}`}
                 role="option"

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -11,6 +11,7 @@ import {
 import {
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -1908,7 +1909,11 @@ function Select({
     ),
   );
   const root = useRef<HTMLDivElement>(null);
+  const trigger = useRef<HTMLButtonElement>(null);
+  const listId = useId();
   const selected = options.find((option) => option.value === value);
+  const activeId =
+    options[active] != null ? `${listId}-opt-${active}` : undefined;
 
   useEffect(() => {
     if (!open) return;
@@ -1923,6 +1928,7 @@ function Select({
   const pick = (next: string) => {
     onChange(next);
     setOpen(false);
+    trigger.current?.focus();
   };
 
   const onMenuKey = (e: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -1957,6 +1963,7 @@ function Select({
     <div ref={root} className="relative max-w-52">
       <button
         type="button"
+        ref={trigger}
         aria-label={label}
         aria-expanded={open}
         aria-haspopup="listbox"
@@ -1979,9 +1986,13 @@ function Select({
           width={280}
           maxHeight={320}
           autoFocus
-          onDismiss={() => setOpen(false)}
+          onDismiss={(reason) => {
+            setOpen(false);
+            if (reason === "escape") trigger.current?.focus();
+          }}
           role="listbox"
           aria-label={label}
+          aria-activedescendant={activeId}
           tabIndex={-1}
           onKeyDown={onMenuKey}
           className="overflow-y-auto overscroll-contain p-1"
@@ -1993,7 +2004,9 @@ function Select({
               <button
                 key={option.value}
                 type="button"
+                id={`${listId}-opt-${index}`}
                 role="option"
+                tabIndex={-1}
                 aria-selected={isSelected}
                 onMouseDown={(e) => e.preventDefault()}
                 onMouseEnter={() => setActive(index)}

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -1890,6 +1890,7 @@ function Toggle({
   );
 }
 
+/** Theme-aware dropdown for a Settings row: a trigger button opening a Popover listbox. Used instead of a native select, whose option popup is OS-rendered and unreadable in dark mode on Windows/Linux. */
 function Select({
   label,
   value,


### PR DESCRIPTION
## What changed

Replaced the native `<select>` in the Settings model rows with the app's theme-aware `Popover` picker, following the existing `AccessPicker` pattern (button trigger + `listbox`/`option` roles, keyboard nav, selected check mark).

## Why

Fixes #148. The native option popup is OS-rendered: on Windows (and likely Linux) the list paints white while the option text inherits the light dark-mode `text-content` color, so model names are unreadable until hovered.

## UI

Before: white OS popup with washed-out pale options.
<img width="501" height="475" alt="image" src="https://github.com/user-attachments/assets/ddeb3aff-f640-4954-a267-9722c1bb9178" />


After: dark glass `Popover` matching the app theme.

<img width="529" height="595" alt="image" src="https://github.com/user-attachments/assets/c2d623c9-0226-49b5-8c3d-ea6bc60a24b7" />

## Checklist

- [x] I ran `npm run check:web` (vitest: 141 files / 1437 tests passed, `tsc --noEmit` clean; no Rust changes so `check:rust` is unaffected)
- [x] This PR is small and focused
- [x] I did not mix unrelated changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved settings selectors with keyboard navigation, active-option highlighting, and clearer focus management.
  - Added support for Arrow keys, Home/End, Enter, Tab, and Escape interactions.
  - Focus is restored to the selector after choosing an option or dismissing the menu.
  - Added mouse selection and improved visibility of selection menus in dark mode.
  - Selected options now provide clearer labels for assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->