### PR TITLE
Fix OMP advisor interjection rendering

### DIFF
--- a/src/lib/harness/apply.test.ts
+++ b/src/lib/harness/apply.test.ts
@@ -161,6 +161,55 @@ describe("status blocks", () => {
   });
 });
 
+describe("interjection blocks", () => {
+  it("seals assistant streams on both sides of the boundary", () => {
+    let session = appendUser(newSession("pi", "/tmp"), "go");
+    session = applyHarnessEvent(session, {
+      type: "message.delta",
+      text: "Complete answer.",
+    });
+    session = applyHarnessEvent(session, {
+      type: "interjection",
+      text: "Check the fallback.",
+      customType: "advisor",
+    });
+    session = applyHarnessEvent(session, {
+      type: "message.delta",
+      text: "Checked.",
+    });
+
+    expect(session.blocks.slice(1)).toMatchObject([
+      { role: "assistant", text: "Complete answer.", streaming: false },
+      { role: "system", interjection: { customType: "advisor" } },
+      { role: "assistant", text: "Checked.", streaming: true },
+    ]);
+  });
+
+  it("appends every interjection as a distinct persisted boundary", () => {
+    let session = appendUser(newSession("pi", "/tmp"), "go");
+    session = applyHarnessEvent(session, {
+      type: "interjection",
+      text: "Check the fallback.",
+      customType: "advisor",
+      severity: "concern",
+    });
+    session = applyHarnessEvent(session, {
+      type: "interjection",
+      text: "Check the fallback.",
+      customType: "advisor",
+      severity: "concern",
+    });
+
+    const interjections = session.blocks.filter((block) => block.interjection);
+    expect(interjections).toHaveLength(2);
+    expect(interjections[0]).toMatchObject({
+      role: "system",
+      text: "Check the fallback.",
+      interjection: { customType: "advisor", severity: "concern" },
+    });
+  });
+});
+
 describe("task list updates", () => {
   it("updates one structured checklist instead of appending plan cards", () => {
     let session = appendUser(newSession("codex", "/tmp"), "fix it");
@@ -454,17 +503,26 @@ describe("applyHarnessEvent context", () => {
 describe("tool enrichment", () => {
   it("retains Edit and Write previews when a tool completes without repeating its input", () => {
     for (const [name, input] of [
-      ["Edit", { file_path: "/notes.md", old_string: "old", new_string: "new" }],
+      [
+        "Edit",
+        { file_path: "/notes.md", old_string: "old", new_string: "new" },
+      ],
       ["Write", { file_path: "/notes.md", content: "  content\n" }],
       ["Write", { file_path: "/notes.md", content: "" }],
     ] as const) {
       const preview = previewFromTool(name, input)!;
       let session = applyHarnessEvent(newSession("claude", "/repo"), {
-        type: "tool.started", callId: "edit", title: name, kind: "edit",
-        status: "pending", preview,
+        type: "tool.started",
+        callId: "edit",
+        title: name,
+        kind: "edit",
+        status: "pending",
+        preview,
       });
       session = applyHarnessEvent(session, {
-        type: "tool.updated", callId: "edit", status: "completed",
+        type: "tool.updated",
+        callId: "edit",
+        status: "completed",
       });
       expect(session.blocks[0].tool?.preview).toMatchObject(preview);
       expect(session.blocks[0].tool?.preview?.lines).toEqual(preview.lines);

--- a/src/lib/harness/apply.ts
+++ b/src/lib/harness/apply.ts
@@ -102,11 +102,28 @@ export function applyHarnessEvent(
         ...session,
         ...(event.model ? { model: event.model } : {}),
         ...(event.modelSettings
-          ? { modelSettings: { ...session.modelSettings, ...event.modelSettings } }
+          ? {
+              modelSettings: {
+                ...session.modelSettings,
+                ...event.modelSettings,
+              },
+            }
           : {}),
       };
     case "status":
       return appendStatus(session, event.text);
+    case "interjection":
+      // A visible boundary the user must not miss, so unlike status it never
+      // deduplicates and never reads as turn lifecycle.
+      return appendBlock(session, {
+        id: crypto.randomUUID(),
+        role: "system",
+        text: event.text,
+        interjection: {
+          customType: event.customType,
+          ...(event.severity ? { severity: event.severity } : {}),
+        },
+      });
     default:
       return session;
   }

--- a/src/lib/harness/ompLive.test.ts
+++ b/src/lib/harness/ompLive.test.ts
@@ -392,6 +392,100 @@ describe("OMP command lifecycle over the real RPC multiplexer", () => {
       1,
     );
   });
+
+  it("surfaces displayed OMP advisor notes and hides internal messages", async () => {
+    const running = await started();
+    const advisor = {
+      role: "custom",
+      customType: "advisor",
+      display: true,
+      content: "raw advisory envelope",
+      details: {
+        notes: [
+          { note: "Minor note", severity: "nit" },
+          { note: "Stop here", severity: "blocker" },
+        ],
+      },
+    };
+    frame("omp-test", { type: "message_start", message: advisor });
+    frame("omp-test", { type: "message_end", message: advisor });
+    frame("omp-test", {
+      type: "message_start",
+      message: {
+        role: "custom",
+        customType: "xdev-mount-notice",
+        display: false,
+        content: "internal mount details",
+      },
+    });
+    frame("omp-test", { type: "advisor_yielded" });
+
+    expect(events).toContainEqual({
+      type: "interjection",
+      text: "Minor note\n\nStop here",
+      customType: "advisor",
+      severity: "blocker",
+    });
+    expect(
+      events.filter((event) => event.type === "interjection"),
+    ).toHaveLength(1);
+    expect(
+      events.some(
+        (event) => "text" in event && event.text === "internal mount details",
+      ),
+    ).toBe(false);
+    frame("omp-test", { type: "agent_end" });
+    await running.turn;
+  });
+
+  it("uses generic content for other displayed OMP custom messages", async () => {
+    const running = await started();
+    frame("omp-test", {
+      type: "message_start",
+      message: {
+        role: "custom",
+        customType: "extension-notice",
+        display: true,
+        content: [
+          { type: "text", text: "Extension changed the plan." },
+          { type: "image", data: "ignored", mimeType: "image/png" },
+          { type: "text", text: "Review it." },
+        ],
+      },
+    });
+
+    expect(events).toContainEqual({
+      type: "interjection",
+      text: "Extension changed the plan.\nReview it.",
+      customType: "extension-notice",
+    });
+    frame("omp-test", { type: "agent_end" });
+    await running.turn;
+  });
+
+  it("does not reinterpret Pi custom messages as OMP interjections", async () => {
+    const turn = sendPiTurn({
+      ...input("pi-test", "hello"),
+      model: "pi:default",
+    });
+    await vi.waitFor(() =>
+      expect(transport.requests.some((r) => r.command.type === "prompt")).toBe(
+        true,
+      ),
+    );
+    frame("pi-test", {
+      type: "message_start",
+      message: {
+        role: "custom",
+        customType: "advisor",
+        display: true,
+        content: "Pi-owned custom frame",
+      },
+    });
+    expect(events.some((event) => event.type === "interjection")).toBe(false);
+    frame("pi-test", { type: "agent_end" });
+    await turn;
+  });
 });
 
 describe("OMP live command inventories", () => {

--- a/src/lib/harness/piFamily.ts
+++ b/src/lib/harness/piFamily.ts
@@ -612,6 +612,64 @@ async function runTurn(
   }
 }
 
+/**
+ * OMP's advisor and extensions interject mid-turn. Frames marked display:true
+ * exist so clients can show them: structured advisor notes replace the raw
+ * advisory envelope when present, and even a blank body stays a labeled
+ * boundary so the segments around it never silently merge.
+ */
+function customMessageText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return "";
+  return value
+    .flatMap((part) => {
+      const record = asRecord(part);
+      return record?.type === "text" && typeof record.text === "string"
+        ? [record.text]
+        : [];
+    })
+    .join("\n");
+}
+
+function interjectionFromCustomMessage(
+  message: Record<string, unknown>,
+): Extract<HarnessEvent, { type: "interjection" }> | undefined {
+  if (message.display !== true) return undefined;
+  const customType = stringField(message, "customType") ?? "custom";
+  if (customType === "advisor") {
+    const notes = asRecord(message.details)?.notes;
+    const bodies: string[] = [];
+    let severity: Extract<HarnessEvent, { type: "interjection" }>["severity"];
+    if (Array.isArray(notes)) {
+      for (const raw of notes) {
+        const note = asRecord(raw);
+        const body = stringField(note, "note");
+        if (!body) continue;
+        bodies.push(body);
+        // Keep the highest severity the retained notes actually carry.
+        const level = note?.severity;
+        if (level === "blocker") severity = "blocker";
+        else if (level === "concern" && severity !== "blocker") {
+          severity = "concern";
+        } else if (level === "nit" && !severity) severity = "nit";
+      }
+    }
+    if (bodies.length > 0) {
+      return {
+        type: "interjection",
+        text: bodies.join("\n\n"),
+        customType,
+        ...(severity ? { severity } : {}),
+      };
+    }
+  }
+  return {
+    type: "interjection",
+    text: customMessageText(message.content),
+    customType,
+  };
+}
+
 function handleFrame(
   flavor: PiFlavor,
   sessionId: string,
@@ -649,6 +707,20 @@ function handleFrame(
 
   const type = stringField(rec, "type");
   if (flavor.id === "omp") {
+    // OMP emits persisted custom_message entries on the live RPC stream as a
+    // message_start/message_end pair. Render the start once; consume the end
+    // and hidden custom messages so none can leak through a generic path.
+    if (type === "message_start" || type === "message_end") {
+      const message = asRecord(rec.message);
+      if (message?.role === "custom") {
+        if (type === "message_start") {
+          const interjection = interjectionFromCustomMessage(message);
+          if (interjection) live.onEvent(interjection);
+        }
+        return;
+      }
+    }
+    if (type === "advisor_yielded") return;
     if (type === "session_info_update") {
       const providerSessionId = stringField(rec, "sessionId");
       if (providerSessionId) {

--- a/src/lib/harness/types.ts
+++ b/src/lib/harness/types.ts
@@ -1,5 +1,6 @@
 import type {
   Attachment,
+  InterjectionMeta,
   RuntimeMode,
   TaskListItem,
   ToolPreview,
@@ -18,6 +19,7 @@ export type HarnessEvent =
       modelSettings?: Record<string, string>;
     }
   | { type: "status"; text: string }
+  | ({ type: "interjection"; text: string } & InterjectionMeta)
   | { type: "message.delta"; text: string }
   | { type: "message.completed" }
   | { type: "reasoning.delta"; text: string }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -94,6 +94,15 @@ export type SecondOpinionMeta = {
   kind?: "handoff";
 };
 
+/** A mid-turn interjection the harness asked to surface, e.g. OMP advisor notes. */
+export type InterjectionSeverity = "nit" | "concern" | "blocker";
+
+export type InterjectionMeta = {
+  customType: string;
+  /** Highest severity among this interjection's retained notes, when any is known. */
+  severity?: InterjectionSeverity;
+};
+
 export type ToolPreviewKind = "read" | "write" | "shell" | "search";
 
 export type ToolPreviewLineKind = "add" | "del" | "context";
@@ -174,6 +183,8 @@ export type Block = {
   secondOpinion?: SecondOpinionMeta;
   /** Note chip shown on this user turn. Body is not stored; the harness already received it. */
   noteCard?: NoteCardMeta;
+  /** Mid-turn interjection chrome; system blocks only. Body lives in text. */
+  interjection?: InterjectionMeta;
 };
 
 export type RuntimeMode =

--- a/src/lib/sessionStore.test.ts
+++ b/src/lib/sessionStore.test.ts
@@ -76,6 +76,53 @@ describe("sanitizeSessionForPersist", () => {
     });
   });
 
+  it("keeps valid interjection chrome only on system blocks", () => {
+    const session = newSession("pi", "/tmp/project");
+    session.blocks = [
+      {
+        id: "i1",
+        role: "system",
+        text: "Review the fallback.",
+        interjection: { customType: " advisor ", severity: "blocker" },
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        text: "Not chrome",
+        interjection: { customType: "advisor", severity: "nit" },
+      },
+    ];
+
+    const persisted = sanitizeSessionForPersist(session);
+    expect(persisted.blocks[0]).toMatchObject({
+      role: "system",
+      text: "Review the fallback.",
+      interjection: { customType: "advisor", severity: "blocker" },
+    });
+    expect(persisted.blocks[1]?.interjection).toBeUndefined();
+  });
+
+  it("drops malformed interjection metadata without dropping its system row", () => {
+    const session = newSession("pi", "/tmp/project");
+    session.blocks = [
+      {
+        id: "i1",
+        role: "system",
+        text: "Still visible",
+        interjection: {
+          customType: " ",
+          severity: "unknown",
+        } as unknown as Block["interjection"],
+      },
+    ];
+
+    expect(sanitizeSessionForPersist(session).blocks[0]).toEqual({
+      id: "i1",
+      role: "system",
+      text: "Still visible",
+    });
+  });
+
   it("keeps a second-opinion card on the user turn", () => {
     const session = newSession("codex", "/tmp/project");
     session.blocks = [

--- a/src/lib/sessionStore.ts
+++ b/src/lib/sessionStore.ts
@@ -7,6 +7,7 @@ import type {
   HarnessId,
   HandoffMeta,
   HandoffStatus,
+  InterjectionMeta,
   LinkedWorkItem,
   RuntimeMode,
   SecondOpinionMeta,
@@ -402,7 +403,32 @@ function sanitizeBlock(block: Block): Block | null {
   if (secondOpinion) next.secondOpinion = secondOpinion;
   const noteCard = sanitizeNoteCard(block.noteCard);
   if (noteCard) next.noteCard = noteCard;
+  // Interjection chrome survives restarts only on system blocks; a malformed
+  // payload keeps the ordinary system row rather than losing its body.
+  if (block.role === "system") {
+    const interjection = sanitizeInterjection(block.interjection);
+    if (interjection) next.interjection = interjection;
+  }
   return next;
+}
+
+function sanitizeInterjection(
+  value: Block["interjection"],
+): InterjectionMeta | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const customType =
+    typeof record.customType === "string" ? record.customType.trim() : "";
+  if (!customType) return undefined;
+  const severity = record.severity;
+  return {
+    customType,
+    ...(severity === "nit" || severity === "concern" || severity === "blocker"
+      ? { severity }
+      : {}),
+  };
 }
 
 function sanitizePlan(value: unknown, text: string): PlanBlockMeta | null {

--- a/src/surfaces/AgentTranscript.test.ts
+++ b/src/surfaces/AgentTranscript.test.ts
@@ -84,4 +84,25 @@ describe("AgentTranscript collapsed work", () => {
       markup.indexOf('aria-label="Worked for 1s"'),
     );
   });
+
+  it("renders an advisor interjection between answered work phases", () => {
+    const markup = render([
+      tool("before"),
+      { id: "answer", role: "assistant", text: "Complete answer." },
+      {
+        id: "advisor",
+        role: "system",
+        text: "Check the fallback.",
+        interjection: { customType: "advisor", severity: "concern" },
+      },
+      tool("after"),
+      { id: "ack", role: "assistant", text: "Checked." },
+    ]);
+
+    expect(markup).toContain("Complete answer.");
+    expect(markup).toContain('aria-label="Interjection: Advisor"');
+    expect(markup).toContain("Concern");
+    expect(markup).toContain("Check the fallback.");
+    expect(markup).toContain("Checked.");
+  });
 });

--- a/src/surfaces/AgentTranscript.tsx
+++ b/src/surfaces/AgentTranscript.tsx
@@ -902,6 +902,9 @@ const TranscriptBlock = memo(function TranscriptBlock({
   }
 
   if (block.role === "system") {
+    if (block.interjection) {
+      return <InterjectionDivider block={block} />;
+    }
     return (
       <div className="px-4 py-2 text-content/50">
         <pre className="min-w-0 whitespace-pre-wrap break-words">
@@ -2197,6 +2200,60 @@ function HandoffDivider({ block }: { block: Block }) {
         </div>
         <div className="h-px min-w-4 flex-1 bg-content/12" />
       </div>
+    </div>
+  );
+}
+
+/** A mid-turn interjection, e.g. OMP advisor notes: a labeled boundary with
+ * the full advisory body below it. */
+function InterjectionDivider({ block }: { block: Block }) {
+  const meta = block.interjection;
+  if (!meta) return null;
+  const label =
+    meta.customType === "advisor"
+      ? "Advisor"
+      : meta.customType === "custom"
+        ? "Notice"
+        : meta.customType;
+  const severityText =
+    meta.severity === "blocker"
+      ? "Blocker"
+      : meta.severity === "concern"
+        ? "Concern"
+        : meta.severity === "nit"
+          ? "Nit"
+          : undefined;
+  const severityClass =
+    meta.severity === "blocker"
+      ? "text-red-400"
+      : meta.severity === "concern"
+        ? "text-amber-400"
+        : "text-content/55";
+  return (
+    <div className="px-4 py-4">
+      <div className="flex items-center gap-3">
+        <div className="h-px min-w-4 flex-1 bg-content/12" />
+        <div
+          role="separator"
+          aria-label={`Interjection: ${label}`}
+          className="flex items-center gap-2 px-1.5 font-sans text-[12px] text-content/55"
+        >
+          <span>{label}</span>
+          {severityText ? (
+            <span className={`text-[11px] ${severityClass}`}>
+              {severityText}
+            </span>
+          ) : null}
+        </div>
+        <div className="h-px min-w-4 flex-1 bg-content/12" />
+      </div>
+      {block.text ? (
+        <div className="mt-2 px-2">
+          <pre className="min-w-0 whitespace-pre-wrap break-words font-sans text-[12.5px] leading-5 text-content/70">
+            {block.text}
+          </pre>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/surfaces/transcriptActivity.test.ts
+++ b/src/surfaces/transcriptActivity.test.ts
@@ -677,6 +677,27 @@ describe("foldableWork", () => {
     expect(foldableWork(turn)).toEqual({ start: 3, end: 3 });
   });
 
+  it("uses an interjection as a hard boundary between answered work phases", () => {
+    const turn = items([
+      shell("before"),
+      note("answer", "The complete answer."),
+      {
+        id: "advisor",
+        role: "system",
+        text: "Check the fallback.",
+        interjection: { customType: "advisor", severity: "nit" },
+      },
+      shell("after"),
+      note("ack", "Checked."),
+    ]);
+    const fold = foldableWork(turn)!;
+
+    expect(fold).toEqual({ start: 3, end: 3 });
+    expect(foldedBlocks(turn, fold).map((block) => block.id)).toEqual([
+      "after",
+    ]);
+  });
+
   it("leaves an approval attached to earlier work outside the fold", () => {
     const turn = items([
       shell("pending", "pending", { requestId: 1 }),

--- a/src/surfaces/transcriptActivity.ts
+++ b/src/surfaces/transcriptActivity.ts
@@ -591,6 +591,10 @@ export type WorkFold = { start: number; end: number };
  * approval. As the turn streams, each new paragraph folds the work and running
  * commentary before it, leaving the final answer visible. A late approval can
  * reopen that boundary so its controls remain available.
+ *
+ * Persisted interjections (system blocks with interjection chrome) are neither
+ * prose nor work, so they stop the fold: an answer the harness already showed
+ * never folds behind an interjection that arrived after it.
  */
 export function foldableWork(items: TurnItem[]): WorkFold | undefined {
   let end = -1;


### PR DESCRIPTION
## What changed

- Handle OMP `message_start` / `message_end` pairs whose message has `role: "custom"`.
- Render displayed custom messages as persisted transcript dividers. Advisor cards use structured note text and the highest reported severity.
- Keep hidden custom messages hidden, preserve Pi behavior, and retain interjection metadata across restarts.
- Treat the divider as a fold boundary so a complete pre-advisor answer stays visible.

## Why

OMP emits advisor cards over RPC as `message_start` followed by `message_end`; the nested message carries `role: "custom"`, `customType`, `display`, `content`, and `details`. MonoCode ignored that message role. Without a visible boundary, the post-advisor work phase caused `foldableWork()` to fold the complete answer that preceded it.

Issue #123 calls the live frame `custom_message`, which is the session JSONL entry type. This patch follows the wire shape from OMP 18.1.16 and emits one divider on `message_start`; it consumes `message_end` without duplicating the row.

Closes #123.

## UI

Before: the fold contains the first work phase, the complete answer, and the post-advisor work. The transcript shows only the prompt, one work row, and the short tail reply.

After: the complete answer stays visible above an `Advisor` divider. The divider shows the structured note and severity; only the work after the advisor folds under the later work row.

I rendered both states at 1598 x 870 through the real `AgentTranscript` component and checked the screenshots for clipping, overflow, hierarchy, and fold placement.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying advisor and other visible system interjections in the transcript.
  - Interjections can show custom labels, message content, and severity levels.
  - Interjections persist across session restarts and visually separate surrounding work phases.
  - Hidden internal messages and unsupported content are excluded from the transcript.

- **Bug Fixes**
  - Prevented transcript folding from obscuring work completed before an interjection.
  - Added validation to discard malformed interjection metadata while preserving the system message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->