### PR TITLE
Add middle-click tab closing

### DIFF
--- a/src/chrome/SurfaceTabs.tsx
+++ b/src/chrome/SurfaceTabs.tsx
@@ -269,6 +269,15 @@ export function SurfaceTabs({
             } ${dragging ? "opacity-40" : ""} ${
               canDrag ? "cursor-grab active:cursor-grabbing" : ""
             }`}
+            onMouseDownCapture={(event) => {
+              if (event.button === 1) event.preventDefault();
+            }}
+            onAuxClick={(event) => {
+              if (event.button !== 1) return;
+              event.preventDefault();
+              event.stopPropagation();
+              onCloseFile(file.id);
+            }}
             onPointerDown={(event) => {
               if (event.button !== 0) return;
               if (

--- a/src/chrome/TabMiddleClick.test.ts
+++ b/src/chrome/TabMiddleClick.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment happy-dom
+import { act, createElement, type ComponentProps } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SurfaceTabs } from "./SurfaceTabs";
+import { TitleBar, type Tab } from "./TitleBar";
+
+vi.mock("./WindowControls", () => ({ WindowControls: () => null }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+function mouse(target: Element, type: string, button: number) {
+  const EventClass = type.startsWith("pointer") ? PointerEvent : MouseEvent;
+  const event = new EventClass(type, {
+    button,
+    bubbles: true,
+    cancelable: true,
+  });
+  act(() => target.dispatchEvent(event));
+  return event;
+}
+
+function click(target: Element, button: number) {
+  mouse(target, "pointerdown", button);
+  const down = mouse(target, "mousedown", button);
+  mouse(target, "pointerup", button);
+  mouse(target, "mouseup", button);
+  const up = mouse(target, button === 0 ? "click" : "auxclick", button);
+  return { down, up };
+}
+
+function workspaceTab(id: string): Tab {
+  return {
+    id,
+    project: "project",
+    title: id,
+    more: [],
+    sessionCount: 1,
+    harnesses: [],
+    busyHarnesses: [],
+    files: [],
+  };
+}
+
+function renderTabs(
+  kind: "workspace" | "file" | "terminal",
+  activeId = "first",
+) {
+  const onClose = vi.fn();
+  const onSelect = vi.fn();
+  const onReorder = vi.fn();
+  if (kind === "workspace") {
+    act(() =>
+      root.render(
+        createElement(TitleBar, {
+          tabs: [workspaceTab("first"), workspaceTab("second")],
+          activeId,
+          cwd: "/project",
+          onToggleSidebar: vi.fn(),
+          onNew: vi.fn(),
+          onSelect,
+          onClose,
+          onCloseMany: vi.fn(),
+          onReorder,
+        }),
+      ),
+    );
+  } else {
+    act(() =>
+      root.render(
+        createElement(SurfaceTabs, {
+          files: ["first", "second"].map((id) => ({
+            id,
+            path: id,
+            cwd: "/project",
+            ...(kind === "terminal"
+              ? { terminal: true, foreground: "vite" }
+              : {}),
+          })),
+          activeFileId: activeId,
+          dirtyFileIds: new Set(kind === "file" ? ["second"] : []),
+          fileErrorCounts: new Map(),
+          onSelectFile: onSelect,
+          onCloseFile: onClose,
+          onReorder,
+        }),
+      ),
+    );
+  }
+  const closeButton = container.querySelector('[aria-label="Close second"]')!;
+  const tab = closeButton.parentElement!.querySelector("button")!;
+  return { onClose, onSelect, onReorder, tab, closeButton };
+}
+
+describe.each(["workspace", "file", "terminal"] as const)(
+  "%s tab mouse gestures",
+  (kind) => {
+    it.each(["first", "second"])(
+      "closes on middle release without selecting, active tab is %s",
+      (activeId) => {
+        const { tab, onClose, onSelect, onReorder } = renderTabs(
+          kind,
+          activeId,
+        );
+        const { down, up } = click(tab, 1);
+        expect(down.defaultPrevented).toBe(true);
+        expect(up.defaultPrevented).toBe(true);
+        expect(onClose).toHaveBeenCalledExactlyOnceWith("second");
+        expect(onSelect).not.toHaveBeenCalled();
+        expect(onReorder).not.toHaveBeenCalled();
+      },
+    );
+
+    it("does not close on middle press alone", () => {
+      const { tab, onClose, onSelect } = renderTabs(kind);
+      mouse(tab, "pointerdown", 1);
+      mouse(tab, "mousedown", 1);
+      expect(onClose).not.toHaveBeenCalled();
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it.each(["icon", "padding", "close button"])(
+      "accepts middle clicks on the %s",
+      (target) => {
+        const { tab, closeButton, onClose, onSelect } = renderTabs(kind);
+        const element =
+          target === "icon"
+            ? tab.firstElementChild!
+            : target === "padding"
+              ? tab.parentElement!
+              : closeButton;
+        const { down, up } = click(element, 1);
+        expect(down.defaultPrevented).toBe(true);
+        expect(up.defaultPrevented).toBe(true);
+        expect(onClose).toHaveBeenCalledExactlyOnceWith("second");
+        expect(onSelect).not.toHaveBeenCalled();
+      },
+    );
+
+    it("keeps left-click selection and the close button working", () => {
+      const { tab, closeButton, onClose, onSelect } = renderTabs(kind);
+      click(tab, 0);
+      expect(onSelect).toHaveBeenCalledWith("second");
+      expect(onClose).not.toHaveBeenCalled();
+      onSelect.mockClear();
+      click(closeButton, 0);
+      expect(onClose).toHaveBeenCalledExactlyOnceWith("second");
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("does not close on right click", () => {
+      const { tab, onClose } = renderTabs(kind);
+      const { down, up } = click(tab, 2);
+      expect(down.defaultPrevented).toBe(false);
+      expect(up.defaultPrevented).toBe(false);
+      mouse(tab, "contextmenu", 2);
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  },
+);
+
+it("keeps the sole blank workspace tab open", () => {
+  const onClose = vi.fn();
+  const props: ComponentProps<typeof TitleBar> = {
+    tabs: [{ ...workspaceTab("blank"), blank: true }],
+    activeId: "blank",
+    cwd: "/project",
+    onToggleSidebar: vi.fn(),
+    onNew: vi.fn(),
+    onSelect: vi.fn(),
+    onClose,
+    onCloseMany: vi.fn(),
+    onReorder: vi.fn(),
+  };
+  act(() => root.render(createElement(TitleBar, props)));
+  const tab = container.querySelector('[aria-label="project · blank"]')!;
+  expect(tab).not.toBeNull();
+  click(tab, 1);
+  expect(onClose).not.toHaveBeenCalled();
+});

--- a/src/chrome/TitleBar.tsx
+++ b/src/chrome/TitleBar.tsx
@@ -268,6 +268,15 @@ function TitleTabItem({
         event.stopPropagation();
         onContextMenu(tab.id, event);
       }}
+      onMouseDownCapture={(event) => {
+        if (event.button === 1) event.preventDefault();
+      }}
+      onAuxClick={(event) => {
+        if (event.button !== 1 || !closable) return;
+        event.preventDefault();
+        event.stopPropagation();
+        onClose(tab.id);
+      }}
       onPointerDown={(event) => {
         if (event.button !== 0) return;
         if ((event.target as HTMLElement | null)?.closest("[data-no-drag]")) {


### PR DESCRIPTION
## What changed

Middle-clicking a workspace, file, or terminal tab closes it through the same handler as its X button. Closing a background tab does not select it first, and the last blank workspace tab stays open.

## Why

The tab-closing gesture browsers use, without aiming for the X button.

## UI

No layout change. Existing unsaved-file and running-terminal confirmations still apply, since middle click reuses the same close path.

Before, with the background tab about to be middle-clicked:

![Two workspace tabs open, the active one holding a composer draft](https://raw.githubusercontent.com/50BytesOfJohn/monocode/pr-assets/tabs-before-middle-click.png)

After, with the background tab closed and the active tab's draft intact:

![One workspace tab left, its composer draft unchanged](https://raw.githubusercontent.com/50BytesOfJohn/monocode/pr-assets/tabs-after-middle-click.png)

Verified in the macOS desktop app: active and background workspace tabs, terminal close, the unsaved-file prompt, and a background close leaving the active draft alone. Not verified on Windows or Linux. Windows is where the `mousedown` `preventDefault` earns its keep, since WebView2 is the engine that starts autoscroll on middle press.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes

Green on `npm run check` with Rust 1.88.0: 1,489 web tests, 230 Rust tests, `tsc --noEmit`, `cargo fmt`, and Clippy. `npm run build` passes.

Covered by DOM tests: middle click on the tab, its icon, its padding, and its close button; middle press alone; left-click selection and the X button still working; right click not closing; and the last blank workspace tab staying open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Middle-clicking a closable workspace, file, or terminal tab now closes it.
  * Middle-clicking tab icons, padding, or other tab areas is supported.

* **Bug Fixes**
  * Prevented middle-click from triggering unwanted browser behaviors such as automatic scrolling.
  * The default blank workspace tab remains protected from closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->