### PR TITLE
Fix OMP advisor interjections folding away complete answers

### DIFF
--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -47,6 +47,24 @@ pub struct OmpInterjectionAnchor {
 pub fn omp_session_interjections(
     provider_session_id: String,
 ) -> Result<Vec<OmpInterjectionAnchor>, String> {
+    let Some(path) = omp_session_path(&provider_session_id)? else {
+        return Ok(Vec::new());
+    };
+    parse_omp_interjections(&path)
+}
+
+#[tauri::command(async)]
+pub fn omp_verify_assistant_texts(
+    provider_session_id: String,
+    texts: Vec<String>,
+) -> Result<Vec<bool>, String> {
+    let Some(path) = omp_session_path(&provider_session_id)? else {
+        return Ok(vec![false; texts.len()]);
+    };
+    verify_omp_assistant_texts(&path, &texts)
+}
+
+fn omp_session_path(provider_session_id: &str) -> Result<Option<PathBuf>, String> {
     if provider_session_id.is_empty()
         || !provider_session_id
             .bytes()
@@ -58,10 +76,7 @@ pub fn omp_session_interjections(
         .map(PathBuf::from)
         .ok_or("Home directory is unavailable")?
         .join(".omp/agent/sessions");
-    let Some(path) = find_omp_session_file(&root, &provider_session_id) else {
-        return Ok(Vec::new());
-    };
-    parse_omp_interjections(&path)
+    Ok(find_omp_session_file(&root, provider_session_id))
 }
 
 fn find_omp_session_file(root: &Path, provider_session_id: &str) -> Option<PathBuf> {
@@ -115,13 +130,8 @@ fn omp_message_text(value: &serde_json::Value, separator: &str) -> String {
         .join(separator)
 }
 
-fn parse_omp_interjections(path: &Path) -> Result<Vec<OmpInterjectionAnchor>, String> {
+fn read_omp_entries(path: &Path) -> Result<Vec<serde_json::Value>, String> {
     let file = std::fs::File::open(path).map_err(|error| format!("{}: {error}", path.display()))?;
-    let mut assistants: HashMap<&str, (String, usize, String, usize)> = HashMap::new();
-    let mut occurrences: HashMap<String, usize> = HashMap::new();
-    let mut concat_occurrences: HashMap<String, usize> = HashMap::new();
-    let mut out: Vec<OmpInterjectionAnchor> = Vec::new();
-
     let mut entries = Vec::new();
     for line in BufReader::new(file).lines() {
         let Ok(line) = line else { continue };
@@ -130,6 +140,10 @@ fn parse_omp_interjections(path: &Path) -> Result<Vec<OmpInterjectionAnchor>, St
         };
         entries.push(value);
     }
+    Ok(entries)
+}
+
+fn omp_active_ids(entries: &[serde_json::Value]) -> HashSet<&str> {
     let nodes: HashMap<_, _> = entries
         .iter()
         .filter_map(|value| value["id"].as_str().map(|id| (id, value)))
@@ -142,6 +156,43 @@ fn parse_omp_interjections(path: &Path) -> Result<Vec<OmpInterjectionAnchor>, St
         }
         cursor = nodes.get(id).and_then(|value| value["parentId"].as_str());
     }
+    active
+}
+
+fn verify_omp_assistant_texts(path: &Path, texts: &[String]) -> Result<Vec<bool>, String> {
+    let entries = read_omp_entries(path)?;
+    let active = omp_active_ids(&entries);
+    let mut pending: HashSet<&str> = texts.iter().map(String::as_str).collect();
+    for value in &entries {
+        if pending.is_empty() {
+            break;
+        }
+        if value["type"] == "message"
+            && value["message"]["role"] == "assistant"
+            && value["id"].as_str().is_some_and(|id| active.contains(id))
+        {
+            let content = &value["message"]["content"];
+            pending.remove(omp_message_text(content, "\n").as_str());
+            pending.remove(omp_message_text(content, "").as_str());
+        }
+    }
+    Ok(texts
+        .iter()
+        .map(|text| !pending.contains(text.as_str()))
+        .collect())
+}
+
+fn parse_omp_interjections(path: &Path) -> Result<Vec<OmpInterjectionAnchor>, String> {
+    let entries = read_omp_entries(path)?;
+    let nodes: HashMap<_, _> = entries
+        .iter()
+        .filter_map(|value| value["id"].as_str().map(|id| (id, value)))
+        .collect();
+    let active = omp_active_ids(&entries);
+    let mut assistants: HashMap<&str, (String, usize, String, usize)> = HashMap::new();
+    let mut occurrences: HashMap<String, usize> = HashMap::new();
+    let mut concat_occurrences: HashMap<String, usize> = HashMap::new();
+    let mut out: Vec<OmpInterjectionAnchor> = Vec::new();
     // Metadata and compaction participate in ancestry, not anchor text.
     // Keep file order for occurrences and notes, but exclude abandoned branches.
     for value in &entries {
@@ -4194,6 +4245,38 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn omp_assistant_verification_requires_exact_active_message_text() {
+        let dir = tmp("omp-verification");
+        let path = dir.0.join("session.jsonl");
+        let records = [
+            serde_json::json!({"type":"message","id":"u","message":{"role":"user","content":"User only"}}),
+            serde_json::json!({"type":"message","id":"abandoned","parentId":"u","message":{"role":"assistant","content":"Off branch"}}),
+            serde_json::json!({"type":"message","id":"a","parentId":"u","message":{"role":"assistant","content":[{"type":"text","text":"First."},{"type":"thinking","thinking":"Hidden"},{"type":"text","text":"Second."}]}}),
+            serde_json::json!({"type":"message","id":"b","parentId":"a","message":{"role":"assistant","content":"Plain"}}),
+            serde_json::json!({"type":"custom_message","id":"note","parentId":"b","content":"Note only"}),
+        ];
+        let jsonl = records.iter().map(|v| format!("{v}\n")).collect::<String>();
+        std::fs::write(&path, jsonl).unwrap();
+        let texts = [
+            "First.\nSecond.",
+            "First.Second.",
+            "Plain",
+            "Off branch",
+            "User only",
+            "Note only",
+            "First.",
+            " First.Second.",
+            "First. Second.",
+            "First.Second.",
+        ]
+        .map(str::to_owned);
+        assert_eq!(
+            verify_omp_assistant_texts(&path, &texts).unwrap(),
+            [true, true, true, false, false, false, false, false, false, true]
+        );
+    }
 
     #[test]
     fn omp_interjections_require_displayed_assistant_anchors() {

--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::io::ErrorKind;
-use std::io::Write;
+use std::io::{BufRead, BufReader, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Mutex;
@@ -21,6 +20,197 @@ pub struct DirEntry {
     path: String,
     is_dir: bool,
     ignored: bool,
+}
+
+#[derive(Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct OmpInterjectionAnchor {
+    id: String,
+    after_assistant_text: String,
+    after_occurrence: usize,
+    /// A directly following text-only answer can have been coalesced into the
+    /// parent block by old builds. Require both full texts before splitting it.
+    following_assistant_text: Option<String>,
+    text: String,
+    custom_type: String,
+    severity: Option<String>,
+}
+
+/// Recover displayed OMP custom messages that older MonoCode builds omitted
+/// from their persisted transcript. The provider id is already stored with the
+/// session; matching the original JSONL keeps the repair deterministic instead
+/// of guessing from neighbouring reasoning text.
+#[tauri::command(async)]
+pub fn omp_session_interjections(
+    provider_session_id: String,
+) -> Result<Vec<OmpInterjectionAnchor>, String> {
+    if provider_session_id.is_empty()
+        || !provider_session_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+    {
+        return Err("Invalid OMP provider session id".into());
+    }
+    let root = dirs_home()
+        .map(PathBuf::from)
+        .ok_or("Home directory is unavailable")?
+        .join(".omp/agent/sessions");
+    let Some(path) = find_omp_session_file(&root, &provider_session_id) else {
+        return Ok(Vec::new());
+    };
+    parse_omp_interjections(&path)
+}
+
+fn find_omp_session_file(root: &Path, provider_session_id: &str) -> Option<PathBuf> {
+    let suffix = format!("_{provider_session_id}.jsonl");
+    let projects = std::fs::read_dir(root).ok()?;
+    for project in projects.flatten() {
+        let path = project.path();
+        if path.is_file()
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(&suffix))
+        {
+            return Some(path);
+        }
+        if !path.is_dir() {
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(path) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let candidate = entry.path();
+            if candidate.is_file()
+                && candidate
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with(&suffix))
+            {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+fn omp_message_text(value: &serde_json::Value) -> String {
+    if let Some(text) = value.as_str() {
+        return text.to_owned();
+    }
+    value
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|part| {
+            (part.get("type").and_then(serde_json::Value::as_str) == Some("text"))
+                .then(|| part.get("text").and_then(serde_json::Value::as_str))
+                .flatten()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn parse_omp_interjections(path: &Path) -> Result<Vec<OmpInterjectionAnchor>, String> {
+    let file = std::fs::File::open(path).map_err(|error| format!("{}: {error}", path.display()))?;
+    let mut assistants: HashMap<String, (String, usize)> = HashMap::new();
+    let mut occurrences: HashMap<String, usize> = HashMap::new();
+    let mut out: Vec<OmpInterjectionAnchor> = Vec::new();
+
+    for line in BufReader::new(file).lines() {
+        let Ok(line) = line else { continue };
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        match value.get("type").and_then(serde_json::Value::as_str) {
+            Some("message")
+                if value
+                    .pointer("/message/role")
+                    .and_then(serde_json::Value::as_str)
+                    == Some("assistant") =>
+            {
+                let Some(id) = value.get("id").and_then(serde_json::Value::as_str) else {
+                    continue;
+                };
+                let text = omp_message_text(&value["message"]["content"]);
+                if text.trim().is_empty() {
+                    continue;
+                }
+                if let Some(anchor) = out.last_mut() {
+                    let text_only = value["message"]["content"]
+                        .as_array()
+                        .is_some_and(|parts| parts.iter().all(|part| part["type"] == "text"));
+                    if text_only
+                        && value.get("parentId").and_then(serde_json::Value::as_str)
+                            == Some(anchor.id.as_str())
+                    {
+                        anchor.following_assistant_text = Some(text.clone());
+                    }
+                }
+                let occurrence = occurrences.entry(text.clone()).or_default();
+                *occurrence += 1;
+                assistants.insert(id.to_owned(), (text, *occurrence));
+            }
+            Some("custom_message")
+                if value.get("display").and_then(serde_json::Value::as_bool) == Some(true) =>
+            {
+                let Some(id) = value.get("id").and_then(serde_json::Value::as_str) else {
+                    continue;
+                };
+                let Some(parent_id) = value.get("parentId").and_then(serde_json::Value::as_str)
+                else {
+                    continue;
+                };
+                let Some((after_assistant_text, after_occurrence)) = assistants.get(parent_id)
+                else {
+                    continue;
+                };
+                let custom_type = value
+                    .get("customType")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("custom")
+                    .to_owned();
+                let mut severity = None;
+                let mut note_bodies = Vec::new();
+                if custom_type == "advisor" {
+                    for note in value
+                        .pointer("/details/notes")
+                        .and_then(serde_json::Value::as_array)
+                        .into_iter()
+                        .flatten()
+                    {
+                        if let Some(body) = note.get("note").and_then(serde_json::Value::as_str) {
+                            note_bodies.push(body);
+                        }
+                        let next = note.get("severity").and_then(serde_json::Value::as_str);
+                        if next == Some("blocker")
+                            || (next == Some("concern") && severity.as_deref() != Some("blocker"))
+                            || (next == Some("nit") && severity.is_none())
+                        {
+                            severity = next.map(str::to_owned);
+                        }
+                    }
+                }
+                let text = if note_bodies.is_empty() {
+                    omp_message_text(&value["content"])
+                } else {
+                    note_bodies.join("\n\n")
+                };
+                out.push(OmpInterjectionAnchor {
+                    id: id.to_owned(),
+                    after_assistant_text: after_assistant_text.clone(),
+                    after_occurrence: *after_occurrence,
+                    following_assistant_text: None,
+                    text,
+                    custom_type,
+                    severity,
+                });
+            }
+            _ => {}
+        }
+    }
+    Ok(out)
 }
 
 /// Immediate children of `path` (project tree). Folders first, then files.
@@ -3947,6 +4137,54 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn omp_interjections_require_displayed_assistant_anchors() {
+        let dir = tmp("omp-interjections");
+        let path = dir.0.join("session.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"message\",\"id\":\"u\",\"message\":{\"role\":\"user\",\"content\":\"Go\"}}\n",
+                "{\"type\":\"custom_message\",\"id\":\"orphan\",\"parentId\":\"u\",\"display\":true}\n",
+                "{\"type\":\"message\",\"id\":\"a1\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Answer\"}]}}\n",
+                "{\"type\":\"custom_message\",\"id\":\"hidden\",\"parentId\":\"a1\",\"display\":false}\n",
+                "invalid partial line\n",
+                "{\"type\":\"message\",\"id\":\"a2\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Answer\"}]}}\n",
+                "{\"type\":\"custom_message\",\"id\":\"review\",\"parentId\":\"a2\",\"display\":true,\"customType\":\"advisor\",\"details\":{\"notes\":[{\"note\":\"First\",\"severity\":\"nit\"},{\"note\":\"Second\",\"severity\":\"blocker\"}]}}\n",
+                "{\"type\":\"message\",\"id\":\"a3\",\"parentId\":\"review\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Checked\"}]}}\n",
+            ),
+        )
+        .unwrap();
+        let anchors = parse_omp_interjections(&path).unwrap();
+        assert_eq!(anchors.len(), 1);
+        assert_eq!(anchors[0].after_assistant_text, "Answer");
+        assert_eq!(anchors[0].after_occurrence, 2);
+        assert_eq!(
+            anchors[0].following_assistant_text.as_deref(),
+            Some("Checked")
+        );
+        assert_eq!(anchors[0].text, "First\n\nSecond");
+        assert_eq!(anchors[0].severity.as_deref(), Some("blocker"));
+    }
+
+    #[test]
+    fn omp_interjections_do_not_coalesce_across_reasoning() {
+        let dir = tmp("omp-interjections-reasoning");
+        let path = dir.0.join("session.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"message\",\"id\":\"a\",\"message\":{\"role\":\"assistant\",\"content\":\"Answer\"}}\n",
+                "{\"type\":\"custom_message\",\"id\":\"review\",\"parentId\":\"a\",\"display\":true,\"content\":\"Check\"}\n",
+                "{\"type\":\"message\",\"id\":\"b\",\"parentId\":\"review\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"Wait\"},{\"type\":\"text\",\"text\":\"Checked\"}]}}\n",
+            ),
+        )
+        .unwrap();
+        let anchors = parse_omp_interjections(&path).unwrap();
+        assert_eq!(anchors[0].following_assistant_text, None);
+        assert_eq!(anchors[0].text, "Check");
+    }
 
     #[test]
     fn stat_files_returns_mtime_for_existing_files_only() {

--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -57,9 +57,9 @@ pub fn omp_session_interjections(
 pub fn omp_verify_assistant_texts(
     provider_session_id: String,
     texts: Vec<String>,
-) -> Result<Vec<bool>, String> {
+) -> Result<Vec<usize>, String> {
     let Some(path) = omp_session_path(&provider_session_id)? else {
-        return Ok(vec![false; texts.len()]);
+        return Ok(vec![0; texts.len()]);
     };
     verify_omp_assistant_texts(&path, &texts)
 }
@@ -159,26 +159,40 @@ fn omp_active_ids(entries: &[serde_json::Value]) -> HashSet<&str> {
     active
 }
 
-fn verify_omp_assistant_texts(path: &Path, texts: &[String]) -> Result<Vec<bool>, String> {
+// Return occurrence bounds, not a boolean vote per candidate. Duplicate
+// requests share the same bound; the persisted walk accounts for occupancy.
+fn verify_omp_assistant_texts(path: &Path, texts: &[String]) -> Result<Vec<usize>, String> {
     let entries = read_omp_entries(path)?;
     let active = omp_active_ids(&entries);
-    let mut pending: HashSet<&str> = texts.iter().map(String::as_str).collect();
+    let requested: HashSet<&str> = texts.iter().map(String::as_str).collect();
+    let mut occurrences = HashMap::<String, usize>::new();
+    let mut concat_occurrences = HashMap::<String, usize>::new();
     for value in &entries {
-        if pending.is_empty() {
-            break;
-        }
         if value["type"] == "message"
             && value["message"]["role"] == "assistant"
             && value["id"].as_str().is_some_and(|id| active.contains(id))
         {
             let content = &value["message"]["content"];
-            pending.remove(omp_message_text(content, "\n").as_str());
-            pending.remove(omp_message_text(content, "").as_str());
+            let text = omp_message_text(content, "\n");
+            let concat = omp_message_text(content, "");
+            if requested.contains(text.as_str()) {
+                *occurrences.entry(text).or_default() += 1;
+            }
+            if requested.contains(concat.as_str()) {
+                *concat_occurrences.entry(concat).or_default() += 1;
+            }
         }
     }
     Ok(texts
         .iter()
-        .map(|text| !pending.contains(text.as_str()))
+        .map(|text| {
+            // The two forms are alternatives, never two source occurrences.
+            occurrences
+                .get(text)
+                .copied()
+                .unwrap_or(0)
+                .max(concat_occurrences.get(text).copied().unwrap_or(0))
+        })
         .collect())
 }
 
@@ -4274,7 +4288,31 @@ mod tests {
         .map(str::to_owned);
         assert_eq!(
             verify_omp_assistant_texts(&path, &texts).unwrap(),
-            [true, true, true, false, false, false, false, false, false, true]
+            [1, 1, 1, 0, 0, 0, 0, 0, 0, 1]
+        );
+        let count = verify_omp_assistant_texts(&path, &texts).unwrap()[1];
+        assert_eq!([1, 2].map(|occurrence| occurrence <= count), [true, false]);
+    }
+
+    #[test]
+    fn omp_assistant_verification_counts_active_occurrences_not_join_forms() {
+        let dir = tmp("omp-verification-occurrences");
+        let path = dir.0.join("session.jsonl");
+        let records = [
+            serde_json::json!({"type":"message","id":"a","message":{"role":"assistant","content":"Same"}}),
+            serde_json::json!({"type":"message","id":"off","parentId":"a","message":{"role":"assistant","content":"Same"}}),
+            serde_json::json!({"type":"message","id":"b","parentId":"a","message":{"role":"assistant","content":[{"type":"text","text":"Same"}]}}),
+        ];
+        std::fs::write(
+            &path,
+            records.iter().map(|v| format!("{v}\n")).collect::<String>(),
+        )
+        .unwrap();
+        let counts = verify_omp_assistant_texts(&path, &["Same".into(), "Same".into()]).unwrap();
+        assert_eq!(counts, [2, 2]);
+        assert_eq!(
+            [1, 2, 3].map(|occurrence| occurrence <= counts[0]),
+            [true, true, false]
         );
     }
 

--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -28,9 +28,12 @@ pub struct OmpInterjectionAnchor {
     id: String,
     after_assistant_text: String,
     after_occurrence: usize,
+    after_assistant_text_concat: String,
+    after_concat_occurrence: usize,
     /// A directly following text-only answer can have been coalesced into the
     /// parent block by old builds. Require both full texts before splitting it.
     following_assistant_text: Option<String>,
+    following_assistant_text_concat: Option<String>,
     text: String,
     custom_type: String,
     severity: Option<String>,
@@ -95,7 +98,7 @@ fn find_omp_session_file(root: &Path, provider_session_id: &str) -> Option<PathB
     None
 }
 
-fn omp_message_text(value: &serde_json::Value) -> String {
+fn omp_message_text(value: &serde_json::Value, separator: &str) -> String {
     if let Some(text) = value.as_str() {
         return text.to_owned();
     }
@@ -109,20 +112,42 @@ fn omp_message_text(value: &serde_json::Value) -> String {
                 .flatten()
         })
         .collect::<Vec<_>>()
-        .join("\n")
+        .join(separator)
 }
 
 fn parse_omp_interjections(path: &Path) -> Result<Vec<OmpInterjectionAnchor>, String> {
     let file = std::fs::File::open(path).map_err(|error| format!("{}: {error}", path.display()))?;
-    let mut assistants: HashMap<String, (String, usize)> = HashMap::new();
+    let mut assistants: HashMap<&str, (String, usize, String, usize)> = HashMap::new();
     let mut occurrences: HashMap<String, usize> = HashMap::new();
+    let mut concat_occurrences: HashMap<String, usize> = HashMap::new();
     let mut out: Vec<OmpInterjectionAnchor> = Vec::new();
 
+    let mut entries = Vec::new();
     for line in BufReader::new(file).lines() {
         let Ok(line) = line else { continue };
         let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
             continue;
         };
+        entries.push(value);
+    }
+    let nodes: HashMap<_, _> = entries
+        .iter()
+        .filter_map(|value| value["id"].as_str().map(|id| (id, value)))
+        .collect();
+    let mut active = HashSet::new();
+    let mut cursor = entries.last().and_then(|value| value["id"].as_str());
+    while let Some(id) = cursor {
+        if !active.insert(id) {
+            break;
+        }
+        cursor = nodes.get(id).and_then(|value| value["parentId"].as_str());
+    }
+    // Metadata and compaction participate in ancestry, not anchor text.
+    // Keep file order for occurrences and notes, but exclude abandoned branches.
+    for value in &entries {
+        if !value["id"].as_str().is_some_and(|id| active.contains(id)) {
+            continue;
+        }
         match value.get("type").and_then(serde_json::Value::as_str) {
             Some("message")
                 if value
@@ -133,7 +158,8 @@ fn parse_omp_interjections(path: &Path) -> Result<Vec<OmpInterjectionAnchor>, St
                 let Some(id) = value.get("id").and_then(serde_json::Value::as_str) else {
                     continue;
                 };
-                let text = omp_message_text(&value["message"]["content"]);
+                let text = omp_message_text(&value["message"]["content"], "\n");
+                let concat_text = omp_message_text(&value["message"]["content"], "");
                 if text.trim().is_empty() {
                     continue;
                 }
@@ -146,11 +172,14 @@ fn parse_omp_interjections(path: &Path) -> Result<Vec<OmpInterjectionAnchor>, St
                             == Some(anchor.id.as_str())
                     {
                         anchor.following_assistant_text = Some(text.clone());
+                        anchor.following_assistant_text_concat = Some(concat_text.clone());
                     }
                 }
                 let occurrence = occurrences.entry(text.clone()).or_default();
                 *occurrence += 1;
-                assistants.insert(id.to_owned(), (text, *occurrence));
+                let concat_occurrence = concat_occurrences.entry(concat_text.clone()).or_default();
+                *concat_occurrence += 1;
+                assistants.insert(id, (text, *occurrence, concat_text, *concat_occurrence));
             }
             Some("custom_message")
                 if value.get("display").and_then(serde_json::Value::as_bool) == Some(true) =>
@@ -162,7 +191,30 @@ fn parse_omp_interjections(path: &Path) -> Result<Vec<OmpInterjectionAnchor>, St
                 else {
                     continue;
                 };
-                let Some((after_assistant_text, after_occurrence)) = assistants.get(parent_id)
+                let mut ancestor = Some(parent_id);
+                let mut seen = HashSet::new();
+                let mut assistant = None;
+                while let Some(id) = ancestor {
+                    if !active.contains(id) || !seen.insert(id) {
+                        break;
+                    }
+                    if let Some(found) = assistants.get(id) {
+                        assistant = Some(found);
+                        break;
+                    }
+                    let Some(parent) = nodes.get(id) else { break };
+                    if matches!(
+                        parent
+                            .pointer("/message/role")
+                            .and_then(serde_json::Value::as_str),
+                        Some("user" | "assistant")
+                    ) {
+                        break;
+                    }
+                    ancestor = parent["parentId"].as_str();
+                }
+                let Some((after_assistant_text, after_occurrence, concat_text, concat_occurrence)) =
+                    assistant
                 else {
                     continue;
                 };
@@ -193,15 +245,20 @@ fn parse_omp_interjections(path: &Path) -> Result<Vec<OmpInterjectionAnchor>, St
                     }
                 }
                 let text = if note_bodies.is_empty() {
-                    omp_message_text(&value["content"])
+                    omp_message_text(&value["content"], "\n")
                 } else {
                     note_bodies.join("\n\n")
                 };
+                // Tool results, metadata and note chains seal the same preceding
+                // assistant prose. Notes resolving there stack in source order.
                 out.push(OmpInterjectionAnchor {
                     id: id.to_owned(),
                     after_assistant_text: after_assistant_text.clone(),
                     after_occurrence: *after_occurrence,
+                    after_assistant_text_concat: concat_text.clone(),
+                    after_concat_occurrence: *concat_occurrence,
                     following_assistant_text: None,
+                    following_assistant_text_concat: None,
                     text,
                     custom_type,
                     severity,
@@ -4147,10 +4204,10 @@ mod tests {
             concat!(
                 "{\"type\":\"message\",\"id\":\"u\",\"message\":{\"role\":\"user\",\"content\":\"Go\"}}\n",
                 "{\"type\":\"custom_message\",\"id\":\"orphan\",\"parentId\":\"u\",\"display\":true}\n",
-                "{\"type\":\"message\",\"id\":\"a1\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Answer\"}]}}\n",
+                "{\"type\":\"message\",\"id\":\"a1\",\"parentId\":\"orphan\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Answer\"}]}}\n",
                 "{\"type\":\"custom_message\",\"id\":\"hidden\",\"parentId\":\"a1\",\"display\":false}\n",
                 "invalid partial line\n",
-                "{\"type\":\"message\",\"id\":\"a2\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Answer\"}]}}\n",
+                "{\"type\":\"message\",\"id\":\"a2\",\"parentId\":\"hidden\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Answer\"}]}}\n",
                 "{\"type\":\"custom_message\",\"id\":\"review\",\"parentId\":\"a2\",\"display\":true,\"customType\":\"advisor\",\"details\":{\"notes\":[{\"note\":\"First\",\"severity\":\"nit\"},{\"note\":\"Second\",\"severity\":\"blocker\"}]}}\n",
                 "{\"type\":\"message\",\"id\":\"a3\",\"parentId\":\"review\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Checked\"}]}}\n",
             ),
@@ -4184,6 +4241,63 @@ mod tests {
         let anchors = parse_omp_interjections(&path).unwrap();
         assert_eq!(anchors[0].following_assistant_text, None);
         assert_eq!(anchors[0].text, "Check");
+    }
+    #[test]
+    fn omp_interjections_follow_active_ancestry_and_keep_text_forms() {
+        let dir = tmp("omp-interjections-ancestry");
+        let path = dir.0.join("session.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"message\",\"id\":\"a\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"One\"},{\"type\":\"text\",\"text\":\"Two\"}]}}\n",
+                "{\"type\":\"custom_message\",\"id\":\"abandoned\",\"parentId\":\"a\",\"display\":true,\"content\":\"Wrong branch\"}\n",
+                "{\"type\":\"message\",\"id\":\"t\",\"parentId\":\"a\",\"message\":{\"role\":\"toolResult\",\"content\":\"Done\"}}\n",
+                "{\"type\":\"custom_message\",\"id\":\"first\",\"parentId\":\"t\",\"display\":true,\"content\":\"First\"}\n",
+                "{\"type\":\"custom_message\",\"id\":\"second\",\"parentId\":\"first\",\"display\":true,\"content\":\"Second\"}\n",
+                "{\"type\":\"compaction\",\"id\":\"meta\",\"parentId\":\"second\"}\n",
+                "{\"type\":\"custom_message\",\"id\":\"third\",\"parentId\":\"meta\",\"display\":true,\"content\":\"Third\"}\n",
+                "{\"type\":\"message\",\"id\":\"b\",\"parentId\":\"third\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Three\"},{\"type\":\"text\",\"text\":\"Four\"}]}}\n",
+            ),
+        )
+        .unwrap();
+        let anchors = parse_omp_interjections(&path).unwrap();
+        assert_eq!(
+            anchors.iter().map(|a| a.id.as_str()).collect::<Vec<_>>(),
+            ["first", "second", "third"]
+        );
+        for anchor in &anchors {
+            assert_eq!(anchor.after_assistant_text, "One\nTwo");
+            assert_eq!(anchor.after_assistant_text_concat, "OneTwo");
+            assert_eq!(anchor.after_occurrence, 1);
+            assert_eq!(anchor.after_concat_occurrence, 1);
+        }
+        assert_eq!(anchors[0].following_assistant_text, None);
+        assert_eq!(anchors[1].following_assistant_text, None);
+        assert_eq!(
+            anchors[2].following_assistant_text.as_deref(),
+            Some("Three\nFour")
+        );
+        assert_eq!(
+            anchors[2].following_assistant_text_concat.as_deref(),
+            Some("ThreeFour")
+        );
+    }
+
+    #[test]
+    fn omp_interjections_do_not_cross_users_or_empty_assistant_messages() {
+        let dir = tmp("omp-interjections-barriers");
+        let path = dir.0.join("session.jsonl");
+        for role in ["user", "assistant"] {
+            let records = [
+                serde_json::json!({"type":"message","id":"a","message":{"role":"assistant","content":"Earlier"}}),
+                serde_json::json!({"type":"message","id":"barrier","parentId":"a","message":{"role":role,"content":[]}}),
+                serde_json::json!({"type":"message","id":"tool","parentId":"barrier","message":{"role":"toolResult","content":"Done"}}),
+                serde_json::json!({"type":"custom_message","id":"note","parentId":"tool","display":true,"content":"Note"}),
+            ];
+            let jsonl = records.map(|record| record.to_string()).join("\n");
+            std::fs::write(&path, jsonl).unwrap();
+            assert!(parse_omp_interjections(&path).unwrap().is_empty());
+        }
     }
 
     #[test]

--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -39,6 +39,14 @@ pub struct OmpInterjectionAnchor {
     severity: Option<String>,
 }
 
+/// One active-path assistant message in file order. Both join forms of its
+/// text parts are alternatives for the same message, never two messages.
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub struct OmpAssistantText {
+    text: String,
+    concat: String,
+}
+
 /// Recover displayed OMP custom messages that older MonoCode builds omitted
 /// from their persisted transcript. The provider id is already stored with the
 /// session; matching the original JSONL keeps the repair deterministic instead
@@ -54,14 +62,13 @@ pub fn omp_session_interjections(
 }
 
 #[tauri::command(async)]
-pub fn omp_verify_assistant_texts(
+pub fn omp_active_assistant_texts(
     provider_session_id: String,
-    texts: Vec<String>,
-) -> Result<Vec<usize>, String> {
+) -> Result<Vec<OmpAssistantText>, String> {
     let Some(path) = omp_session_path(&provider_session_id)? else {
-        return Ok(vec![0; texts.len()]);
+        return Ok(Vec::new());
     };
-    verify_omp_assistant_texts(&path, &texts)
+    active_omp_assistant_texts(&path)
 }
 
 fn omp_session_path(provider_session_id: &str) -> Result<Option<PathBuf>, String> {
@@ -159,40 +166,26 @@ fn omp_active_ids(entries: &[serde_json::Value]) -> HashSet<&str> {
     active
 }
 
-// Return occurrence bounds, not a boolean vote per candidate. Duplicate
-// requests share the same bound; the persisted walk accounts for occupancy.
-fn verify_omp_assistant_texts(path: &Path, texts: &[String]) -> Result<Vec<usize>, String> {
+// Return the ordered sequence, not per-text counts: a status split may only
+// be merged with the message at its own source position.
+fn active_omp_assistant_texts(path: &Path) -> Result<Vec<OmpAssistantText>, String> {
     let entries = read_omp_entries(path)?;
     let active = omp_active_ids(&entries);
-    let requested: HashSet<&str> = texts.iter().map(String::as_str).collect();
-    let mut occurrences = HashMap::<String, usize>::new();
-    let mut concat_occurrences = HashMap::<String, usize>::new();
-    for value in &entries {
-        if value["type"] == "message"
-            && value["message"]["role"] == "assistant"
-            && value["id"].as_str().is_some_and(|id| active.contains(id))
-        {
-            let content = &value["message"]["content"];
-            let text = omp_message_text(content, "\n");
-            let concat = omp_message_text(content, "");
-            if requested.contains(text.as_str()) {
-                *occurrences.entry(text).or_default() += 1;
-            }
-            if requested.contains(concat.as_str()) {
-                *concat_occurrences.entry(concat).or_default() += 1;
-            }
-        }
-    }
-    Ok(texts
+    Ok(entries
         .iter()
-        .map(|text| {
-            // The two forms are alternatives, never two source occurrences.
-            occurrences
-                .get(text)
-                .copied()
-                .unwrap_or(0)
-                .max(concat_occurrences.get(text).copied().unwrap_or(0))
+        .filter(|value| {
+            value["type"] == "message"
+                && value["message"]["role"] == "assistant"
+                && value["id"].as_str().is_some_and(|id| active.contains(id))
         })
+        .map(|value| {
+            let content = &value["message"]["content"];
+            OmpAssistantText {
+                text: omp_message_text(content, "\n"),
+                concat: omp_message_text(content, ""),
+            }
+        })
+        .filter(|message| !message.text.trim().is_empty())
         .collect())
 }
 
@@ -4260,59 +4253,60 @@ mod tests {
 
     static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
+    fn assistant_text(text: &str, concat: &str) -> OmpAssistantText {
+        OmpAssistantText {
+            text: text.into(),
+            concat: concat.into(),
+        }
+    }
+
     #[test]
-    fn omp_assistant_verification_requires_exact_active_message_text() {
-        let dir = tmp("omp-verification");
+    fn omp_active_assistant_texts_keep_active_message_order_with_both_forms() {
+        let dir = tmp("omp-active-texts");
         let path = dir.0.join("session.jsonl");
         let records = [
             serde_json::json!({"type":"message","id":"u","message":{"role":"user","content":"User only"}}),
             serde_json::json!({"type":"message","id":"abandoned","parentId":"u","message":{"role":"assistant","content":"Off branch"}}),
             serde_json::json!({"type":"message","id":"a","parentId":"u","message":{"role":"assistant","content":[{"type":"text","text":"First."},{"type":"thinking","thinking":"Hidden"},{"type":"text","text":"Second."}]}}),
-            serde_json::json!({"type":"message","id":"b","parentId":"a","message":{"role":"assistant","content":"Plain"}}),
+            serde_json::json!({"type":"message","id":"tool","parentId":"a","message":{"role":"assistant","content":[{"type":"toolCall","name":"read"}]}}),
+            serde_json::json!({"type":"message","id":"b","parentId":"tool","message":{"role":"assistant","content":"Plain"}}),
             serde_json::json!({"type":"custom_message","id":"note","parentId":"b","content":"Note only"}),
         ];
         let jsonl = records.iter().map(|v| format!("{v}\n")).collect::<String>();
         std::fs::write(&path, jsonl).unwrap();
-        let texts = [
-            "First.\nSecond.",
-            "First.Second.",
-            "Plain",
-            "Off branch",
-            "User only",
-            "Note only",
-            "First.",
-            " First.Second.",
-            "First. Second.",
-            "First.Second.",
-        ]
-        .map(str::to_owned);
         assert_eq!(
-            verify_omp_assistant_texts(&path, &texts).unwrap(),
-            [1, 1, 1, 0, 0, 0, 0, 0, 0, 1]
+            active_omp_assistant_texts(&path).unwrap(),
+            [
+                assistant_text("First.\nSecond.", "First.Second."),
+                assistant_text("Plain", "Plain"),
+            ]
         );
-        let count = verify_omp_assistant_texts(&path, &texts).unwrap()[1];
-        assert_eq!([1, 2].map(|occurrence| occurrence <= count), [true, false]);
     }
 
     #[test]
-    fn omp_assistant_verification_counts_active_occurrences_not_join_forms() {
-        let dir = tmp("omp-verification-occurrences");
+    fn omp_active_assistant_texts_repeat_equal_messages_in_file_order() {
+        let dir = tmp("omp-active-texts-repeats");
         let path = dir.0.join("session.jsonl");
         let records = [
-            serde_json::json!({"type":"message","id":"a","message":{"role":"assistant","content":"Same"}}),
-            serde_json::json!({"type":"message","id":"off","parentId":"a","message":{"role":"assistant","content":"Same"}}),
-            serde_json::json!({"type":"message","id":"b","parentId":"a","message":{"role":"assistant","content":[{"type":"text","text":"Same"}]}}),
+            serde_json::json!({"type":"message","id":"a","message":{"role":"assistant","content":"First."}}),
+            serde_json::json!({"type":"message","id":"off","parentId":"a","message":{"role":"assistant","content":"First.Second."}}),
+            serde_json::json!({"type":"message","id":"b","parentId":"a","message":{"role":"assistant","content":[{"type":"text","text":"Second."}]}}),
+            serde_json::json!({"type":"message","id":"c","parentId":"b","message":{"role":"assistant","content":"First.Second."}}),
+            serde_json::json!({"type":"message","id":"d","parentId":"c","message":{"role":"assistant","content":"First.Second."}}),
         ];
         std::fs::write(
             &path,
             records.iter().map(|v| format!("{v}\n")).collect::<String>(),
         )
         .unwrap();
-        let counts = verify_omp_assistant_texts(&path, &["Same".into(), "Same".into()]).unwrap();
-        assert_eq!(counts, [2, 2]);
         assert_eq!(
-            [1, 2, 3].map(|occurrence| occurrence <= counts[0]),
-            [true, true, false]
+            active_omp_assistant_texts(&path).unwrap(),
+            [
+                assistant_text("First.", "First."),
+                assistant_text("Second.", "Second."),
+                assistant_text("First.Second.", "First.Second."),
+                assistant_text("First.Second.", "First.Second."),
+            ]
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -268,7 +268,7 @@ pub fn run() {
             fs::write_attachment,
             fs::read_text_file,
             fs::omp_session_interjections,
-            fs::omp_verify_assistant_texts,
+            fs::omp_active_assistant_texts,
             fs::write_text_file,
             skills::list_skills,
             search::search_project,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -268,6 +268,7 @@ pub fn run() {
             fs::write_attachment,
             fs::read_text_file,
             fs::omp_session_interjections,
+            fs::omp_verify_assistant_texts,
             fs::write_text_file,
             skills::list_skills,
             search::search_project,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -267,6 +267,7 @@ pub fn run() {
             fs::read_binary_file,
             fs::write_attachment,
             fs::read_text_file,
+            fs::omp_session_interjections,
             fs::write_text_file,
             skills::list_skills,
             search::search_project,

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -8,9 +8,13 @@ export type OmpInterjectionAnchor = InterjectionMeta & {
   afterAssistantText: string;
   /** One-based occurrence among assistant messages with exactly this text. */
   afterOccurrence: number;
+  /** Direct-concat live representation, with its own exact-text occurrence. */
+  afterAssistantTextConcat?: string;
+  afterConcatOccurrence?: number;
   text: string;
   /** Full text of a directly following text-only answer, if present. */
   followingAssistantText?: string | null;
+  followingAssistantTextConcat?: string | null;
 };
 
 export function ompSessionInterjections(

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -1,6 +1,25 @@
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { slash } from "./paths";
+import type { InterjectionMeta } from "./session";
+
+export type OmpInterjectionAnchor = InterjectionMeta & {
+  id: string;
+  afterAssistantText: string;
+  /** One-based occurrence among assistant messages with exactly this text. */
+  afterOccurrence: number;
+  text: string;
+  /** Full text of a directly following text-only answer, if present. */
+  followingAssistantText?: string | null;
+};
+
+export function ompSessionInterjections(
+  providerSessionId: string,
+): Promise<OmpInterjectionAnchor[]> {
+  return invoke<OmpInterjectionAnchor[]>("omp_session_interjections", {
+    providerSessionId,
+  });
+}
 
 export type FsEntry = {
   name: string;

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -25,6 +25,13 @@ export function ompSessionInterjections(
   });
 }
 
+export function ompVerifyAssistantTexts(
+  providerSessionId: string,
+  texts: string[],
+): Promise<boolean[]> {
+  return invoke<boolean[]>("omp_verify_assistant_texts", { providerSessionId, texts });
+}
+
 export type FsEntry = {
   name: string;
   path: string;

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -25,19 +25,16 @@ export function ompSessionInterjections(
   });
 }
 
-/** Active exact-text occurrences, not independent votes for duplicate requests.
- * Newline and concat representations are counted separately; take their max.
+/** One active-path assistant message in source order. Its newline and concat
+ * representations are alternative forms of the same message, not two messages.
  */
-export interface OmpAssistantTextEvidence {
+export interface OmpAssistantText {
   text: string;
-  occurrences: number;
+  concat: string;
 }
 
-export function ompVerifyAssistantTexts(
-  providerSessionId: string,
-  texts: string[],
-): Promise<number[]> {
-  return invoke<number[]>("omp_verify_assistant_texts", { providerSessionId, texts });
+export function ompActiveAssistantTexts(providerSessionId: string): Promise<OmpAssistantText[]> {
+  return invoke<OmpAssistantText[]>("omp_active_assistant_texts", { providerSessionId });
 }
 
 export type FsEntry = {

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -25,11 +25,19 @@ export function ompSessionInterjections(
   });
 }
 
+/** Active exact-text occurrences, not independent votes for duplicate requests.
+ * Newline and concat representations are counted separately; take their max.
+ */
+export interface OmpAssistantTextEvidence {
+  text: string;
+  occurrences: number;
+}
+
 export function ompVerifyAssistantTexts(
   providerSessionId: string,
   texts: string[],
-): Promise<boolean[]> {
-  return invoke<boolean[]>("omp_verify_assistant_texts", { providerSessionId, texts });
+): Promise<number[]> {
+  return invoke<number[]>("omp_verify_assistant_texts", { providerSessionId, texts });
 }
 
 export type FsEntry = {

--- a/src/lib/harness/apply.test.ts
+++ b/src/lib/harness/apply.test.ts
@@ -92,21 +92,35 @@ describe("streamed markdown", () => {
     expect(session.blocks[0]?.text).toBe("I'll read the file");
   });
 
-  it("continues open prose through status and interjection rows, then completes it", () => {
+  it("continues open prose through status rows, then completes it", () => {
     let session = newSession("omp", "/tmp");
     session = applyHarnessEvent(session, { type: "message.delta", text: "contributor（" });
     const id = session.blocks[0].id;
     session = applyHarnessEvent(session, { type: "status", text: "Advisor reviewed this turn" });
-    session = applyHarnessEvent(session, { type: "interjection", text: "Review", customType: "advisor" });
     session = applyHarnessEvent(session, { type: "message.delta", text: "邮箱归属链已验证）" });
     expect(session.blocks.map(block => block.text)).toEqual([
-      "contributor（邮箱归属链已验证）", "Advisor reviewed this turn", "Review",
+      "contributor（邮箱归属链已验证）", "Advisor reviewed this turn",
     ]);
     expect(session.blocks[0]).toMatchObject({ id, streaming: true });
     session = applyHarnessEvent(session, { type: "message.completed" });
     session = applyHarnessEvent(session, { type: "message.delta", text: "Next message." });
     expect(session.blocks[0].streaming).toBe(false);
-    expect(session.blocks[3]).toMatchObject({ role: "assistant", text: "Next message." });
+    expect(session.blocks[2]).toMatchObject({ role: "assistant", text: "Next message." });
+  });
+
+  it.each([false, true])("seals open prose at an interjection, with preceding status: %s", status => {
+    let session = newSession("omp", "/tmp");
+    session = applyHarnessEvent(session, { type: "message.delta", text: "contributor（" });
+    const id = session.blocks[0].id;
+    if (status) session = applyHarnessEvent(session, { type: "status", text: "Reviewed" });
+    session = applyHarnessEvent(session, { type: "interjection", text: "Review", customType: "advisor" });
+    expect(session.blocks[0]).toMatchObject({ id, streaming: false });
+    session = applyHarnessEvent(session, { type: "message.delta", text: "邮箱归属链已验证）" });
+    expect(session.blocks.map(block => block.text)).toEqual([
+      "contributor（", ...(status ? ["Reviewed"] : []), "Review", "邮箱归属链已验证）",
+    ]);
+    expect(session.blocks.at(-1)).toMatchObject({ role: "assistant", streaming: true });
+    expect(session.blocks.at(-1)!.id).not.toBe(id);
   });
 
   it("continues reasoning across status but seals it when a tool starts", () => {

--- a/src/lib/harness/apply.test.ts
+++ b/src/lib/harness/apply.test.ts
@@ -91,6 +91,40 @@ describe("streamed markdown", () => {
     expect(session.blocks).toHaveLength(1);
     expect(session.blocks[0]?.text).toBe("I'll read the file");
   });
+
+  it("continues open prose through status and interjection rows, then completes it", () => {
+    let session = newSession("omp", "/tmp");
+    session = applyHarnessEvent(session, { type: "message.delta", text: "contributor（" });
+    const id = session.blocks[0].id;
+    session = applyHarnessEvent(session, { type: "status", text: "Advisor reviewed this turn" });
+    session = applyHarnessEvent(session, { type: "interjection", text: "Review", customType: "advisor" });
+    session = applyHarnessEvent(session, { type: "message.delta", text: "邮箱归属链已验证）" });
+    expect(session.blocks.map(block => block.text)).toEqual([
+      "contributor（邮箱归属链已验证）", "Advisor reviewed this turn", "Review",
+    ]);
+    expect(session.blocks[0]).toMatchObject({ id, streaming: true });
+    session = applyHarnessEvent(session, { type: "message.completed" });
+    session = applyHarnessEvent(session, { type: "message.delta", text: "Next message." });
+    expect(session.blocks[0].streaming).toBe(false);
+    expect(session.blocks[3]).toMatchObject({ role: "assistant", text: "Next message." });
+  });
+
+  it("continues reasoning across status but seals it when a tool starts", () => {
+    let session = newSession("omp", "/tmp");
+    session = applyHarnessEvent(session, { type: "reasoning.delta", text: "Think" });
+    session = applyHarnessEvent(session, { type: "status", text: "Reviewing" });
+    session = applyHarnessEvent(session, { type: "reasoning.delta", text: " more" });
+    expect(session.blocks[0]).toMatchObject({ text: "Think more", streaming: true });
+    session = applyHarnessEvent(session, { type: "tool.started", callId: "call", title: "Read" });
+    expect(session.blocks[0].streaming).toBe(false);
+    session = applyHarnessEvent(session, { type: "status", text: "Waiting" });
+    session = applyHarnessEvent(session, { type: "tool.updated", callId: "call", status: "completed" });
+    expect(session.blocks.filter(block => block.role === "tool")).toMatchObject([
+      { streaming: false, tool: { callId: "call", status: "completed" } },
+    ]);
+    session = applyHarnessEvent(session, { type: "reasoning.delta", text: "New thought" });
+    expect(session.blocks.at(-1)).toMatchObject({ role: "reasoning", text: "New thought" });
+  });
 });
 
 describe("appendSteerUser", () => {
@@ -162,12 +196,13 @@ describe("status blocks", () => {
 });
 
 describe("interjection blocks", () => {
-  it("seals assistant streams on both sides of the boundary", () => {
+  it("keeps a boundary between completed assistant messages", () => {
     let session = appendUser(newSession("pi", "/tmp"), "go");
     session = applyHarnessEvent(session, {
       type: "message.delta",
       text: "Complete answer.",
     });
+    session = applyHarnessEvent(session, { type: "message.completed" });
     session = applyHarnessEvent(session, {
       type: "interjection",
       text: "Check the fallback.",

--- a/src/lib/harness/apply.test.ts
+++ b/src/lib/harness/apply.test.ts
@@ -123,6 +123,54 @@ describe("streamed markdown", () => {
     expect(session.blocks.at(-1)!.id).not.toBe(id);
   });
 
+  it("does not resume a sealed assistant through status after an interjection", () => {
+    let session = newSession("omp", "/tmp");
+    session = applyHarnessEvent(session, { type: "message.delta", text: "First." });
+    const id = session.blocks[0].id;
+    session = applyHarnessEvent(session, { type: "interjection", text: "Review", customType: "advisor" });
+    session = applyHarnessEvent(session, { type: "status", text: "Advisor reviewed this turn" });
+    session = applyHarnessEvent(session, { type: "message.delta", text: "Second." });
+    expect(session.blocks.map(block => block.text)).toEqual([
+      "First.", "Review", "Advisor reviewed this turn", "Second.",
+    ]);
+    expect(session.blocks[0]).toMatchObject({ id, streaming: false, text: "First." });
+    expect(session.blocks.at(-1)!.id).not.toBe(id);
+  });
+
+  it("keeps stacked interjections as hard boundaries", () => {
+    let session = newSession("omp", "/tmp");
+    session = applyHarnessEvent(session, { type: "message.delta", text: "First." });
+    session = applyHarnessEvent(session, { type: "interjection", text: "One", customType: "advisor" });
+    session = applyHarnessEvent(session, { type: "interjection", text: "Two", customType: "advisor" });
+    session = applyHarnessEvent(session, { type: "message.delta", text: "Second." });
+    expect(session.blocks.map(block => [block.role, block.text])).toEqual([
+      ["assistant", "First."], ["system", "One"], ["system", "Two"], ["assistant", "Second."],
+    ]);
+  });
+
+  it("seals open reasoning at an interjection", () => {
+    let session = newSession("omp", "/tmp");
+    session = applyHarnessEvent(session, { type: "reasoning.delta", text: "Think" });
+    const id = session.blocks[0].id;
+    session = applyHarnessEvent(session, { type: "interjection", text: "Review", customType: "advisor" });
+    session = applyHarnessEvent(session, { type: "reasoning.delta", text: " more" });
+    expect(session.blocks[0]).toMatchObject({ id, text: "Think", streaming: false });
+    expect(session.blocks.at(-1)).toMatchObject({ role: "reasoning", text: " more", streaming: true });
+    expect(session.blocks.at(-1)!.id).not.toBe(id);
+  });
+
+  it("continues open prose through many status rows", () => {
+    let session = newSession("omp", "/tmp");
+    session = applyHarnessEvent(session, { type: "message.delta", text: "Hel" });
+    const id = session.blocks[0].id;
+    for (const text of ["A", "B", "C", "D", "E"]) {
+      session = applyHarnessEvent(session, { type: "status", text });
+    }
+    session = applyHarnessEvent(session, { type: "message.delta", text: "lo" });
+    expect(session.blocks[0]).toMatchObject({ id, text: "Hello", streaming: true });
+    expect(session.blocks.filter(block => block.role === "system")).toHaveLength(5);
+  });
+
   it("continues reasoning across status but seals it when a tool starts", () => {
     let session = newSession("omp", "/tmp");
     session = applyHarnessEvent(session, { type: "reasoning.delta", text: "Think" });

--- a/src/lib/harness/apply.test.ts
+++ b/src/lib/harness/apply.test.ts
@@ -161,6 +161,55 @@ describe("status blocks", () => {
   });
 });
 
+describe("interjection blocks", () => {
+  it("seals assistant streams on both sides of the boundary", () => {
+    let session = appendUser(newSession("pi", "/tmp"), "go");
+    session = applyHarnessEvent(session, {
+      type: "message.delta",
+      text: "Complete answer.",
+    });
+    session = applyHarnessEvent(session, {
+      type: "interjection",
+      text: "Check the fallback.",
+      customType: "advisor",
+    });
+    session = applyHarnessEvent(session, {
+      type: "message.delta",
+      text: "Checked.",
+    });
+
+    expect(session.blocks.slice(1)).toMatchObject([
+      { role: "assistant", text: "Complete answer.", streaming: false },
+      { role: "system", interjection: { customType: "advisor" } },
+      { role: "assistant", text: "Checked.", streaming: true },
+    ]);
+  });
+
+  it("appends every interjection as a distinct persisted boundary", () => {
+    let session = appendUser(newSession("pi", "/tmp"), "go");
+    session = applyHarnessEvent(session, {
+      type: "interjection",
+      text: "Check the fallback.",
+      customType: "advisor",
+      severity: "concern",
+    });
+    session = applyHarnessEvent(session, {
+      type: "interjection",
+      text: "Check the fallback.",
+      customType: "advisor",
+      severity: "concern",
+    });
+
+    const interjections = session.blocks.filter((block) => block.interjection);
+    expect(interjections).toHaveLength(2);
+    expect(interjections[0]).toMatchObject({
+      role: "system",
+      text: "Check the fallback.",
+      interjection: { customType: "advisor", severity: "concern" },
+    });
+  });
+});
+
 describe("task list updates", () => {
   it("updates one structured checklist instead of appending plan cards", () => {
     let session = appendUser(newSession("codex", "/tmp"), "fix it");
@@ -454,17 +503,26 @@ describe("applyHarnessEvent context", () => {
 describe("tool enrichment", () => {
   it("retains Edit and Write previews when a tool completes without repeating its input", () => {
     for (const [name, input] of [
-      ["Edit", { file_path: "/notes.md", old_string: "old", new_string: "new" }],
+      [
+        "Edit",
+        { file_path: "/notes.md", old_string: "old", new_string: "new" },
+      ],
       ["Write", { file_path: "/notes.md", content: "  content\n" }],
       ["Write", { file_path: "/notes.md", content: "" }],
     ] as const) {
       const preview = previewFromTool(name, input)!;
       let session = applyHarnessEvent(newSession("claude", "/repo"), {
-        type: "tool.started", callId: "edit", title: name, kind: "edit",
-        status: "pending", preview,
+        type: "tool.started",
+        callId: "edit",
+        title: name,
+        kind: "edit",
+        status: "pending",
+        preview,
       });
       session = applyHarnessEvent(session, {
-        type: "tool.updated", callId: "edit", status: "completed",
+        type: "tool.updated",
+        callId: "edit",
+        status: "completed",
       });
       expect(session.blocks[0].tool?.preview).toMatchObject(preview);
       expect(session.blocks[0].tool?.preview?.lines).toEqual(preview.lines);

--- a/src/lib/harness/apply.ts
+++ b/src/lib/harness/apply.ts
@@ -478,11 +478,11 @@ function appendStatus(session: Session, text: string): Session {
 function appendBlock(session: Session, block: Block): Session {
   return {
     ...session,
-    blocks: [...(block.role === "system" ? session.blocks : sealLastStream(session.blocks)), block],
+    blocks: [...(block.role === "system" && !block.interjection ? session.blocks : sealLastStream(session.blocks)), block],
   };
 }
 
-/** Status and interjection rows do not end an open prose stream. */
+/** Only ordinary status rows leave an open prose stream intact. */
 function patchStreaming(
   session: Session,
   role: "assistant" | "reasoning",
@@ -491,7 +491,7 @@ function patchStreaming(
 ): Session {
   if (!text && role === "reasoning") return session;
   let index = session.blocks.length - 1;
-  while (index >= 0 && session.blocks[index].role === "system") index--;
+  while (index >= 0 && session.blocks[index].role === "system" && !session.blocks[index].interjection) index--;
   const last = session.blocks[index];
   if (last?.role === role && (index === session.blocks.length - 1 || last.streaming)) {
     const nextText = joinStreamText(last.text, text);
@@ -749,7 +749,7 @@ function findToolIndex(
 
 function sealLastStream(blocks: Block[]): Block[] {
   let index = blocks.length - 1;
-  while (index >= 0 && blocks[index].role === "system") index--;
+  while (index >= 0 && blocks[index].role === "system" && !blocks[index].interjection) index--;
   const last = blocks[index];
   if (
     !last?.streaming ||

--- a/src/lib/harness/apply.ts
+++ b/src/lib/harness/apply.ts
@@ -476,10 +476,13 @@ function appendStatus(session: Session, text: string): Session {
 }
 
 function appendBlock(session: Session, block: Block): Session {
-  return { ...session, blocks: [...sealLastStream(session.blocks), block] };
+  return {
+    ...session,
+    blocks: [...(block.role === "system" ? session.blocks : sealLastStream(session.blocks)), block],
+  };
 }
 
-/** Append to the latest block only when it is the same role; never splice into an earlier one. */
+/** Status and interjection rows do not end an open prose stream. */
 function patchStreaming(
   session: Session,
   role: "assistant" | "reasoning",
@@ -487,12 +490,14 @@ function patchStreaming(
   streaming: boolean,
 ): Session {
   if (!text && role === "reasoning") return session;
-  const last = session.blocks[session.blocks.length - 1];
-  if (last?.role === role) {
+  let index = session.blocks.length - 1;
+  while (index >= 0 && session.blocks[index].role === "system") index--;
+  const last = session.blocks[index];
+  if (last?.role === role && (index === session.blocks.length - 1 || last.streaming)) {
     const nextText = joinStreamText(last.text, text);
     if (nextText === last.text && last.streaming === streaming) return session;
     const blocks = session.blocks.slice();
-    blocks[blocks.length - 1] = {
+    blocks[index] = {
       ...last,
       text: nextText,
       streaming,
@@ -743,7 +748,9 @@ function findToolIndex(
 }
 
 function sealLastStream(blocks: Block[]): Block[] {
-  const last = blocks[blocks.length - 1];
+  let index = blocks.length - 1;
+  while (index >= 0 && blocks[index].role === "system") index--;
+  const last = blocks[index];
   if (
     !last?.streaming ||
     (last.role !== "assistant" && last.role !== "reasoning")
@@ -751,7 +758,7 @@ function sealLastStream(blocks: Block[]): Block[] {
     return blocks.slice();
   }
   const next = blocks.slice();
-  next[next.length - 1] = { ...last, streaming: false };
+  next[index] = { ...last, streaming: false };
   return next;
 }
 

--- a/src/lib/harness/apply.ts
+++ b/src/lib/harness/apply.ts
@@ -102,11 +102,28 @@ export function applyHarnessEvent(
         ...session,
         ...(event.model ? { model: event.model } : {}),
         ...(event.modelSettings
-          ? { modelSettings: { ...session.modelSettings, ...event.modelSettings } }
+          ? {
+              modelSettings: {
+                ...session.modelSettings,
+                ...event.modelSettings,
+              },
+            }
           : {}),
       };
     case "status":
       return appendStatus(session, event.text);
+    case "interjection":
+      // A visible boundary the user must not miss, so unlike status it never
+      // deduplicates and never reads as turn lifecycle.
+      return appendBlock(session, {
+        id: crypto.randomUUID(),
+        role: "system",
+        text: event.text,
+        interjection: {
+          customType: event.customType,
+          ...(event.severity ? { severity: event.severity } : {}),
+        },
+      });
     default:
       return session;
   }

--- a/src/lib/harness/ompLive.test.ts
+++ b/src/lib/harness/ompLive.test.ts
@@ -438,6 +438,17 @@ describe("OMP command lifecycle over the real RPC multiplexer", () => {
     await running.turn;
   });
 
+  it("emits a transient status when the OMP advisor yields", async () => {
+    const running = await started();
+    const start = events.length;
+    frame("omp-test", { type: "advisor_yielded" });
+    expect(events.slice(start)).toEqual([
+      { type: "status", text: expect.any(String) },
+    ]);
+    frame("omp-test", { type: "agent_end" });
+    await running.turn;
+  });
+
   it("uses generic content for other displayed OMP custom messages", async () => {
     const running = await started();
     frame("omp-test", {

--- a/src/lib/harness/ompLive.test.ts
+++ b/src/lib/harness/ompLive.test.ts
@@ -392,6 +392,100 @@ describe("OMP command lifecycle over the real RPC multiplexer", () => {
       1,
     );
   });
+
+  it("surfaces displayed OMP advisor notes and hides internal messages", async () => {
+    const running = await started();
+    const advisor = {
+      role: "custom",
+      customType: "advisor",
+      display: true,
+      content: "raw advisory envelope",
+      details: {
+        notes: [
+          { note: "Minor note", severity: "nit" },
+          { note: "Stop here", severity: "blocker" },
+        ],
+      },
+    };
+    frame("omp-test", { type: "message_start", message: advisor });
+    frame("omp-test", { type: "message_end", message: advisor });
+    frame("omp-test", {
+      type: "message_start",
+      message: {
+        role: "custom",
+        customType: "xdev-mount-notice",
+        display: false,
+        content: "internal mount details",
+      },
+    });
+    frame("omp-test", { type: "advisor_yielded" });
+
+    expect(events).toContainEqual({
+      type: "interjection",
+      text: "Minor note\n\nStop here",
+      customType: "advisor",
+      severity: "blocker",
+    });
+    expect(
+      events.filter((event) => event.type === "interjection"),
+    ).toHaveLength(1);
+    expect(
+      events.some(
+        (event) => "text" in event && event.text === "internal mount details",
+      ),
+    ).toBe(false);
+    frame("omp-test", { type: "agent_end" });
+    await running.turn;
+  });
+
+  it("uses generic content for other displayed OMP custom messages", async () => {
+    const running = await started();
+    frame("omp-test", {
+      type: "message_start",
+      message: {
+        role: "custom",
+        customType: "extension-notice",
+        display: true,
+        content: [
+          { type: "text", text: "Extension changed the plan." },
+          { type: "image", data: "ignored", mimeType: "image/png" },
+          { type: "text", text: "Review it." },
+        ],
+      },
+    });
+
+    expect(events).toContainEqual({
+      type: "interjection",
+      text: "Extension changed the plan.\nReview it.",
+      customType: "extension-notice",
+    });
+    frame("omp-test", { type: "agent_end" });
+    await running.turn;
+  });
+
+  it("does not reinterpret Pi custom messages as OMP interjections", async () => {
+    const turn = sendPiTurn({
+      ...input("pi-test", "hello"),
+      model: "pi:default",
+    });
+    await vi.waitFor(() =>
+      expect(transport.requests.some((r) => r.command.type === "prompt")).toBe(
+        true,
+      ),
+    );
+    frame("pi-test", {
+      type: "message_start",
+      message: {
+        role: "custom",
+        customType: "advisor",
+        display: true,
+        content: "Pi-owned custom frame",
+      },
+    });
+    expect(events.some((event) => event.type === "interjection")).toBe(false);
+    frame("pi-test", { type: "agent_end" });
+    await turn;
+  });
 });
 
 describe("OMP live command inventories", () => {

--- a/src/lib/harness/piFamily.ts
+++ b/src/lib/harness/piFamily.ts
@@ -612,6 +612,64 @@ async function runTurn(
   }
 }
 
+/**
+ * OMP's advisor and extensions interject mid-turn. Frames marked display:true
+ * exist so clients can show them: structured advisor notes replace the raw
+ * advisory envelope when present, and even a blank body stays a labeled
+ * boundary so the segments around it never silently merge.
+ */
+function customMessageText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return "";
+  return value
+    .flatMap((part) => {
+      const record = asRecord(part);
+      return record?.type === "text" && typeof record.text === "string"
+        ? [record.text]
+        : [];
+    })
+    .join("\n");
+}
+
+function interjectionFromCustomMessage(
+  message: Record<string, unknown>,
+): Extract<HarnessEvent, { type: "interjection" }> | undefined {
+  if (message.display !== true) return undefined;
+  const customType = stringField(message, "customType") ?? "custom";
+  if (customType === "advisor") {
+    const notes = asRecord(message.details)?.notes;
+    const bodies: string[] = [];
+    let severity: Extract<HarnessEvent, { type: "interjection" }>["severity"];
+    if (Array.isArray(notes)) {
+      for (const raw of notes) {
+        const note = asRecord(raw);
+        const body = stringField(note, "note");
+        if (!body) continue;
+        bodies.push(body);
+        // Keep the highest severity the retained notes actually carry.
+        const level = note?.severity;
+        if (level === "blocker") severity = "blocker";
+        else if (level === "concern" && severity !== "blocker") {
+          severity = "concern";
+        } else if (level === "nit" && !severity) severity = "nit";
+      }
+    }
+    if (bodies.length > 0) {
+      return {
+        type: "interjection",
+        text: bodies.join("\n\n"),
+        customType,
+        ...(severity ? { severity } : {}),
+      };
+    }
+  }
+  return {
+    type: "interjection",
+    text: customMessageText(message.content),
+    customType,
+  };
+}
+
 function handleFrame(
   flavor: PiFlavor,
   sessionId: string,
@@ -649,6 +707,20 @@ function handleFrame(
 
   const type = stringField(rec, "type");
   if (flavor.id === "omp") {
+    // OMP emits persisted custom_message entries on the live RPC stream as a
+    // message_start/message_end pair. Render the start once; consume the end
+    // and hidden custom messages so none can leak through a generic path.
+    if (type === "message_start" || type === "message_end") {
+      const message = asRecord(rec.message);
+      if (message?.role === "custom") {
+        if (type === "message_start") {
+          const interjection = interjectionFromCustomMessage(message);
+          if (interjection) live.onEvent(interjection);
+        }
+        return;
+      }
+    }
+    if (type === "advisor_yielded") return;
     if (type === "session_info_update") {
       const providerSessionId = stringField(rec, "sessionId");
       if (providerSessionId) {

--- a/src/lib/harness/piFamily.ts
+++ b/src/lib/harness/piFamily.ts
@@ -720,7 +720,10 @@ function handleFrame(
         return;
       }
     }
-    if (type === "advisor_yielded") return;
+    if (type === "advisor_yielded") {
+      live.onEvent({ type: "status", text: "Advisor reviewed this turn" });
+      return;
+    }
     if (type === "session_info_update") {
       const providerSessionId = stringField(rec, "sessionId");
       if (providerSessionId) {

--- a/src/lib/harness/types.ts
+++ b/src/lib/harness/types.ts
@@ -1,5 +1,6 @@
 import type {
   Attachment,
+  InterjectionMeta,
   RuntimeMode,
   TaskListItem,
   ToolPreview,
@@ -18,6 +19,7 @@ export type HarnessEvent =
       modelSettings?: Record<string, string>;
     }
   | { type: "status"; text: string }
+  | ({ type: "interjection"; text: string } & InterjectionMeta)
   | { type: "message.delta"; text: string }
   | { type: "message.completed" }
   | { type: "reasoning.delta"; text: string }

--- a/src/lib/ompInterjections.test.ts
+++ b/src/lib/ompInterjections.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OmpInterjectionAnchor } from "./fs";
-import { backfillOmpInterjections } from "./ompInterjections";
+import { backfillOmpInterjections, ompStatusSplitTexts } from "./ompInterjections";
 import { newSession, type Block } from "./session";
 import { getSession } from "./sessionStore";
 import { foldableWork, foldedBlocks, groupTurnItems, groupTurns } from "../surfaces/transcriptActivity";
@@ -213,6 +213,22 @@ describe("OMP persisted interjection repair", () => {
     expect(repaired.map(block => block.id)).toEqual(["a", "status", "c", "omp-interjection-review"]);
     expect(backfillOmpInterjections(repaired, [{ ...anchor, afterOccurrence: 2 }])).toBe(repaired);
   });
+
+  it("keeps streaming fragments and metadata even with verified full text", () => {
+    const blocks: Block[] = [
+      { id: "a", role: "assistant", text: "First." },
+      { id: "status", role: "system", text: "Reviewed" },
+      { id: "b", role: "assistant", text: "Second." },
+    ];
+    for (const index of [0, 2]) {
+      const streaming = blocks.map((block, i) => i === index ? { ...block, streaming: true } : block);
+      expect(ompStatusSplitTexts(streaming)).toEqual([]);
+      expect(backfillOmpInterjections(streaming, [], ["First.Second."])).toBe(streaming);
+    }
+    const metadata = blocks.map(block => block.id === "b" ? { ...block, durationMs: 10 } : block);
+    expect(ompStatusSplitTexts(metadata)).toEqual([]);
+    expect(backfillOmpInterjections(metadata, [], ["First.Second."])).toBe(metadata);
+  });
 });
 
 describe("persisted session loading", () => {
@@ -238,6 +254,36 @@ describe("persisted session loading", () => {
     const second = await getSession(record.id);
     expect(second!.blocks).toEqual(first!.blocks);
     expect(writes).toBe(1);
+  });
+
+  it.each([true, false])("repairs unanchored status splits only when verified: %s", async verified => {
+    let record = { ...stored(), blocks: [
+      { id: "a", role: "assistant", text: "First." },
+      { id: "status", role: "system", text: "Reviewed" },
+      { id: "b", role: "assistant", text: "Second." },
+      { id: "u", role: "user", text: "Continue" },
+    ] as Block[] };
+    const original = record.blocks;
+    let writes = 0;
+    mocks.invoke.mockImplementation(async (command, args) => {
+      if (command === "session_get") return record;
+      if (command === "omp_session_interjections") return [];
+      if (command === "omp_verify_assistant_texts") {
+        expect(args.texts).toEqual(["First.Second."]);
+        return [verified];
+      }
+      if (command === "session_upsert") {
+        writes++;
+        record = { ...record, ...args.session };
+        return record;
+      }
+      throw new Error(command);
+    });
+    const first = await getSession(record.id);
+    expect(first!.blocks).toEqual(verified
+      ? [{ ...original[0], text: "First.Second." }, original[1], original[3]] : original);
+    expect((await getSession(record.id))!.blocks).toEqual(first!.blocks);
+    expect(writes).toBe(verified ? 1 : 0);
   });
 
   it("leaves other harnesses and unbound OMP sessions untouched", async () => {

--- a/src/lib/ompInterjections.test.ts
+++ b/src/lib/ompInterjections.test.ts
@@ -209,9 +209,10 @@ describe("OMP persisted interjection repair", () => {
       { id: "b", role: "assistant", text: "answer." },
       { id: "c", role: "assistant", text: anchor.afterAssistantText },
     ];
-    const repaired = backfillOmpInterjections(blocks, [{ ...anchor, afterOccurrence: 2 }]);
+    const evidence = [{ text: anchor.afterAssistantText, occurrences: 1 }];
+    const repaired = backfillOmpInterjections(blocks, [{ ...anchor, afterOccurrence: 2 }], evidence);
     expect(repaired.map(block => block.id)).toEqual(["a", "status", "c", "omp-interjection-review"]);
-    expect(backfillOmpInterjections(repaired, [{ ...anchor, afterOccurrence: 2 }])).toBe(repaired);
+    expect(backfillOmpInterjections(repaired, [{ ...anchor, afterOccurrence: 2 }], evidence)).toBe(repaired);
   });
 
   it("keeps streaming fragments and metadata even with verified full text", () => {
@@ -223,11 +224,66 @@ describe("OMP persisted interjection repair", () => {
     for (const index of [0, 2]) {
       const streaming = blocks.map((block, i) => i === index ? { ...block, streaming: true } : block);
       expect(ompStatusSplitTexts(streaming)).toEqual([]);
-      expect(backfillOmpInterjections(streaming, [], ["First.Second."])).toBe(streaming);
+      expect(backfillOmpInterjections(streaming, [], [{ text: "First.Second.", occurrences: 1 }])).toBe(streaming);
     }
     const metadata = blocks.map(block => block.id === "b" ? { ...block, durationMs: 10 } : block);
     expect(ompStatusSplitTexts(metadata)).toEqual([]);
-    expect(backfillOmpInterjections(metadata, [], ["First.Second."])).toBe(metadata);
+    expect(backfillOmpInterjections(metadata, [], [{ text: "First.Second.", occurrences: 1 }])).toBe(metadata);
+  });
+
+  function split(id: string): Block[] {
+    return [
+      { id, role: "assistant", text: "First." },
+      { id: `${id}-status`, role: "system", text: "Reviewed" },
+      { id: `${id}-end`, role: "assistant", text: "Second." },
+    ];
+  }
+
+  it.each(["verified", "anchor", "concat"] as const)("uses one source occurrence only once: %s", source => {
+    const blocks = [...split("a"), ...split("b")];
+    const anchors = source === "verified" ? [] : [{
+      ...anchor,
+      afterAssistantText: source === "concat" ? "First.\nSecond." : "First.Second.",
+      afterAssistantTextConcat: "First.Second.",
+      afterOccurrence: source === "concat" ? 2 : 1,
+      afterConcatOccurrence: 1,
+    }];
+    const evidence = source === "verified" ? [{ text: "First.Second.", occurrences: 1 }] : [];
+    const repaired = backfillOmpInterjections(blocks, anchors, evidence);
+    expect(repaired.find(block => block.id === "a")!.text).toBe("First.Second.");
+    expect(repaired.filter(block => block.id.startsWith("b"))).toEqual(split("b"));
+    expect(backfillOmpInterjections(repaired, anchors, evidence)).toBe(repaired);
+  });
+
+  it.each([false, true])("counts an unsplit answer before a later candidate, anchored: %s", anchored => {
+    const blocks: Block[] = [{ id: "complete", role: "assistant", text: "First.Second." }, ...split("a")];
+    const anchors = anchored ? [{ ...anchor, afterAssistantText: "First.Second." }] : [];
+    const repaired = backfillOmpInterjections(blocks, anchors, [{ text: "First.Second.", occurrences: 1 }]);
+    expect(repaired.filter(block => block.id.startsWith("a"))).toEqual(split("a"));
+  });
+
+  it("repairs two splits only with two verified occurrences", () => {
+    const blocks = [...split("a"), ...split("b")];
+    const evidence = [{ text: "First.Second.", occurrences: 2 }];
+    const repaired = backfillOmpInterjections(blocks, [], evidence);
+    expect(repaired.map(block => block.id)).toEqual(["a", "a-status", "b", "b-status"]);
+    expect(repaired.filter(block => block.role === "assistant").map(block => block.text)).toEqual(["First.Second.", "First.Second."]);
+    expect(backfillOmpInterjections(repaired, [], evidence)).toBe(repaired);
+  });
+
+  it("keeps anchor and verified evidence for the same occurrence from adding together", () => {
+    const blocks = [...split("a"), ...split("b")];
+    const anchors = [{ ...anchor, afterAssistantText: "First.Second." }];
+    const evidence = [{ text: "First.Second.", occurrences: 1 }, { text: "First.Second.", occurrences: 1 }];
+    const repaired = backfillOmpInterjections(blocks, anchors, evidence);
+    expect(repaired.filter(block => block.id.startsWith("b"))).toEqual(split("b"));
+    expect(backfillOmpInterjections(repaired, anchors, evidence)).toBe(repaired);
+  });
+
+  it("does not bind a later anchor occurrence or unnumbered following text to an earlier split", () => {
+    const blocks = split("a");
+    expect(backfillOmpInterjections(blocks, [{ ...anchor, afterAssistantText: "First.Second.", afterOccurrence: 2 }])).toBe(blocks);
+    expect(backfillOmpInterjections(blocks, [{ ...anchor, followingAssistantText: "First.Second." }])).toBe(blocks);
   });
 });
 
@@ -270,7 +326,7 @@ describe("persisted session loading", () => {
       if (command === "omp_session_interjections") return [];
       if (command === "omp_verify_assistant_texts") {
         expect(args.texts).toEqual(["First.Second."]);
-        return [verified];
+        return [verified ? 1 : 0];
       }
       if (command === "session_upsert") {
         writes++;
@@ -284,6 +340,34 @@ describe("persisted session loading", () => {
       ? [{ ...original[0], text: "First.Second." }, original[1], original[3]] : original);
     expect((await getSession(record.id))!.blocks).toEqual(first!.blocks);
     expect(writes).toBe(verified ? 1 : 0);
+  });
+
+  it.each([false, true])("loads duplicate text without reusing occupied source evidence, complete first: %s", async complete => {
+    const first: Block[] = complete ? [{ id: "a", role: "assistant", text: "First.Second." }] : [
+      { id: "a", role: "assistant", text: "First." },
+      { id: "s1", role: "system", text: "Reviewed" },
+      { id: "b", role: "assistant", text: "Second." },
+    ];
+    const later: Block[] = [
+      { id: "c", role: "assistant", text: "First." },
+      { id: "s2", role: "system", text: "Reviewed" },
+      { id: "d", role: "assistant", text: "Second." },
+    ];
+    const record = { ...stored(), blocks: [...first, ...later] };
+    mocks.invoke.mockImplementation(async (command, args) => {
+      if (command === "session_get") return record;
+      if (command === "omp_session_interjections") return [];
+      if (command === "omp_verify_assistant_texts") {
+        expect(args.texts).toEqual(complete ? ["First.Second."] : ["First.Second.", "First.Second."]);
+        return args.texts.map(() => 1);
+      }
+      if (command === "session_upsert") return args.session;
+      throw new Error(command);
+    });
+    const loaded = (await getSession(record.id))!;
+    expect(loaded.blocks[0]).toMatchObject({ id: "a", text: "First.Second." });
+    expect(loaded.blocks.slice(-3)).toEqual(later);
+    expect(loaded.blocks).toHaveLength(complete ? 4 : 5);
   });
 
   it("leaves other harnesses and unbound OMP sessions untouched", async () => {

--- a/src/lib/ompInterjections.test.ts
+++ b/src/lib/ompInterjections.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OmpInterjectionAnchor } from "./fs";
+import type { OmpAssistantText, OmpInterjectionAnchor } from "./fs";
 import { backfillOmpInterjections, ompStatusSplitTexts } from "./ompInterjections";
 import { newSession, type Block } from "./session";
 import { getSession } from "./sessionStore";
@@ -178,7 +178,12 @@ describe("OMP persisted interjection repair", () => {
     expect(backfillOmpInterjections(repaired, [first, last])).toBe(repaired);
   });
 
-  it("merges status-split prose with exact source evidence before placing later anchors", () => {
+  /** Ordered active-path source messages; a string is one message in both forms. */
+  function source(...messages: (string | OmpAssistantText)[]): OmpAssistantText[] {
+    return messages.map(message => typeof message === "string" ? { text: message, concat: message } : message);
+  }
+
+  it("merges status-split prose with the next source message before placing later anchors", () => {
     const first = { ...anchor, afterAssistantText: "First.Second.", followingAssistantText: "Later." };
     const later = { ...anchor, id: "later", afterAssistantText: "Later." };
     const blocks: Block[] = [
@@ -187,35 +192,66 @@ describe("OMP persisted interjection repair", () => {
       { id: "b", role: "assistant", text: "Second." },
       { id: "c", role: "assistant", text: "Later." },
     ];
-    const repaired = backfillOmpInterjections(blocks, [first, later]);
+    const messages = source("First.Second.", "Later.");
+    const repaired = backfillOmpInterjections(blocks, [first, later], messages);
     expect(repaired.map(block => [block.id, block.text])).toEqual([
       ["a", "First.Second."], ["omp-interjection-review", anchor.text],
       ["status", blocks[1].text], ["c", "Later."], ["omp-interjection-later", anchor.text],
     ]);
-    expect(backfillOmpInterjections(repaired, [first, later])).toBe(repaired);
+    expect(backfillOmpInterjections(repaired, [first, later], messages)).toBe(repaired);
     expect(blocks[0].text).toBe("First.");
-    expect(backfillOmpInterjections(blocks, [{ ...first, afterAssistantText: "First. Second." }])).toBe(blocks);
+    expect(backfillOmpInterjections(blocks, [{ ...first, afterAssistantText: "First. Second." }], source("First. Second.", "Later."))).toBe(blocks);
     const interleaved = blocks.map(block => block.id === "status"
       ? { ...block, interjection: { customType: "advisor" } } : block);
-    expect(backfillOmpInterjections(interleaved, [first])).toBe(interleaved);
+    expect(backfillOmpInterjections(interleaved, [first], messages)).toBe(interleaved);
     const metadata = blocks.map(block => block.id === "b" ? { ...block, durationMs: 10 } : block);
-    expect(backfillOmpInterjections(metadata, [first])).toBe(metadata);
+    expect(backfillOmpInterjections(metadata, [first], messages)).toBe(metadata);
   });
 
-  it("counts merged messages in exact source occurrence order", () => {
+  it("never merges on anchor occurrences alone", () => {
+    const blocks: Block[] = [
+      { id: "a", role: "assistant", text: "First." },
+      { id: "status", role: "system", text: "Reviewed" },
+      { id: "b", role: "assistant", text: "Second." },
+    ];
+    const anchors = [{ ...anchor, afterAssistantText: "First.Second.", afterAssistantTextConcat: "First.Second.", afterConcatOccurrence: 1 }];
+    expect(backfillOmpInterjections(blocks, anchors)).toBe(blocks);
+    expect(backfillOmpInterjections(blocks, [{ ...anchors[0], afterAssistantText: "First.\nSecond.", afterOccurrence: 2 }])).toBe(blocks);
+    const repaired = backfillOmpInterjections(blocks, anchors, source("First.Second."));
+    expect(repaired.map(block => block.id)).toEqual(["a", "omp-interjection-review", "status"]);
+  });
+
+  it("keeps a split whose fragments are the next two source messages before the real complete answer", () => {
+    const blocks: Block[] = [
+      { id: "a", role: "assistant", text: "First." },
+      { id: "status", role: "system", text: "Reviewed" },
+      { id: "b", role: "assistant", text: "Second." },
+      { id: "c", role: "assistant", text: "First.Second." },
+    ];
+    const messages = source("First.", "Second.", "First.Second.");
+    expect(ompStatusSplitTexts(blocks)).toEqual(["First.Second."]);
+    expect(backfillOmpInterjections(blocks, [], messages)).toBe(blocks);
+    const anchors = [{ ...anchor, afterAssistantText: "First.Second." }];
+    const repaired = backfillOmpInterjections(blocks, anchors, messages);
+    expect(repaired.map(block => block.id)).toEqual(["a", "status", "b", "c", "omp-interjection-review"]);
+    expect(backfillOmpInterjections(repaired, anchors, messages)).toBe(repaired);
+  });
+
+  it("leaves a split whose first fragment is its own source message and anchors the later complete answer", () => {
     const blocks: Block[] = [
       { id: "a", role: "assistant", text: "The complete " },
       { id: "status", role: "system", text: "Reviewed" },
       { id: "b", role: "assistant", text: "answer." },
       { id: "c", role: "assistant", text: anchor.afterAssistantText },
     ];
-    const evidence = [{ text: anchor.afterAssistantText, occurrences: 1 }];
-    const repaired = backfillOmpInterjections(blocks, [{ ...anchor, afterOccurrence: 2 }], evidence);
-    expect(repaired.map(block => block.id)).toEqual(["a", "status", "c", "omp-interjection-review"]);
-    expect(backfillOmpInterjections(repaired, [{ ...anchor, afterOccurrence: 2 }], evidence)).toBe(repaired);
+    const messages = source("The complete ", "answer.", anchor.afterAssistantText);
+    const repaired = backfillOmpInterjections(blocks, [anchor], messages);
+    expect(repaired.map(block => block.id)).toEqual(["a", "status", "b", "c", "omp-interjection-review"]);
+    expect(backfillOmpInterjections(repaired, [anchor], messages)).toBe(repaired);
+    expect(backfillOmpInterjections(blocks, [{ ...anchor, afterOccurrence: 2 }], messages)).toBe(blocks);
   });
 
-  it("keeps streaming fragments and metadata even with verified full text", () => {
+  it("keeps streaming fragments and metadata even with a matching source message", () => {
     const blocks: Block[] = [
       { id: "a", role: "assistant", text: "First." },
       { id: "status", role: "system", text: "Reviewed" },
@@ -224,11 +260,11 @@ describe("OMP persisted interjection repair", () => {
     for (const index of [0, 2]) {
       const streaming = blocks.map((block, i) => i === index ? { ...block, streaming: true } : block);
       expect(ompStatusSplitTexts(streaming)).toEqual([]);
-      expect(backfillOmpInterjections(streaming, [], [{ text: "First.Second.", occurrences: 1 }])).toBe(streaming);
+      expect(backfillOmpInterjections(streaming, [], source("First.Second."))).toBe(streaming);
     }
     const metadata = blocks.map(block => block.id === "b" ? { ...block, durationMs: 10 } : block);
     expect(ompStatusSplitTexts(metadata)).toEqual([]);
-    expect(backfillOmpInterjections(metadata, [], [{ text: "First.Second.", occurrences: 1 }])).toBe(metadata);
+    expect(backfillOmpInterjections(metadata, [], source("First.Second."))).toBe(metadata);
   });
 
   function split(id: string): Block[] {
@@ -239,45 +275,53 @@ describe("OMP persisted interjection repair", () => {
     ];
   }
 
-  it.each(["verified", "anchor", "concat"] as const)("uses one source occurrence only once: %s", source => {
+  it.each([
+    ["newline", { text: "First.\nSecond.", concat: "First.Second." }],
+    ["concat", { text: "First.Second.", concat: "First.Second." }],
+  ])("consumes one source message for one split, form: %s", (_form, message) => {
     const blocks = [...split("a"), ...split("b")];
-    const anchors = source === "verified" ? [] : [{
-      ...anchor,
-      afterAssistantText: source === "concat" ? "First.\nSecond." : "First.Second.",
-      afterAssistantTextConcat: "First.Second.",
-      afterOccurrence: source === "concat" ? 2 : 1,
-      afterConcatOccurrence: 1,
-    }];
-    const evidence = source === "verified" ? [{ text: "First.Second.", occurrences: 1 }] : [];
-    const repaired = backfillOmpInterjections(blocks, anchors, evidence);
+    const messages = source(message);
+    const repaired = backfillOmpInterjections(blocks, [], messages);
     expect(repaired.find(block => block.id === "a")!.text).toBe("First.Second.");
     expect(repaired.filter(block => block.id.startsWith("b"))).toEqual(split("b"));
-    expect(backfillOmpInterjections(repaired, anchors, evidence)).toBe(repaired);
+    expect(backfillOmpInterjections(repaired, [], messages)).toBe(repaired);
   });
 
-  it.each([false, true])("counts an unsplit answer before a later candidate, anchored: %s", anchored => {
+  it("merges a true split followed by a different complete message", () => {
+    const blocks: Block[] = [...split("a"), { id: "c", role: "assistant", text: "Later." }];
+    const repaired = backfillOmpInterjections(blocks, [], source("First.Second.", "Later."));
+    expect(repaired.map(block => [block.id, block.text])).toEqual([
+      ["a", "First.Second."], ["a-status", "Reviewed"], ["c", "Later."],
+    ]);
+  });
+
+  it.each([false, true])("lets an unsplit answer occupy its source slot before a later candidate, anchored: %s", anchored => {
     const blocks: Block[] = [{ id: "complete", role: "assistant", text: "First.Second." }, ...split("a")];
     const anchors = anchored ? [{ ...anchor, afterAssistantText: "First.Second." }] : [];
-    const repaired = backfillOmpInterjections(blocks, anchors, [{ text: "First.Second.", occurrences: 1 }]);
+    const repaired = backfillOmpInterjections(blocks, anchors, source("First.Second."));
     expect(repaired.filter(block => block.id.startsWith("a"))).toEqual(split("a"));
+    const both = backfillOmpInterjections(blocks, anchors, source("First.Second.", "First.Second."));
+    expect(both.filter(block => block.role === "assistant").map(block => [block.id, block.text])).toEqual([
+      ["complete", "First.Second."], ["a", "First.Second."],
+    ]);
   });
 
-  it("repairs two splits only with two verified occurrences", () => {
+  it("repairs two splits only with two source messages", () => {
     const blocks = [...split("a"), ...split("b")];
-    const evidence = [{ text: "First.Second.", occurrences: 2 }];
-    const repaired = backfillOmpInterjections(blocks, [], evidence);
+    const messages = source("First.Second.", "First.Second.");
+    const repaired = backfillOmpInterjections(blocks, [], messages);
     expect(repaired.map(block => block.id)).toEqual(["a", "a-status", "b", "b-status"]);
     expect(repaired.filter(block => block.role === "assistant").map(block => block.text)).toEqual(["First.Second.", "First.Second."]);
-    expect(backfillOmpInterjections(repaired, [], evidence)).toBe(repaired);
+    expect(backfillOmpInterjections(repaired, [], messages)).toBe(repaired);
   });
 
-  it("keeps anchor and verified evidence for the same occurrence from adding together", () => {
+  it("keeps anchor evidence from adding to the source sequence", () => {
     const blocks = [...split("a"), ...split("b")];
     const anchors = [{ ...anchor, afterAssistantText: "First.Second." }];
-    const evidence = [{ text: "First.Second.", occurrences: 1 }, { text: "First.Second.", occurrences: 1 }];
-    const repaired = backfillOmpInterjections(blocks, anchors, evidence);
+    const messages = source("First.Second.");
+    const repaired = backfillOmpInterjections(blocks, anchors, messages);
     expect(repaired.filter(block => block.id.startsWith("b"))).toEqual(split("b"));
-    expect(backfillOmpInterjections(repaired, anchors, evidence)).toBe(repaired);
+    expect(backfillOmpInterjections(repaired, anchors, messages)).toBe(repaired);
   });
 
   it("does not bind a later anchor occurrence or unnumbered following text to an earlier split", () => {
@@ -286,12 +330,19 @@ describe("OMP persisted interjection repair", () => {
     expect(backfillOmpInterjections(blocks, [{ ...anchor, followingAssistantText: "First.Second." }])).toBe(blocks);
   });
 
-  it("caps ten identical splits at the verified occurrence bound", () => {
+  it("merges ten identical splits only against the three source messages in order", () => {
     const blocks = Array.from({ length: 10 }, (_, i) => split(String(i))).flat();
-    const repaired = backfillOmpInterjections(blocks, [], [{ text: "First.Second.", occurrences: 3 }]);
-    expect(repaired.filter(block => block.role === "assistant" && block.text === "First.Second.")).toHaveLength(3);
+    const messages = source("First.Second.", "First.Second.", "First.Second.");
+    const repaired = backfillOmpInterjections(blocks, [], messages);
+    expect(repaired.filter(block => block.role === "assistant" && block.text === "First.Second.").map(block => block.id)).toEqual(["0", "1", "2"]);
     expect(repaired.filter(block => block.id.endsWith("-end"))).toHaveLength(7);
-    expect(backfillOmpInterjections(repaired, [], [{ text: "First.Second.", occurrences: 3 }])).toBe(repaired);
+    expect(backfillOmpInterjections(repaired, [], messages)).toBe(repaired);
+  });
+
+  it("realigns a complete block past source messages the transcript never stored", () => {
+    const blocks: Block[] = [{ id: "complete", role: "assistant", text: "Intro." }, ...split("a")];
+    const repaired = backfillOmpInterjections(blocks, [], source("Setup.", "Intro.", "First.Second."));
+    expect(repaired.map(block => block.id)).toEqual(["complete", "a", "a-status"]);
   });
 });
 
@@ -332,9 +383,9 @@ describe("persisted session loading", () => {
     mocks.invoke.mockImplementation(async (command, args) => {
       if (command === "session_get") return record;
       if (command === "omp_session_interjections") return [];
-      if (command === "omp_verify_assistant_texts") {
-        expect(args.texts).toEqual(["First.Second."]);
-        return [verified ? 1 : 0];
+      if (command === "omp_active_assistant_texts") {
+        expect(args).toEqual({ providerSessionId: "provider" });
+        return verified ? [{ text: "First.Second.", concat: "First.Second." }] : [];
       }
       if (command === "session_upsert") {
         writes++;
@@ -365,10 +416,7 @@ describe("persisted session loading", () => {
     mocks.invoke.mockImplementation(async (command, args) => {
       if (command === "session_get") return record;
       if (command === "omp_session_interjections") return [];
-      if (command === "omp_verify_assistant_texts") {
-        expect(args.texts).toEqual(complete ? ["First.Second."] : ["First.Second.", "First.Second."]);
-        return args.texts.map(() => 1);
-      }
+      if (command === "omp_active_assistant_texts") return [{ text: "First.Second.", concat: "First.Second." }];
       if (command === "session_upsert") return args.session;
       throw new Error(command);
     });
@@ -376,6 +424,27 @@ describe("persisted session loading", () => {
     expect(loaded.blocks[0]).toMatchObject({ id: "a", text: "First.Second." });
     expect(loaded.blocks.slice(-3)).toEqual(later);
     expect(loaded.blocks).toHaveLength(complete ? 4 : 5);
+  });
+
+  it("loads a split of two source messages before their concatenation unchanged", async () => {
+    const record = { ...stored(), blocks: [
+      { id: "a", role: "assistant", text: "First." },
+      { id: "status", role: "system", text: "Reviewed" },
+      { id: "b", role: "assistant", text: "Second." },
+      { id: "c", role: "assistant", text: "First.Second." },
+    ] as Block[] };
+    const commands: string[] = [];
+    mocks.invoke.mockImplementation(async command => {
+      commands.push(command);
+      if (command === "session_get") return record;
+      if (command === "omp_session_interjections") return [];
+      if (command === "omp_active_assistant_texts") {
+        return ["First.", "Second.", "First.Second."].map(text => ({ text, concat: text }));
+      }
+      throw new Error(command);
+    });
+    expect((await getSession(record.id))!.blocks).toEqual(record.blocks);
+    expect(commands).toEqual(["session_get", "omp_session_interjections", "omp_active_assistant_texts"]);
   });
 
   it("leaves other harnesses and unbound OMP sessions untouched", async () => {

--- a/src/lib/ompInterjections.test.ts
+++ b/src/lib/ompInterjections.test.ts
@@ -237,6 +237,87 @@ describe("OMP persisted interjection repair", () => {
     expect(backfillOmpInterjections(repaired, anchors, messages)).toBe(repaired);
   });
 
+  it("keeps a split whose fragments are later source messages when the combined text was never persisted", () => {
+    const blocks = split("a");
+    const messages = source("First.Second.", "First.", "Second.");
+    expect(backfillOmpInterjections(blocks, [], messages)).toBe(blocks);
+    const tail: Block[] = [...blocks, { id: "c", role: "assistant", text: "First.Second." }];
+    const messagesTail = source("First.Second.", "First.", "Second.", "First.Second.");
+    expect(backfillOmpInterjections(tail, [], messagesTail)).toBe(tail);
+  });
+
+  it("prefers the alignment that explains every block when fragment slots are claimed by later pairs", () => {
+    const blocks: Block[] = [
+      ...split("p1"),
+      { id: "m", role: "assistant", text: "Marker." },
+      ...split("p2"),
+      { id: "tail", role: "assistant", text: "First.Second." },
+    ];
+    const messages = source("First.Second.", "Marker.", "First.", "Second.", "First.Second.");
+    const repaired = backfillOmpInterjections(blocks, [], messages);
+    expect(repaired.map(block => [block.id, block.text])).toEqual([
+      ["p1", "First.Second."], ["p1-status", "Reviewed"], ["m", "Marker."],
+      ["p2", "First."], ["p2-status", "Reviewed"], ["p2-end", "Second."], ["tail", "First.Second."],
+    ]);
+  });
+
+  it("repairs a status chain as one message in a single idempotent pass", () => {
+    const chained: Block[] = [
+      { id: "a", role: "assistant", text: "A." },
+      { id: "a-s1", role: "system", text: "Reviewed" },
+      { id: "a-b", role: "assistant", text: "B." },
+      { id: "a-s2", role: "system", text: "Reviewed" },
+      { id: "a-c", role: "assistant", text: "C." },
+    ];
+    const repaired = backfillOmpInterjections(chained, [], source("A.B.", "A.B.C."));
+    expect(repaired.map(block => [block.id, block.text])).toEqual([
+      ["a", "A.B.C."], ["a-s1", "Reviewed"], ["a-s2", "Reviewed"],
+    ]);
+    expect(backfillOmpInterjections(repaired, [], source("A.B.", "A.B.C."))).toBe(repaired);
+  });
+
+  it("welds only the pair when a chain's middle fragment ends a real message", () => {
+    const chained: Block[] = [
+      { id: "a", role: "assistant", text: "A." },
+      { id: "a-s1", role: "system", text: "Reviewed" },
+      { id: "a-b", role: "assistant", text: "B." },
+      { id: "a-s2", role: "system", text: "Reviewed" },
+      { id: "a-c", role: "assistant", text: "C." },
+    ];
+    const repaired = backfillOmpInterjections(chained, [], source("A.B.", "C."));
+    expect(repaired.map(block => [block.id, block.text])).toEqual([
+      ["a", "A.B."], ["a-s1", "Reviewed"], ["a-s2", "Reviewed"], ["a-c", "C."],
+    ]);
+  });
+
+  it("never re-welds a block that already claimed an earlier source slot", () => {
+    const blocks: Block[] = [
+      { id: "a", role: "assistant", text: "First." },
+      { id: "a-status", role: "system", text: "Reviewed" },
+      { id: "b", role: "assistant", text: "Second." },
+      { id: "c", role: "assistant", text: "Third." },
+    ];
+    const messages = source("First.Second.", "First.Second.Third.");
+    const once = backfillOmpInterjections(blocks, [], messages);
+    expect(once.map(block => [block.id, block.text])).toEqual([
+      ["a", "First.Second."], ["a-status", "Reviewed"], ["c", "Third."],
+    ]);
+    expect(backfillOmpInterjections(once, [], messages)).toBe(once);
+  });
+
+  it("keeps a split whose fragments are separated later source messages", () => {
+    const blocks = split("a");
+    const messages = source("First.Second.", "Unrelated.", "First.", "Second.");
+    expect(backfillOmpInterjections(blocks, [], messages)).toBe(blocks);
+  });
+
+  it("still merges a true split when only one fragment is a later source message", () => {
+    for (const messages of [source("First.Second.", "First."), source("First.Second.", "Second.")]) {
+      const repaired = backfillOmpInterjections(split("a"), [], messages);
+      expect(repaired.map(block => block.text)).toEqual(["First.Second.", "Reviewed"]);
+    }
+  });
+
   it("leaves a split whose first fragment is its own source message and anchors the later complete answer", () => {
     const blocks: Block[] = [
       { id: "a", role: "assistant", text: "The complete " },

--- a/src/lib/ompInterjections.test.ts
+++ b/src/lib/ompInterjections.test.ts
@@ -90,6 +90,51 @@ describe("OMP persisted interjection repair", () => {
     ]);
     expect(backfillOmpInterjections(repaired, [anchor, second])).toBe(repaired);
   });
+
+  it("preserves a split continuation after an existing live boundary and a new anchor", () => {
+    const blocks: Block[] = [
+      { id: "a", role: "assistant", text: "First.Second." },
+      { id: "live", role: "system", text: anchor.text, interjection: { customType: "advisor", severity: "concern" } },
+    ];
+    const first = { ...anchor, afterAssistantText: "First.Second." };
+    const second = { ...anchor, id: "second", afterAssistantText: "First.", followingAssistantText: "Second.", text: "Another review." };
+    const repaired = backfillOmpInterjections(blocks, [first, second]);
+    expect(repaired.map(block => [block.role, block.text])).toEqual([
+      ["assistant", "First."], ["system", anchor.text],
+      ["system", second.text], ["assistant", "Second."],
+    ]);
+    expect(backfillOmpInterjections(repaired, [first, second])).toBe(repaired);
+    expect(backfillOmpInterjections(blocks, [first, second])).toEqual(repaired);
+    expect(blocks[0].text).toBe("First.Second.");
+  });
+
+  it("matches subsequent anchors against a continuation created in the same pass", () => {
+    const blocks: Block[] = [{ id: "a", role: "assistant", text: "First.Second." }];
+    const first = { ...anchor, afterAssistantText: "First.", followingAssistantText: "Second." };
+    const second = { ...anchor, id: "second", afterAssistantText: "Second.", text: "Second review." };
+    const repaired = backfillOmpInterjections(blocks, [first, second]);
+    expect(repaired.map(block => [block.role, block.text])).toEqual([
+      ["assistant", "First."], ["system", first.text],
+      ["assistant", "Second."], ["system", second.text],
+    ]);
+    expect(backfillOmpInterjections(repaired, [first, second])).toBe(repaired);
+  });
+
+  it("keeps all adjacent live notes before a recovered continuation", () => {
+    const first = { ...anchor, afterAssistantText: "First.", followingAssistantText: "Second." };
+    const second = { ...first, id: "second", text: "Second review." };
+    const blocks: Block[] = [
+      { id: "a", role: "assistant", text: "First.Second." },
+      { id: "live-1", role: "system", text: first.text, interjection: { customType: "advisor", severity: "concern" } },
+      { id: "live-2", role: "system", text: second.text, interjection: { customType: "advisor", severity: "concern" } },
+    ];
+    const repaired = backfillOmpInterjections(blocks, [first, second]);
+    expect(repaired.map(block => [block.role, block.text])).toEqual([
+      ["assistant", "First."], ["system", first.text],
+      ["system", second.text], ["assistant", "Second."],
+    ]);
+    expect(backfillOmpInterjections(repaired, [first, second])).toBe(repaired);
+  });
 });
 
 describe("persisted session loading", () => {

--- a/src/lib/ompInterjections.test.ts
+++ b/src/lib/ompInterjections.test.ts
@@ -285,6 +285,14 @@ describe("OMP persisted interjection repair", () => {
     expect(backfillOmpInterjections(blocks, [{ ...anchor, afterAssistantText: "First.Second.", afterOccurrence: 2 }])).toBe(blocks);
     expect(backfillOmpInterjections(blocks, [{ ...anchor, followingAssistantText: "First.Second." }])).toBe(blocks);
   });
+
+  it("caps ten identical splits at the verified occurrence bound", () => {
+    const blocks = Array.from({ length: 10 }, (_, i) => split(String(i))).flat();
+    const repaired = backfillOmpInterjections(blocks, [], [{ text: "First.Second.", occurrences: 3 }]);
+    expect(repaired.filter(block => block.role === "assistant" && block.text === "First.Second.")).toHaveLength(3);
+    expect(repaired.filter(block => block.id.endsWith("-end"))).toHaveLength(7);
+    expect(backfillOmpInterjections(repaired, [], [{ text: "First.Second.", occurrences: 3 }])).toBe(repaired);
+  });
 });
 
 describe("persisted session loading", () => {

--- a/src/lib/ompInterjections.test.ts
+++ b/src/lib/ompInterjections.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OmpInterjectionAnchor } from "./fs";
+import { backfillOmpInterjections } from "./ompInterjections";
+import { newSession, type Block } from "./session";
+import { getSession } from "./sessionStore";
+import { foldableWork, foldedBlocks, groupTurnItems, groupTurns } from "../surfaces/transcriptActivity";
+
+const mocks = vi.hoisted(() => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
+afterEach(() => mocks.invoke.mockReset());
+
+const anchor: OmpInterjectionAnchor = {
+  id: "review",
+  afterAssistantText: "The complete answer.",
+  afterOccurrence: 1,
+  text: "Check the fallback.",
+  customType: "advisor",
+  severity: "concern",
+};
+
+function oldBlocks(): Block[] {
+  return [
+    { id: "u", role: "user", text: "Go" },
+    { id: "r1", role: "reasoning", text: "Thinking" },
+    { id: "t1", role: "tool", text: "Check", tool: { kind: "shell", title: "Check", status: "completed" } },
+    { id: "a1", role: "assistant", text: anchor.afterAssistantText },
+    { id: "r2", role: "reasoning", text: "Rechecking" },
+    { id: "t2", role: "tool", text: "Test", tool: { kind: "shell", title: "Test", status: "completed" } },
+    { id: "a2", role: "assistant", text: "Checked." },
+  ];
+}
+
+function foldedIds(blocks: Block[]) {
+  const items = groupTurnItems(groupTurns(blocks)[0]);
+  return foldedBlocks(items, foldableWork(items)!).map(block => block.id);
+}
+
+describe("OMP persisted interjection repair", () => {
+  it("restores the complete answer outside the work fold without inventing a turn", () => {
+    const before = oldBlocks();
+    expect(foldedIds(before)).toContain("a1");
+    const repaired = backfillOmpInterjections(before, [anchor]);
+    expect(repaired[4]).toMatchObject({ id: "omp-interjection-review", role: "system", text: anchor.text, interjection: { customType: "advisor", severity: "concern" } });
+    expect(groupTurns(repaired)).toHaveLength(1);
+    expect(foldedIds(repaired)).toEqual(["r2", "t2"]);
+    expect(before.map(block => block.id)).toEqual(["u", "r1", "t1", "a1", "r2", "t2", "a2"]);
+  });
+
+  it("targets the second identical answer rather than the first", () => {
+    const blocks = oldBlocks();
+    blocks[6] = { ...blocks[6], text: anchor.afterAssistantText };
+    const repaired = backfillOmpInterjections(blocks, [{ ...anchor, afterOccurrence: 2 }]);
+    expect(repaired.map(block => block.id)).toEqual(["u", "r1", "t1", "a1", "r2", "t2", "a2", "omp-interjection-review"]);
+  });
+
+  it("keeps unanchored progress prose folding and rejects approximate matches", () => {
+    const blocks = oldBlocks();
+    expect(backfillOmpInterjections(blocks, [])).toBe(blocks);
+    expect(backfillOmpInterjections(blocks, [{ ...anchor, afterAssistantText: "The complete" }])).toBe(blocks);
+    expect(backfillOmpInterjections(blocks, [{ ...anchor, afterAssistantText: ` ${anchor.afterAssistantText}` }])).toBe(blocks);
+    expect(foldedIds(blocks)).toContain("a1");
+  });
+
+  it("does not duplicate repaired or already captured live boundaries", () => {
+    const repaired = backfillOmpInterjections(oldBlocks(), [anchor]);
+    expect(backfillOmpInterjections(repaired, [anchor])).toBe(repaired);
+    const live = repaired.map(block => block.interjection ? { ...block, id: "random-live-id" } : block);
+    expect(backfillOmpInterjections(live, [anchor])).toBe(live);
+  });
+
+  it("splits a coalesced answer only with an exact full continuation from the source", () => {
+    const blocks: Block[] = [{ id: "a", role: "assistant", text: "First.\uD834\uDD1ESecond." }];
+    const merged = { ...anchor, afterAssistantText: "First.\uD834\uDD1E", followingAssistantText: "Second." };
+    const repaired = backfillOmpInterjections(blocks, [merged]);
+    expect(repaired.map(block => [block.role, block.text])).toEqual([
+      ["assistant", "First.\uD834\uDD1E"], ["system", anchor.text], ["assistant", "Second."],
+    ]);
+    expect(backfillOmpInterjections(repaired, [merged])).toBe(repaired);
+    expect(backfillOmpInterjections(blocks, [{ ...merged, followingAssistantText: "Second" }])).toBe(blocks);
+    expect(backfillOmpInterjections(blocks, [{ ...merged, followingAssistantText: undefined }])).toBe(blocks);
+  });
+
+  it("preserves source order and consumes live rows only once", () => {
+    const first = backfillOmpInterjections(oldBlocks(), [anchor]);
+    first[4] = { ...first[4], id: "live" };
+    const second = { ...anchor, id: "review-again" };
+    const repaired = backfillOmpInterjections(first, [anchor, second]);
+    expect(repaired.filter(block => block.interjection).map(block => block.id)).toEqual([
+      "live", "omp-interjection-review-again",
+    ]);
+    expect(backfillOmpInterjections(repaired, [anchor, second])).toBe(repaired);
+  });
+});
+
+describe("persisted session loading", () => {
+  function stored(harness: "omp" | "pi" = "omp", providerSessionId: string | undefined = "provider") {
+    return { ...newSession(harness, "/tmp/project"), id: "repair-load", providerSessionId, blocks: oldBlocks() };
+  }
+
+  it("repairs before returning and persists only the first repair", async () => {
+    let record = stored();
+    let writes = 0;
+    mocks.invoke.mockImplementation(async (command, args) => {
+      if (command === "session_get") return record;
+      if (command === "omp_session_interjections") return [anchor];
+      if (command === "session_upsert") {
+        writes += 1;
+        record = { ...record, ...args.session };
+        return record;
+      }
+      throw new Error(command);
+    });
+    const first = await getSession(record.id);
+    expect(foldedIds(first!.blocks)).toEqual(["r2", "t2"]);
+    const second = await getSession(record.id);
+    expect(second!.blocks).toEqual(first!.blocks);
+    expect(writes).toBe(1);
+  });
+
+  it("leaves other harnesses and unbound OMP sessions untouched", async () => {
+    const other = stored("pi");
+    mocks.invoke.mockResolvedValue(other);
+    expect((await getSession(other.id))!.blocks).toEqual(other.blocks);
+    const unbound = { ...stored(), providerSessionId: undefined };
+    mocks.invoke.mockResolvedValue(unbound);
+    expect((await getSession(unbound.id))!.blocks).toEqual(unbound.blocks);
+    expect(mocks.invoke.mock.calls.map(call => call[0])).toEqual(["session_get", "session_get"]);
+  });
+
+  it("loads normally when the source command fails", async () => {
+    const record = stored();
+    mocks.invoke.mockImplementation(async command => {
+      if (command === "session_get") return record;
+      throw new Error("Log unavailable");
+    });
+    expect((await getSession(record.id))!.blocks).toEqual(record.blocks);
+  });
+
+  it("still displays recovered boundaries when persistence fails", async () => {
+    const record = stored();
+    mocks.invoke.mockImplementation(async command => {
+      if (command === "session_get") return record;
+      if (command === "omp_session_interjections") return [anchor];
+      throw new Error("Database unavailable");
+    });
+    expect(foldedIds((await getSession(record.id))!.blocks)).toEqual(["r2", "t2"]);
+  });
+});

--- a/src/lib/ompInterjections.test.ts
+++ b/src/lib/ompInterjections.test.ts
@@ -177,6 +177,42 @@ describe("OMP persisted interjection repair", () => {
     expect(repaired.map(block => block.text)).toEqual(["First.", first.text, last.text, "Second."]);
     expect(backfillOmpInterjections(repaired, [first, last])).toBe(repaired);
   });
+
+  it("merges status-split prose with exact source evidence before placing later anchors", () => {
+    const first = { ...anchor, afterAssistantText: "First.Second.", followingAssistantText: "Later." };
+    const later = { ...anchor, id: "later", afterAssistantText: "Later." };
+    const blocks: Block[] = [
+      { id: "a", role: "assistant", text: "First." },
+      { id: "status", role: "system", text: "Advisor reviewed this turn" },
+      { id: "b", role: "assistant", text: "Second." },
+      { id: "c", role: "assistant", text: "Later." },
+    ];
+    const repaired = backfillOmpInterjections(blocks, [first, later]);
+    expect(repaired.map(block => [block.id, block.text])).toEqual([
+      ["a", "First.Second."], ["omp-interjection-review", anchor.text],
+      ["status", blocks[1].text], ["c", "Later."], ["omp-interjection-later", anchor.text],
+    ]);
+    expect(backfillOmpInterjections(repaired, [first, later])).toBe(repaired);
+    expect(blocks[0].text).toBe("First.");
+    expect(backfillOmpInterjections(blocks, [{ ...first, afterAssistantText: "First. Second." }])).toBe(blocks);
+    const interleaved = blocks.map(block => block.id === "status"
+      ? { ...block, interjection: { customType: "advisor" } } : block);
+    expect(backfillOmpInterjections(interleaved, [first])).toBe(interleaved);
+    const metadata = blocks.map(block => block.id === "b" ? { ...block, durationMs: 10 } : block);
+    expect(backfillOmpInterjections(metadata, [first])).toBe(metadata);
+  });
+
+  it("counts merged messages in exact source occurrence order", () => {
+    const blocks: Block[] = [
+      { id: "a", role: "assistant", text: "The complete " },
+      { id: "status", role: "system", text: "Reviewed" },
+      { id: "b", role: "assistant", text: "answer." },
+      { id: "c", role: "assistant", text: anchor.afterAssistantText },
+    ];
+    const repaired = backfillOmpInterjections(blocks, [{ ...anchor, afterOccurrence: 2 }]);
+    expect(repaired.map(block => block.id)).toEqual(["a", "status", "c", "omp-interjection-review"]);
+    expect(backfillOmpInterjections(repaired, [{ ...anchor, afterOccurrence: 2 }])).toBe(repaired);
+  });
 });
 
 describe("persisted session loading", () => {

--- a/src/lib/ompInterjections.test.ts
+++ b/src/lib/ompInterjections.test.ts
@@ -135,6 +135,48 @@ describe("OMP persisted interjection repair", () => {
     ]);
     expect(backfillOmpInterjections(repaired, [first, second])).toBe(repaired);
   });
+
+  it("adds tool-result and chained notes around an already repaired boundary without changing IDs", () => {
+    const before = backfillOmpInterjections(oldBlocks(), [anchor]);
+    const earlier = { ...anchor, id: "tool-note", text: "Tool review" };
+    const later = { ...anchor, id: "chained-note", text: "Another review" };
+    const repaired = backfillOmpInterjections(before, [earlier, anchor, later]);
+    expect(repaired.filter(block => block.interjection).map(block => block.id)).toEqual([
+      "omp-interjection-tool-note", "omp-interjection-review", "omp-interjection-chained-note",
+    ]);
+    expect(foldedIds(repaired)).toEqual(["r2", "t2"]);
+    expect(repaired.filter(block => !block.interjection)).toEqual(oldBlocks());
+    expect(backfillOmpInterjections(repaired, [earlier, anchor, later])).toBe(repaired);
+  });
+
+  it("matches both multipart representations with separate occurrences and exact split evidence", () => {
+    const multipart = {
+      ...anchor, afterAssistantText: "One\nTwo", afterAssistantTextConcat: "OneTwo",
+      afterOccurrence: 1, afterConcatOccurrence: 2,
+      followingAssistantText: "Three\nFour", followingAssistantTextConcat: "ThreeFour",
+    };
+    const blocks: Block[] = [
+      { id: "earlier", role: "assistant", text: "OneTwo" },
+      { id: "target", role: "assistant", text: "OneTwoThreeFour" },
+    ];
+    const repaired = backfillOmpInterjections(blocks, [multipart]);
+    expect(repaired.map(block => block.text)).toEqual(["OneTwo", "OneTwo", anchor.text, "ThreeFour"]);
+    expect(backfillOmpInterjections(repaired, [multipart])).toBe(repaired);
+    const legacy: Block[] = [{ id: "target", role: "assistant", text: "One\nTwoThree\nFour" }];
+    expect(backfillOmpInterjections(legacy, [multipart]).map(block => block.text)).toEqual([
+      "One\nTwo", anchor.text, "Three\nFour",
+    ]);
+    expect(backfillOmpInterjections(blocks, [{ ...multipart, followingAssistantTextConcat: "Three" }])).toBe(blocks);
+  });
+
+  it("restores an entire note chain when only its last note has exact split evidence", () => {
+    const first = { ...anchor, afterAssistantText: "First." };
+    const last = { ...first, id: "last", text: "Last note", followingAssistantText: "Second." };
+    const blocks: Block[] = [{ id: "a", role: "assistant", text: "First.Second." }];
+    const repaired = backfillOmpInterjections(blocks, [first, last]);
+    expect(repaired.map(block => block.text)).toEqual(["First.", first.text, last.text, "Second."]);
+    expect(backfillOmpInterjections(repaired, [first, last])).toBe(repaired);
+  });
 });
 
 describe("persisted session loading", () => {

--- a/src/lib/ompInterjections.ts
+++ b/src/lib/ompInterjections.ts
@@ -12,6 +12,39 @@ function sourceOrder(a: BoundaryNode, b: BoundaryNode): number {
   return a.index - b.index || a.offset - b.offset;
 }
 
+/** Undo a status-only split only with a complete, exactly equal source message. */
+function mergeStatusSplits(blocks: Block[], anchors: readonly OmpInterjectionAnchor[]): Block[] {
+  const texts = new Set<string>();
+  for (const anchor of anchors) {
+    texts.add(anchor.afterAssistantText);
+    if (anchor.afterAssistantTextConcat !== undefined) texts.add(anchor.afterAssistantTextConcat);
+    if (anchor.followingAssistantText) texts.add(anchor.followingAssistantText);
+    if (anchor.followingAssistantTextConcat) texts.add(anchor.followingAssistantTextConcat);
+  }
+  let repaired: Block[] | undefined;
+  for (let index = 0; index < blocks.length; index++) {
+    const first = blocks[index];
+    let end = index + 1;
+    if (first.role === "assistant" && first.text && !first.streaming) {
+      while (blocks[end]?.role === "system" && !blocks[end].interjection) end++;
+      const last = blocks[end];
+      if (
+        end > index + 1 && last?.role === "assistant" && last.text && !last.streaming &&
+        // Never discard metadata carried by the removed fragment.
+        Object.keys(last).every(key => ["id", "role", "text", "streaming"].includes(key)) &&
+        texts.has(first.text + last.text)
+      ) {
+        repaired ??= blocks.slice(0, index);
+        repaired.push({ ...first, text: first.text + last.text }, ...blocks.slice(index + 1, end));
+        index = end;
+        continue;
+      }
+    }
+    repaired?.push(first);
+  }
+  return repaired ?? blocks;
+}
+
 /** Restore omitted boundaries, not turns: live interjections also stay mid-turn.
  * Exact text and one-based occurrence avoid inventing boundaries for progress
  * prose. Split coalesced blocks only when both complete source messages
@@ -22,9 +55,10 @@ export function backfillOmpInterjections(
   anchors: readonly OmpInterjectionAnchor[],
 ): Block[] {
   if (anchors.length === 0) return blocks;
+  const merged = mergeStatusSplits(blocks, anchors);
   const positions = new Map<string, BoundaryNode[]>();
   const ids = new Map<string, BoundaryNode>();
-  const nodes = blocks.map((block, index): BoundaryNode => ({ block, index, offset: 0 }));
+  const nodes = merged.map((block, index): BoundaryNode => ({ block, index, offset: 0 }));
   function addPosition(node: BoundaryNode) {
     const matches = positions.get(node.block.text);
     if (matches) {
@@ -57,7 +91,7 @@ export function backfillOmpInterjections(
       rememberContinuation(anchor.afterAssistantTextConcat, anchor.afterConcatOccurrence ?? anchor.afterOccurrence, anchor.followingAssistantTextConcat);
     }
   }
-  let changed = false;
+  let changed = merged !== blocks;
   for (const anchor of anchors) {
     // Keep legacy newline matches and IDs; live streams concatenate text parts.
     // Each representation has its own occurrence count, never fuzzy matching.

--- a/src/lib/ompInterjections.ts
+++ b/src/lib/ompInterjections.ts
@@ -1,6 +1,17 @@
 import type { OmpInterjectionAnchor } from "./fs";
 import type { Block } from "./session";
 
+interface BoundaryNode {
+  block: Block;
+  index: number;
+  offset: number;
+  next?: BoundaryNode;
+}
+
+function sourceOrder(a: BoundaryNode, b: BoundaryNode): number {
+  return a.index - b.index || a.offset - b.offset;
+}
+
 /** Restore omitted boundaries, not turns: live interjections also stay mid-turn.
  * Exact text and one-based occurrence avoid inventing boundaries for progress
  * prose. Split coalesced blocks only when both complete source messages
@@ -11,90 +22,112 @@ export function backfillOmpInterjections(
   anchors: readonly OmpInterjectionAnchor[],
 ): Block[] {
   if (anchors.length === 0) return blocks;
-  const positions = new Map<string, number[]>();
-  const ids = new Map<string, number>();
-  blocks.forEach((block, index) => {
-    ids.set(block.id, index);
-    if (block.role !== "assistant") return;
-    const matches = positions.get(block.text);
-    if (matches) matches.push(index);
-    else positions.set(block.text, [index]);
+  const positions = new Map<string, BoundaryNode[]>();
+  const ids = new Map<string, BoundaryNode>();
+  const nodes = blocks.map((block, index): BoundaryNode => ({ block, index, offset: 0 }));
+  function addPosition(node: BoundaryNode) {
+    const matches = positions.get(node.block.text);
+    if (matches) {
+      matches.push(node);
+      if (matches.length > 1 && sourceOrder(matches[matches.length - 2], node) > 0) {
+        matches.sort(sourceOrder);
+      }
+    } else positions.set(node.block.text, [node]);
+  }
+  nodes.forEach((node, index) => {
+    node.next = nodes[index + 1];
+    ids.set(node.block.id, node);
+    if (node.block.role === "assistant") addPosition(node);
   });
-  const insertions = new Map<number, Block[]>();
-  const matchedLive = new Set<number>();
-  const splitOffsets = new Map<number, number>();
-  const boundaryEnds = new Map<number, number>();
-  let previous = -1;
+  const matchedLive = new Set<BoundaryNode>();
+  const boundaryEnds = new Map<BoundaryNode, BoundaryNode>();
+  let previous: BoundaryNode | undefined;
+  let changed = false;
   for (const anchor of anchors) {
     const exact = positions.get(anchor.afterAssistantText) ?? [];
     const combined = anchor.followingAssistantText
       ? positions.get(anchor.afterAssistantText + anchor.followingAssistantText) ?? []
       : [];
     const candidates = combined.length
-      ? [...exact, ...combined].sort((a, b) => a - b)
+      ? [...exact, ...combined].sort(sourceOrder)
       : exact;
-    const index = candidates[anchor.afterOccurrence - 1];
-    if (index == null || index < previous) continue;
-    previous = index;
+    const node = candidates[anchor.afterOccurrence - 1];
+    if (!node || (previous && sourceOrder(node, previous) < 0)) continue;
+    previous = node;
     const id = `omp-interjection-${anchor.id}`;
-    const existing = ids.get(id);
-    if (existing != null) {
-      boundaryEnds.set(index, existing);
-      continue;
-    }
+    let boundary = ids.get(id);
     // Newer builds already stored live interjections with random IDs. Match
     // only the adjacent boundary, and consume each live row at most once.
-    let liveIndex = index + 1;
-    for (; liveIndex < blocks.length; liveIndex += 1) {
-      const live = blocks[liveIndex];
-      if (live.role !== "system" || !live.interjection) break;
-      if (
-        !matchedLive.has(liveIndex) &&
-        !live.id.startsWith("omp-interjection-") &&
-        live.text === anchor.text &&
-        live.interjection.customType === anchor.customType &&
-        live.interjection.severity === (anchor.severity ?? undefined)
-      ) {
-        matchedLive.add(liveIndex);
-        break;
+    if (!boundary) {
+      for (let live = node.next; live; live = live.next) {
+        const block = live.block;
+        if (block.role !== "system" || !block.interjection) break;
+        if (
+          !matchedLive.has(live) &&
+          !block.id.startsWith("omp-interjection-") &&
+          block.text === anchor.text &&
+          block.interjection.customType === anchor.customType &&
+          block.interjection.severity === (anchor.severity ?? undefined)
+        ) {
+          matchedLive.add(live);
+          boundary = live;
+          break;
+        }
       }
     }
-    if (matchedLive.has(liveIndex)) {
-      boundaryEnds.set(index, liveIndex);
-      continue;
+    if (!boundary) {
+      const end = boundaryEnds.get(node) ?? node;
+      boundary = {
+        block: {
+          id,
+          role: "system",
+          text: anchor.text,
+          interjection: {
+            customType: anchor.customType,
+            ...(anchor.severity ? { severity: anchor.severity } : {}),
+          },
+        },
+        index: node.index,
+        offset: node.offset,
+        next: end.next,
+      };
+      end.next = boundary;
+      ids.set(id, boundary);
+      changed = true;
     }
-    const block: Block = {
-      id,
-      role: "system",
-      text: anchor.text,
-      interjection: {
-        customType: anchor.customType,
-        ...(anchor.severity ? { severity: anchor.severity } : {}),
-      },
-    };
-    const insertionIndex = boundaryEnds.get(index) ?? index;
-    const pending = insertions.get(insertionIndex);
-    if (pending) pending.push(block);
-    else insertions.set(insertionIndex, [block]);
-    ids.set(id, insertionIndex);
-    if (blocks[index].text !== anchor.afterAssistantText) {
-      splitOffsets.set(index, anchor.afterAssistantText.length);
+    boundaryEnds.set(node, boundary);
+    if (node.block.text !== anchor.afterAssistantText) {
+      const text = node.block.text;
+      const split = anchor.afterAssistantText.length;
+      let end = boundary;
+      while (end.next?.block.role === "system" && end.next.block.interjection) {
+        end = end.next;
+      }
+      const continuation: BoundaryNode = {
+        block: {
+          id: `${node.block.id}-${id}-continuation`,
+          role: "assistant",
+          text: text.slice(split),
+        },
+        index: node.index,
+        offset: node.offset + split,
+        next: end.next,
+      };
+      // The suffix belongs to this boundary, not to an insertion's old index.
+      // Index it now so later source anchors can target it in this same pass.
+      end.next = continuation;
+      positions.set(text, positions.get(text)!.filter(match => match !== node));
+      node.block = { ...node.block, text: anchor.afterAssistantText };
+      addPosition(node);
+      addPosition(continuation);
+      ids.set(continuation.block.id, continuation);
+      changed = true;
     }
   }
-  if (insertions.size === 0) return blocks;
+  if (!changed) return blocks;
   const repaired: Block[] = [];
-  blocks.forEach((block, index) => {
-    const split = splitOffsets.get(index);
-    repaired.push(split == null ? block : { ...block, text: block.text.slice(0, split) });
-    const pending = insertions.get(index);
-    if (pending) repaired.push(...pending);
-    if (split != null && pending) {
-      repaired.push({
-        id: `${pending[pending.length - 1].id}-continuation`,
-        role: "assistant",
-        text: block.text.slice(split),
-      });
-    }
-  });
+  for (let node: BoundaryNode | undefined = nodes[0]; node; node = node.next) {
+    repaired.push(node.block);
+  }
   return repaired;
 }

--- a/src/lib/ompInterjections.ts
+++ b/src/lib/ompInterjections.ts
@@ -1,4 +1,4 @@
-import type { OmpInterjectionAnchor } from "./fs";
+import type { OmpAssistantTextEvidence, OmpInterjectionAnchor } from "./fs";
 import type { Block } from "./session";
 
 interface BoundaryNode {
@@ -36,24 +36,44 @@ function statusSplitEnd(blocks: Block[], index: number): number | undefined {
 
 /** Undo a status-only split only with a complete, exactly equal source message. */
 function mergeStatusSplits(
-  blocks: Block[], anchors: readonly OmpInterjectionAnchor[], verifiedTexts: readonly string[],
+  blocks: Block[], anchors: readonly OmpInterjectionAnchor[], verifiedTexts: readonly OmpAssistantTextEvidence[],
 ): Block[] {
-  const texts = new Set(verifiedTexts);
-  for (const anchor of anchors) {
-    texts.add(anchor.afterAssistantText);
-    if (anchor.afterAssistantTextConcat !== undefined) texts.add(anchor.afterAssistantTextConcat);
-    if (anchor.followingAssistantText) texts.add(anchor.followingAssistantText);
-    if (anchor.followingAssistantTextConcat) texts.add(anchor.followingAssistantTextConcat);
+  const counts = new Map<string, number>();
+  for (const { text, occurrences } of verifiedTexts) {
+    counts.set(text, Math.max(counts.get(text) ?? 0, occurrences));
   }
+  const anchored = new Map<string, Set<number>>();
+  function remember(text: string, occurrence: number) {
+    let occurrences = anchored.get(text);
+    if (!occurrences) anchored.set(text, occurrences = new Set());
+    occurrences.add(occurrence);
+  }
+  for (const anchor of anchors) {
+    remember(anchor.afterAssistantText, anchor.afterOccurrence);
+    if (anchor.afterAssistantTextConcat !== undefined) {
+      remember(anchor.afterAssistantTextConcat, anchor.afterConcatOccurrence ?? anchor.afterOccurrence);
+    }
+    // Following text has no occurrence index: it is split-boundary evidence
+    // only, never authority to merge an unrelated status split.
+  }
+  const seen = new Map<string, number>();
   let repaired: Block[] | undefined;
   for (let index = 0; index < blocks.length; index++) {
     const first = blocks[index];
     const end = statusSplitEnd(blocks, index);
-    if (end !== undefined && texts.has(first.text + blocks[end].text)) {
-      repaired ??= blocks.slice(0, index);
-      repaired.push({ ...first, text: first.text + blocks[end].text }, ...blocks.slice(index + 1, end));
-      index = end;
-      continue;
+    if (end !== undefined) {
+      const text = first.text + blocks[end].text;
+      const occurrence = (seen.get(text) ?? 0) + 1;
+      if (occurrence <= (counts.get(text) ?? 0) || anchored.get(text)?.has(occurrence)) {
+        repaired ??= blocks.slice(0, index);
+        repaired.push({ ...first, text }, ...blocks.slice(index + 1, end));
+        seen.set(text, occurrence);
+        index = end;
+        continue;
+      }
+    }
+    if (first.role === "assistant" && !first.streaming) {
+      seen.set(first.text, (seen.get(first.text) ?? 0) + 1);
     }
     repaired?.push(first);
   }
@@ -68,7 +88,7 @@ function mergeStatusSplits(
 export function backfillOmpInterjections(
   blocks: Block[],
   anchors: readonly OmpInterjectionAnchor[],
-  verifiedTexts: readonly string[] = [],
+  verifiedTexts: readonly OmpAssistantTextEvidence[] = [],
 ): Block[] {
   const merged = mergeStatusSplits(blocks, anchors, verifiedTexts);
   if (anchors.length === 0) return merged;

--- a/src/lib/ompInterjections.ts
+++ b/src/lib/ompInterjections.ts
@@ -1,4 +1,4 @@
-import type { OmpAssistantTextEvidence, OmpInterjectionAnchor } from "./fs";
+import type { OmpAssistantText, OmpInterjectionAnchor } from "./fs";
 import type { Block } from "./session";
 
 interface BoundaryNode {
@@ -34,46 +34,35 @@ function statusSplitEnd(blocks: Block[], index: number): number | undefined {
   ) return end;
 }
 
-/** Undo a status-only split only with a complete, exactly equal source message. */
-function mergeStatusSplits(
-  blocks: Block[], anchors: readonly OmpInterjectionAnchor[], verifiedTexts: readonly OmpAssistantTextEvidence[],
-): Block[] {
-  const counts = new Map<string, number>();
-  for (const { text, occurrences } of verifiedTexts) {
-    counts.set(text, Math.max(counts.get(text) ?? 0, occurrences));
-  }
-  const anchored = new Map<string, Set<number>>();
-  function remember(text: string, occurrence: number) {
-    let occurrences = anchored.get(text);
-    if (!occurrences) anchored.set(text, occurrences = new Set());
-    occurrences.add(occurrence);
-  }
-  for (const anchor of anchors) {
-    remember(anchor.afterAssistantText, anchor.afterOccurrence);
-    if (anchor.afterAssistantTextConcat !== undefined) {
-      remember(anchor.afterAssistantTextConcat, anchor.afterConcatOccurrence ?? anchor.afterOccurrence);
-    }
-    // Following text has no occurrence index: it is split-boundary evidence
-    // only, never authority to merge an unrelated status split.
-  }
-  const seen = new Map<string, number>();
+function sameMessage(message: OmpAssistantText | undefined, text: string): boolean {
+  return message !== undefined && (message.text === text || message.concat === text);
+}
+
+/** Undo a status-only split only when the next unused source message is that
+ * exact complete text. A cursor over the ordered active-path messages, not a
+ * count of equal texts, decides which source slot each block occupies: when
+ * the next message is the first fragment itself, the pair are two messages.
+ * Anchors count occurrences without position and never authorize a merge.
+ */
+function mergeStatusSplits(blocks: Block[], source: readonly OmpAssistantText[]): Block[] {
+  let cursor = 0;
   let repaired: Block[] | undefined;
   for (let index = 0; index < blocks.length; index++) {
     const first = blocks[index];
     const end = statusSplitEnd(blocks, index);
-    if (end !== undefined) {
-      const text = first.text + blocks[end].text;
-      const occurrence = (seen.get(text) ?? 0) + 1;
-      if (occurrence <= (counts.get(text) ?? 0) || anchored.get(text)?.has(occurrence)) {
-        repaired ??= blocks.slice(0, index);
-        repaired.push({ ...first, text }, ...blocks.slice(index + 1, end));
-        seen.set(text, occurrence);
-        index = end;
-        continue;
-      }
+    if (end !== undefined && sameMessage(source[cursor], first.text + blocks[end].text)) {
+      repaired ??= blocks.slice(0, index);
+      repaired.push({ ...first, text: first.text + blocks[end].text }, ...blocks.slice(index + 1, end));
+      cursor++;
+      index = end;
+      continue;
     }
     if (first.role === "assistant" && !first.streaming) {
-      seen.set(first.text, (seen.get(first.text) ?? 0) + 1);
+      // A complete block occupies its own slot. Only skip forward past source
+      // messages the transcript never stored, so later splits stay aligned.
+      let slot = cursor;
+      while (slot < source.length && !sameMessage(source[slot], first.text)) slot++;
+      if (slot < source.length) cursor = slot + 1;
     }
     repaired?.push(first);
   }
@@ -88,9 +77,9 @@ function mergeStatusSplits(
 export function backfillOmpInterjections(
   blocks: Block[],
   anchors: readonly OmpInterjectionAnchor[],
-  verifiedTexts: readonly OmpAssistantTextEvidence[] = [],
+  source: readonly OmpAssistantText[] = [],
 ): Block[] {
-  const merged = mergeStatusSplits(blocks, anchors, verifiedTexts);
+  const merged = mergeStatusSplits(blocks, source);
   if (anchors.length === 0) return merged;
   const positions = new Map<string, BoundaryNode[]>();
   const ids = new Map<string, BoundaryNode>();

--- a/src/lib/ompInterjections.ts
+++ b/src/lib/ompInterjections.ts
@@ -42,16 +42,38 @@ export function backfillOmpInterjections(
   const matchedLive = new Set<BoundaryNode>();
   const boundaryEnds = new Map<BoundaryNode, BoundaryNode>();
   let previous: BoundaryNode | undefined;
+  // A chain's final note alone has a directly linked continuation. Its exact
+  // split evidence also locates earlier notes sealing that same source message.
+  const continuations = new Map<string, Map<number, string>>();
+  function rememberContinuation(text: string, occurrence: number, following?: string | null) {
+    if (!following) return;
+    let byOccurrence = continuations.get(text);
+    if (!byOccurrence) continuations.set(text, byOccurrence = new Map());
+    byOccurrence.set(occurrence, following);
+  }
+  for (const anchor of anchors) {
+    rememberContinuation(anchor.afterAssistantText, anchor.afterOccurrence, anchor.followingAssistantText);
+    if (anchor.afterAssistantTextConcat !== undefined) {
+      rememberContinuation(anchor.afterAssistantTextConcat, anchor.afterConcatOccurrence ?? anchor.afterOccurrence, anchor.followingAssistantTextConcat);
+    }
+  }
   let changed = false;
   for (const anchor of anchors) {
-    const exact = positions.get(anchor.afterAssistantText) ?? [];
-    const combined = anchor.followingAssistantText
-      ? positions.get(anchor.afterAssistantText + anchor.followingAssistantText) ?? []
-      : [];
-    const candidates = combined.length
-      ? [...exact, ...combined].sort(sourceOrder)
-      : exact;
-    const node = candidates[anchor.afterOccurrence - 1];
+    // Keep legacy newline matches and IDs; live streams concatenate text parts.
+    // Each representation has its own occurrence count, never fuzzy matching.
+    function match(text: string, occurrence: number, following?: string | null) {
+      following ??= continuations.get(text)?.get(occurrence);
+      const exact = positions.get(text) ?? [];
+      const combined = following ? positions.get(text + following) ?? [] : [];
+      const candidates = combined.length ? [...exact, ...combined].sort(sourceOrder) : exact;
+      return candidates[occurrence - 1];
+    }
+    let afterText = anchor.afterAssistantText;
+    let node = match(afterText, anchor.afterOccurrence, anchor.followingAssistantText);
+    if (!node && anchor.afterAssistantTextConcat !== undefined) {
+      afterText = anchor.afterAssistantTextConcat;
+      node = match(afterText, anchor.afterConcatOccurrence ?? anchor.afterOccurrence, anchor.followingAssistantTextConcat);
+    }
     if (!node || (previous && sourceOrder(node, previous) < 0)) continue;
     previous = node;
     const id = `omp-interjection-${anchor.id}`;
@@ -96,9 +118,9 @@ export function backfillOmpInterjections(
       changed = true;
     }
     boundaryEnds.set(node, boundary);
-    if (node.block.text !== anchor.afterAssistantText) {
+    if (node.block.text !== afterText) {
       const text = node.block.text;
-      const split = anchor.afterAssistantText.length;
+      const split = afterText.length;
       let end = boundary;
       while (end.next?.block.role === "system" && end.next.block.interjection) {
         end = end.next;
@@ -117,7 +139,7 @@ export function backfillOmpInterjections(
       // Index it now so later source anchors can target it in this same pass.
       end.next = continuation;
       positions.set(text, positions.get(text)!.filter(match => match !== node));
-      node.block = { ...node.block, text: anchor.afterAssistantText };
+      node.block = { ...node.block, text: afterText };
       addPosition(node);
       addPosition(continuation);
       ids.set(continuation.block.id, continuation);

--- a/src/lib/ompInterjections.ts
+++ b/src/lib/ompInterjections.ts
@@ -12,45 +12,226 @@ function sourceOrder(a: BoundaryNode, b: BoundaryNode): number {
   return a.index - b.index || a.offset - b.offset;
 }
 
-/** Collect only shapes whose trailing fragment can be removed without data loss. */
+/** For each block index, the next fragment index in a status-split chain
+ * (0 when none): every intervening row is a non-interjection system row and
+ * the next other row is a clean assistant block. */
+function chainHops(blocks: Block[]): Int32Array {
+  const hop = new Int32Array(blocks.length);
+  let nextNonStatus = blocks.length;
+  for (let index = blocks.length - 1; index >= 0; index--) {
+    const block = blocks[index];
+    if (block.role === "system" && !block.interjection) continue;
+    const last = nextNonStatus < blocks.length ? blocks[nextNonStatus] : undefined;
+    if (
+      block.role === "assistant" && block.text && !block.streaming &&
+      nextNonStatus > index + 1 && last?.role === "assistant" && last.text &&
+      !last.streaming &&
+      Object.keys(last).every(key => ["id", "role", "text", "streaming"].includes(key))
+    ) hop[index] = nextNonStatus;
+    nextNonStatus = index;
+  }
+  return hop;
+}
+
+/** Collect only shapes whose trailing fragments can be removed without data loss. */
 export function ompStatusSplitTexts(blocks: Block[]): string[] {
+  const hop = chainHops(blocks);
   const texts: string[] = [];
+  let previous = -1;
   for (let index = 0; index < blocks.length; index++) {
-    const end = statusSplitEnd(blocks, index);
-    if (end !== undefined) texts.push(blocks[index].text + blocks[end].text);
+    const block = blocks[index];
+    if (block.role === "system" && !block.interjection) continue;
+    if (hop[index] && (previous < 0 || hop[previous] !== index)) {
+      let text = block.text;
+      for (let next = hop[index]; next; next = hop[next]) text += blocks[next].text;
+      texts.push(text);
+    }
+    previous = index;
   }
   return texts;
 }
 
-function statusSplitEnd(blocks: Block[], index: number): number | undefined {
-  const first = blocks[index];
-  if (first.role !== "assistant" || !first.text || first.streaming) return;
-  let end = index + 1;
-  while (blocks[end]?.role === "system" && !blocks[end].interjection) end++;
-  const last = blocks[end];
-  if (
-    end > index + 1 && last?.role === "assistant" && last.text && !last.streaming &&
-    Object.keys(last).every(key => ["id", "role", "text", "streaming"].includes(key))
-  ) return end;
+/** Positions of every source text under both join forms; one message, one slot. */
+function sourcePositions(source: readonly OmpAssistantText[]): Map<string, number[]> {
+  const positions = new Map<string, number[]>();
+  source.forEach((message, slot) => {
+    const list = positions.get(message.text);
+    if (list) list.push(slot);
+    else positions.set(message.text, [slot]);
+    if (message.concat !== message.text) {
+      const concatList = positions.get(message.concat);
+      if (concatList) concatList.push(slot);
+      else positions.set(message.concat, [slot]);
+    }
+  });
+  return positions;
 }
 
-function sameMessage(message: OmpAssistantText | undefined, text: string): boolean {
-  return message !== undefined && (message.text === text || message.concat === text);
+function slotAt(positions: Map<string, number[]>, text: string, from: number, limit: number): number {
+  const list = positions.get(text);
+  if (!list) return limit;
+  let lo = 0;
+  let hi = list.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (list[mid] < from) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo < list.length ? list[lo] : limit;
 }
 
-/** Undo a status-only split only when the next unused source message is that
- * exact complete text. A cursor over the ordered active-path messages, not a
- * count of equal texts, decides which source slot each block occupies: when
- * the next message is the first fragment itself, the pair are two messages.
- * Anchors count occurrences without position and never authorize a merge.
+type AlignmentScore = readonly [number, number]; // [items matched, consumed slot sum]
+
+function beats(a: AlignmentScore, b: AlignmentScore): boolean {
+  return a[0] > b[0] || (a[0] === b[0] && a[1] < b[1]);
+}
+
+/** Undo status-only splits through the best in-order alignment between the
+ * persisted assistant sequence and the ordered active-path source messages.
+ * Every assistant block claims its earliest free source slot; a split
+ * candidate may instead weld a prefix of its fragments into one slot by
+ * their combined text. An alignment scores (blocks + source messages
+ * matched, then earliest consumed positions), decided per candidate against
+ * the optimal continuation: a weld never wins when the fragments explain
+ * themselves as real messages — including when the matching combined text is
+ * a message the transcript simply never stored — and equal matches resolve
+ * toward explaining earlier source slots. Anchors never authorize a merge.
+ * Pathological inputs fall back to the cursor rule.
  */
 function mergeStatusSplits(blocks: Block[], source: readonly OmpAssistantText[]): Block[] {
+  const limit = source.length;
+  const width = limit + 1;
+  const positions = sourcePositions(source);
+  const maxText = source.reduce(
+    (max, message) => Math.max(max, message.text.length, message.concat.length), 0);
+  const nextSlot = (text: string, from: number) => slotAt(positions, text, from, limit);
+  const bindable = (block: Block) =>
+    block.role === "assistant" && !block.streaming && !!block.text;
+  const hop = chainHops(blocks);
+  try {
+    // Best continuation score for blocks[i..] against source[j..]: inert
+    // rows and single blocks are forced, so only split candidates branch.
+    const memo = new Map<number, AlignmentScore>();
+    let depth = 0;
+    let built = 0;
+    const score = (i: number, j: number): AlignmentScore => {
+      const key = i * width + j;
+      const hit = memo.get(key);
+      if (hit !== undefined) return hit;
+      if (depth > 2_000 || memo.size > 500_000) throw new Error("alignment budget");
+      depth++;
+      try {
+        let matched = 0;
+        let consumed = 0;
+        while (i < blocks.length) {
+          const block = blocks[i];
+          if (!bindable(block)) {
+            i++;
+            continue;
+          }
+          if (!hop[i]) {
+            const own = nextSlot(block.text, j);
+            if (own < limit) {
+              j = own + 1;
+              matched += 2;
+              consumed += own;
+            }
+            i++;
+            continue;
+          }
+          const own = nextSlot(block.text, j);
+          const tail = score(i + 1, own < limit ? own + 1 : j);
+          let best: AlignmentScore = own < limit
+            ? [tail[0] + 2, tail[1] + own]
+            : tail;
+          let combined = block.text;
+          for (let f = hop[i], t = 1; f && combined.length <= maxText; f = hop[f], t++) {
+            combined += blocks[f].text;
+            built += blocks[f].text.length;
+            if (built > 4_000_000) throw new Error("alignment budget");
+            // A weld that lands behind the first fragment's own slot would
+            // reorder evidence backward — the earlier exact claim wins.
+            const mergeSlot = nextSlot(combined, j);
+            if (mergeSlot < limit && (own >= limit || mergeSlot <= own)) {
+              const rest = score(f + 1, mergeSlot + 1);
+              const candidate: AlignmentScore = [rest[0] + t + 2, rest[1] + mergeSlot];
+              if (!beats(best, candidate)) best = candidate;
+            }
+          }
+          const total: AlignmentScore = [matched + best[0], consumed + best[1]];
+          memo.set(key, total);
+          return total;
+        }
+        const total: AlignmentScore = [matched, consumed];
+        memo.set(key, total);
+        return total;
+      } finally {
+        depth--;
+      }
+    };
+    let cursor = 0;
+    let repaired: Block[] | undefined;
+    for (let index = 0; index < blocks.length; index++) {
+      const first = blocks[index];
+      if (bindable(first) && hop[index]) {
+        const own = nextSlot(first.text, cursor);
+        const tail = score(index + 1, own < limit ? own + 1 : cursor);
+        let best: AlignmentScore = own < limit ? [tail[0] + 2, tail[1] + own] : tail;
+        let chosen: { last: number; slot: number; text: string } | undefined;
+        let combined = first.text;
+        for (let f = hop[index], t = 1; f && combined.length <= maxText; f = hop[f], t++) {
+          combined += blocks[f].text;
+          built += blocks[f].text.length;
+          if (built > 4_000_000) throw new Error("alignment budget");
+          const mergeSlot = nextSlot(combined, cursor);
+          if (mergeSlot < limit && (own >= limit || mergeSlot <= own)) {
+            const rest = score(f + 1, mergeSlot + 1);
+            const candidate: AlignmentScore = [rest[0] + t + 2, rest[1] + mergeSlot];
+            if (!beats(best, candidate)) {
+              best = candidate;
+              chosen = { last: f, slot: mergeSlot, text: combined };
+            }
+          }
+        }
+        if (chosen) {
+          repaired ??= blocks.slice(0, index);
+          repaired.push(
+            { ...first, text: chosen.text },
+            ...blocks.slice(index + 1, chosen.last).filter(block => block.role === "system"),
+          );
+          cursor = chosen.slot + 1;
+          index = chosen.last;
+          continue;
+        }
+        if (own < limit) cursor = own + 1;
+      } else if (bindable(first)) {
+        const own = nextSlot(first.text, cursor);
+        if (own < limit) cursor = own + 1;
+      }
+      repaired?.push(first);
+    }
+    return repaired ?? blocks;
+  } catch {
+    return mergeStatusSplitsLinear(blocks, source);
+  }
+}
+
+/** Fallback when the full alignment exceeds its budget: weld only the first
+ * fragment pair when its combined text is exactly the next unconsumed slot. */
+function mergeStatusSplitsLinear(blocks: Block[], source: readonly OmpAssistantText[]): Block[] {
+  const positions = sourcePositions(source);
+  const limit = source.length;
+  const nextSlot = (text: string, from: number) => slotAt(positions, text, from, limit);
+  const hop = chainHops(blocks);
   let cursor = 0;
   let repaired: Block[] | undefined;
   for (let index = 0; index < blocks.length; index++) {
     const first = blocks[index];
-    const end = statusSplitEnd(blocks, index);
-    if (end !== undefined && sameMessage(source[cursor], first.text + blocks[end].text)) {
+    const end = hop[index] || undefined;
+    if (
+      end !== undefined && cursor < limit &&
+      nextSlot(first.text + blocks[end].text, cursor) === cursor
+    ) {
       repaired ??= blocks.slice(0, index);
       repaired.push({ ...first, text: first.text + blocks[end].text }, ...blocks.slice(index + 1, end));
       cursor++;
@@ -58,11 +239,8 @@ function mergeStatusSplits(blocks: Block[], source: readonly OmpAssistantText[])
       continue;
     }
     if (first.role === "assistant" && !first.streaming) {
-      // A complete block occupies its own slot. Only skip forward past source
-      // messages the transcript never stored, so later splits stay aligned.
-      let slot = cursor;
-      while (slot < source.length && !sameMessage(source[slot], first.text)) slot++;
-      if (slot < source.length) cursor = slot + 1;
+      const own = nextSlot(first.text, cursor);
+      if (own < limit) cursor = own + 1;
     }
     repaired?.push(first);
   }

--- a/src/lib/ompInterjections.ts
+++ b/src/lib/ompInterjections.ts
@@ -12,9 +12,33 @@ function sourceOrder(a: BoundaryNode, b: BoundaryNode): number {
   return a.index - b.index || a.offset - b.offset;
 }
 
+/** Collect only shapes whose trailing fragment can be removed without data loss. */
+export function ompStatusSplitTexts(blocks: Block[]): string[] {
+  const texts: string[] = [];
+  for (let index = 0; index < blocks.length; index++) {
+    const end = statusSplitEnd(blocks, index);
+    if (end !== undefined) texts.push(blocks[index].text + blocks[end].text);
+  }
+  return texts;
+}
+
+function statusSplitEnd(blocks: Block[], index: number): number | undefined {
+  const first = blocks[index];
+  if (first.role !== "assistant" || !first.text || first.streaming) return;
+  let end = index + 1;
+  while (blocks[end]?.role === "system" && !blocks[end].interjection) end++;
+  const last = blocks[end];
+  if (
+    end > index + 1 && last?.role === "assistant" && last.text && !last.streaming &&
+    Object.keys(last).every(key => ["id", "role", "text", "streaming"].includes(key))
+  ) return end;
+}
+
 /** Undo a status-only split only with a complete, exactly equal source message. */
-function mergeStatusSplits(blocks: Block[], anchors: readonly OmpInterjectionAnchor[]): Block[] {
-  const texts = new Set<string>();
+function mergeStatusSplits(
+  blocks: Block[], anchors: readonly OmpInterjectionAnchor[], verifiedTexts: readonly string[],
+): Block[] {
+  const texts = new Set(verifiedTexts);
   for (const anchor of anchors) {
     texts.add(anchor.afterAssistantText);
     if (anchor.afterAssistantTextConcat !== undefined) texts.add(anchor.afterAssistantTextConcat);
@@ -24,21 +48,12 @@ function mergeStatusSplits(blocks: Block[], anchors: readonly OmpInterjectionAnc
   let repaired: Block[] | undefined;
   for (let index = 0; index < blocks.length; index++) {
     const first = blocks[index];
-    let end = index + 1;
-    if (first.role === "assistant" && first.text && !first.streaming) {
-      while (blocks[end]?.role === "system" && !blocks[end].interjection) end++;
-      const last = blocks[end];
-      if (
-        end > index + 1 && last?.role === "assistant" && last.text && !last.streaming &&
-        // Never discard metadata carried by the removed fragment.
-        Object.keys(last).every(key => ["id", "role", "text", "streaming"].includes(key)) &&
-        texts.has(first.text + last.text)
-      ) {
-        repaired ??= blocks.slice(0, index);
-        repaired.push({ ...first, text: first.text + last.text }, ...blocks.slice(index + 1, end));
-        index = end;
-        continue;
-      }
+    const end = statusSplitEnd(blocks, index);
+    if (end !== undefined && texts.has(first.text + blocks[end].text)) {
+      repaired ??= blocks.slice(0, index);
+      repaired.push({ ...first, text: first.text + blocks[end].text }, ...blocks.slice(index + 1, end));
+      index = end;
+      continue;
     }
     repaired?.push(first);
   }
@@ -53,9 +68,10 @@ function mergeStatusSplits(blocks: Block[], anchors: readonly OmpInterjectionAnc
 export function backfillOmpInterjections(
   blocks: Block[],
   anchors: readonly OmpInterjectionAnchor[],
+  verifiedTexts: readonly string[] = [],
 ): Block[] {
-  if (anchors.length === 0) return blocks;
-  const merged = mergeStatusSplits(blocks, anchors);
+  const merged = mergeStatusSplits(blocks, anchors, verifiedTexts);
+  if (anchors.length === 0) return merged;
   const positions = new Map<string, BoundaryNode[]>();
   const ids = new Map<string, BoundaryNode>();
   const nodes = merged.map((block, index): BoundaryNode => ({ block, index, offset: 0 }));

--- a/src/lib/ompInterjections.ts
+++ b/src/lib/ompInterjections.ts
@@ -1,0 +1,100 @@
+import type { OmpInterjectionAnchor } from "./fs";
+import type { Block } from "./session";
+
+/** Restore omitted boundaries, not turns: live interjections also stay mid-turn.
+ * Exact text and one-based occurrence avoid inventing boundaries for progress
+ * prose. Split coalesced blocks only when both complete source messages
+ * concatenate exactly to their text; prefixes alone are not evidence.
+ */
+export function backfillOmpInterjections(
+  blocks: Block[],
+  anchors: readonly OmpInterjectionAnchor[],
+): Block[] {
+  if (anchors.length === 0) return blocks;
+  const positions = new Map<string, number[]>();
+  const ids = new Map<string, number>();
+  blocks.forEach((block, index) => {
+    ids.set(block.id, index);
+    if (block.role !== "assistant") return;
+    const matches = positions.get(block.text);
+    if (matches) matches.push(index);
+    else positions.set(block.text, [index]);
+  });
+  const insertions = new Map<number, Block[]>();
+  const matchedLive = new Set<number>();
+  const splitOffsets = new Map<number, number>();
+  const boundaryEnds = new Map<number, number>();
+  let previous = -1;
+  for (const anchor of anchors) {
+    const exact = positions.get(anchor.afterAssistantText) ?? [];
+    const combined = anchor.followingAssistantText
+      ? positions.get(anchor.afterAssistantText + anchor.followingAssistantText) ?? []
+      : [];
+    const candidates = combined.length
+      ? [...exact, ...combined].sort((a, b) => a - b)
+      : exact;
+    const index = candidates[anchor.afterOccurrence - 1];
+    if (index == null || index < previous) continue;
+    previous = index;
+    const id = `omp-interjection-${anchor.id}`;
+    const existing = ids.get(id);
+    if (existing != null) {
+      boundaryEnds.set(index, existing);
+      continue;
+    }
+    // Newer builds already stored live interjections with random IDs. Match
+    // only the adjacent boundary, and consume each live row at most once.
+    let liveIndex = index + 1;
+    for (; liveIndex < blocks.length; liveIndex += 1) {
+      const live = blocks[liveIndex];
+      if (live.role !== "system" || !live.interjection) break;
+      if (
+        !matchedLive.has(liveIndex) &&
+        !live.id.startsWith("omp-interjection-") &&
+        live.text === anchor.text &&
+        live.interjection.customType === anchor.customType &&
+        live.interjection.severity === (anchor.severity ?? undefined)
+      ) {
+        matchedLive.add(liveIndex);
+        break;
+      }
+    }
+    if (matchedLive.has(liveIndex)) {
+      boundaryEnds.set(index, liveIndex);
+      continue;
+    }
+    const block: Block = {
+      id,
+      role: "system",
+      text: anchor.text,
+      interjection: {
+        customType: anchor.customType,
+        ...(anchor.severity ? { severity: anchor.severity } : {}),
+      },
+    };
+    const insertionIndex = boundaryEnds.get(index) ?? index;
+    const pending = insertions.get(insertionIndex);
+    if (pending) pending.push(block);
+    else insertions.set(insertionIndex, [block]);
+    ids.set(id, insertionIndex);
+    if (blocks[index].text !== anchor.afterAssistantText) {
+      splitOffsets.set(index, anchor.afterAssistantText.length);
+    }
+  }
+  if (insertions.size === 0) return blocks;
+  const repaired: Block[] = [];
+  blocks.forEach((block, index) => {
+    const split = splitOffsets.get(index);
+    repaired.push(split == null ? block : { ...block, text: block.text.slice(0, split) });
+    const pending = insertions.get(index);
+    if (pending) repaired.push(...pending);
+    if (split != null && pending) {
+      repaired.push({
+        id: `${pending[pending.length - 1].id}-continuation`,
+        role: "assistant",
+        text: block.text.slice(split),
+      });
+    }
+  });
+  return repaired;
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -94,6 +94,15 @@ export type SecondOpinionMeta = {
   kind?: "handoff";
 };
 
+/** A mid-turn interjection the harness asked to surface, e.g. OMP advisor notes. */
+export type InterjectionSeverity = "nit" | "concern" | "blocker";
+
+export type InterjectionMeta = {
+  customType: string;
+  /** Highest severity among this interjection's retained notes, when any is known. */
+  severity?: InterjectionSeverity;
+};
+
 export type ToolPreviewKind = "read" | "write" | "shell" | "search";
 
 export type ToolPreviewLineKind = "add" | "del" | "context";
@@ -174,6 +183,8 @@ export type Block = {
   secondOpinion?: SecondOpinionMeta;
   /** Note chip shown on this user turn. Body is not stored; the harness already received it. */
   noteCard?: NoteCardMeta;
+  /** Mid-turn interjection chrome; system blocks only. Body lives in text. */
+  interjection?: InterjectionMeta;
 };
 
 export type RuntimeMode =

--- a/src/lib/sessionStore.test.ts
+++ b/src/lib/sessionStore.test.ts
@@ -76,6 +76,53 @@ describe("sanitizeSessionForPersist", () => {
     });
   });
 
+  it("keeps valid interjection chrome only on system blocks", () => {
+    const session = newSession("pi", "/tmp/project");
+    session.blocks = [
+      {
+        id: "i1",
+        role: "system",
+        text: "Review the fallback.",
+        interjection: { customType: " advisor ", severity: "blocker" },
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        text: "Not chrome",
+        interjection: { customType: "advisor", severity: "nit" },
+      },
+    ];
+
+    const persisted = sanitizeSessionForPersist(session);
+    expect(persisted.blocks[0]).toMatchObject({
+      role: "system",
+      text: "Review the fallback.",
+      interjection: { customType: "advisor", severity: "blocker" },
+    });
+    expect(persisted.blocks[1]?.interjection).toBeUndefined();
+  });
+
+  it("drops malformed interjection metadata without dropping its system row", () => {
+    const session = newSession("pi", "/tmp/project");
+    session.blocks = [
+      {
+        id: "i1",
+        role: "system",
+        text: "Still visible",
+        interjection: {
+          customType: " ",
+          severity: "unknown",
+        } as unknown as Block["interjection"],
+      },
+    ];
+
+    expect(sanitizeSessionForPersist(session).blocks[0]).toEqual({
+      id: "i1",
+      role: "system",
+      text: "Still visible",
+    });
+  });
+
   it("keeps a second-opinion card on the user turn", () => {
     const session = newSession("codex", "/tmp/project");
     session.blocks = [

--- a/src/lib/sessionStore.ts
+++ b/src/lib/sessionStore.ts
@@ -2,8 +2,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { persistableAttachment } from "./attachments";
 import type { ContextUsage } from "./contextUsage";
 import { normalizeProjectPath } from "./recents";
-import { ompSessionInterjections } from "./fs";
-import { backfillOmpInterjections } from "./ompInterjections";
+import { ompSessionInterjections, ompVerifyAssistantTexts } from "./fs";
+import { backfillOmpInterjections, ompStatusSplitTexts } from "./ompInterjections";
 import type {
   Block,
   HarnessId,
@@ -280,7 +280,14 @@ export async function getSession(sessionId: string): Promise<Session | null> {
   if (session.harness !== "omp" || !session.providerSessionId) return session;
   try {
     const anchors = await ompSessionInterjections(session.providerSessionId);
-    const blocks = backfillOmpInterjections(session.blocks, anchors);
+    const candidates = ompStatusSplitTexts(session.blocks);
+    // Missing verification must not prevent the existing anchored repair.
+    const verified = candidates.length
+      ? await ompVerifyAssistantTexts(session.providerSessionId, candidates).catch(() => [])
+      : [];
+    const blocks = backfillOmpInterjections(
+      session.blocks, anchors, candidates.filter((_, index) => verified[index] === true),
+    );
     if (blocks !== session.blocks) {
       session.blocks = blocks;
       // Persist before exposing the restored session to a new live turn.

--- a/src/lib/sessionStore.ts
+++ b/src/lib/sessionStore.ts
@@ -2,6 +2,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { persistableAttachment } from "./attachments";
 import type { ContextUsage } from "./contextUsage";
 import { normalizeProjectPath } from "./recents";
+import { ompSessionInterjections } from "./fs";
+import { backfillOmpInterjections } from "./ompInterjections";
 import type {
   Block,
   HarnessId,
@@ -274,7 +276,23 @@ export async function getSession(sessionId: string): Promise<Session | null> {
     sessionId,
   });
   if (!record) return null;
-  return recordToSession(record);
+  const session = recordToSession(record);
+  if (session.harness !== "omp" || !session.providerSessionId) return session;
+  try {
+    const anchors = await ompSessionInterjections(session.providerSessionId);
+    const blocks = backfillOmpInterjections(session.blocks, anchors);
+    if (blocks !== session.blocks) {
+      session.blocks = blocks;
+      // Persist before exposing the restored session to a new live turn.
+      // Re-reading the source on later loads allows partial repairs to retry;
+      // deterministic IDs ensure already repaired transcripts are not written.
+      await upsertSession(session);
+    }
+  } catch {
+    // Source logs may be absent/unreadable. Even a failed write must not stop
+    // restore; the recovered in-memory boundaries can still be displayed.
+  }
+  return session;
 }
 
 export async function deleteSession(sessionId: string): Promise<void> {

--- a/src/lib/sessionStore.ts
+++ b/src/lib/sessionStore.ts
@@ -7,6 +7,7 @@ import type {
   HarnessId,
   HandoffMeta,
   HandoffStatus,
+  InterjectionMeta,
   LinkedWorkItem,
   RuntimeMode,
   SecondOpinionMeta,
@@ -402,7 +403,32 @@ function sanitizeBlock(block: Block): Block | null {
   if (secondOpinion) next.secondOpinion = secondOpinion;
   const noteCard = sanitizeNoteCard(block.noteCard);
   if (noteCard) next.noteCard = noteCard;
+  // Interjection chrome survives restarts only on system blocks; a malformed
+  // payload keeps the ordinary system row rather than losing its body.
+  if (block.role === "system") {
+    const interjection = sanitizeInterjection(block.interjection);
+    if (interjection) next.interjection = interjection;
+  }
   return next;
+}
+
+function sanitizeInterjection(
+  value: Block["interjection"],
+): InterjectionMeta | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const customType =
+    typeof record.customType === "string" ? record.customType.trim() : "";
+  if (!customType) return undefined;
+  const severity = record.severity;
+  return {
+    customType,
+    ...(severity === "nit" || severity === "concern" || severity === "blocker"
+      ? { severity }
+      : {}),
+  };
 }
 
 function sanitizePlan(value: unknown, text: string): PlanBlockMeta | null {

--- a/src/lib/sessionStore.ts
+++ b/src/lib/sessionStore.ts
@@ -286,7 +286,7 @@ export async function getSession(sessionId: string): Promise<Session | null> {
       ? await ompVerifyAssistantTexts(session.providerSessionId, candidates).catch(() => [])
       : [];
     const blocks = backfillOmpInterjections(
-      session.blocks, anchors, candidates.filter((_, index) => verified[index] === true),
+      session.blocks, anchors, candidates.map((text, index) => ({ text, occurrences: verified[index] ?? 0 })),
     );
     if (blocks !== session.blocks) {
       session.blocks = blocks;

--- a/src/lib/sessionStore.ts
+++ b/src/lib/sessionStore.ts
@@ -2,7 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { persistableAttachment } from "./attachments";
 import type { ContextUsage } from "./contextUsage";
 import { normalizeProjectPath } from "./recents";
-import { ompSessionInterjections, ompVerifyAssistantTexts } from "./fs";
+import { ompActiveAssistantTexts, ompSessionInterjections } from "./fs";
 import { backfillOmpInterjections, ompStatusSplitTexts } from "./ompInterjections";
 import type {
   Block,
@@ -280,14 +280,11 @@ export async function getSession(sessionId: string): Promise<Session | null> {
   if (session.harness !== "omp" || !session.providerSessionId) return session;
   try {
     const anchors = await ompSessionInterjections(session.providerSessionId);
-    const candidates = ompStatusSplitTexts(session.blocks);
-    // Missing verification must not prevent the existing anchored repair.
-    const verified = candidates.length
-      ? await ompVerifyAssistantTexts(session.providerSessionId, candidates).catch(() => [])
+    // Missing source order must not prevent the existing anchored repair.
+    const source = ompStatusSplitTexts(session.blocks).length
+      ? await ompActiveAssistantTexts(session.providerSessionId).catch(() => [])
       : [];
-    const blocks = backfillOmpInterjections(
-      session.blocks, anchors, candidates.map((text, index) => ({ text, occurrences: verified[index] ?? 0 })),
-    );
+    const blocks = backfillOmpInterjections(session.blocks, anchors, source);
     if (blocks !== session.blocks) {
       session.blocks = blocks;
       // Persist before exposing the restored session to a new live turn.

--- a/src/surfaces/AgentTranscript.interjection.test.ts
+++ b/src/surfaces/AgentTranscript.interjection.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Block } from "../lib/session";
+import { AgentTranscript } from "./AgentTranscript";
+
+let container: HTMLDivElement;
+let root: Root;
+let bodyHeight: number;
+let resize: () => void;
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  // happy-dom has no layout; supply the measured dimensions, not an estimate
+  // based on text length (a short string can wrap in a narrow transcript).
+  bodyHeight = 200;
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(
+    () => bodyHeight,
+  );
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(
+    () => 40,
+  );
+  vi.stubGlobal("ResizeObserver", class {
+    constructor(private callback: () => void) {}
+    observe(el: Element) {
+      if (el.tagName === "PRE") resize = this.callback;
+    }
+    disconnect() {}
+  });
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function render(text: string, severity: "blocker" | "concern" = "concern") {
+  const blocks: Block[] = [{
+    id: "advisor",
+    role: "system",
+    text,
+    interjection: { customType: "advisor", severity },
+  }];
+  act(() => root.render(createElement(AgentTranscript, { blocks, busy: false })));
+}
+
+const note = "Check the fallback.\n```ts\nconst result = read();\nif (!result) throw new Error('missing');\n```";
+
+describe("AgentTranscript interjection preview", () => {
+  it("clamps long blocker bodies by default while retaining the label and full text", () => {
+    render(note, "blocker");
+    expect(container.querySelector("pre")?.classList.contains("line-clamp-2")).toBe(true);
+    expect(container.querySelector("pre")?.textContent).toBe(note);
+    expect(container.querySelector('[aria-label="Interjection: Advisor"]')?.textContent).toContain("Blocker");
+    expect(container.querySelector("button")?.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("expands and reclamps without losing the collapse control", () => {
+    render(note);
+    const button = container.querySelector<HTMLButtonElement>("button")!;
+    act(() => button.click());
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+    expect(container.querySelector("pre")?.classList.contains("line-clamp-2")).toBe(false);
+    expect(container.querySelector("pre")?.textContent).toBe(note);
+    act(() => resize());
+    expect(container.querySelector("button")).toBe(button);
+    act(() => button.click());
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector("pre")?.classList.contains("line-clamp-2")).toBe(true);
+  });
+
+  it("omits the toggle for fitting text and remeasures when the transcript reflows", () => {
+    bodyHeight = 20;
+    render("Check this.");
+    expect(container.querySelector("button")).toBeNull();
+    bodyHeight = 60;
+    act(() => resize());
+    expect(container.querySelector("button")?.getAttribute("aria-expanded")).toBe("false");
+    bodyHeight = 40;
+    act(() => resize());
+    expect(container.querySelector("button")).toBeNull();
+  });
+});

--- a/src/surfaces/AgentTranscript.test.ts
+++ b/src/surfaces/AgentTranscript.test.ts
@@ -84,4 +84,25 @@ describe("AgentTranscript collapsed work", () => {
       markup.indexOf('aria-label="Worked for 1s"'),
     );
   });
+
+  it("renders an advisor interjection between answered work phases", () => {
+    const markup = render([
+      tool("before"),
+      { id: "answer", role: "assistant", text: "Complete answer." },
+      {
+        id: "advisor",
+        role: "system",
+        text: "Check the fallback.",
+        interjection: { customType: "advisor", severity: "concern" },
+      },
+      tool("after"),
+      { id: "ack", role: "assistant", text: "Checked." },
+    ]);
+
+    expect(markup).toContain("Complete answer.");
+    expect(markup).toContain('aria-label="Interjection: Advisor"');
+    expect(markup).toContain("Concern");
+    expect(markup).toContain("Check the fallback.");
+    expect(markup).toContain("Checked.");
+  });
 });

--- a/src/surfaces/AgentTranscript.tsx
+++ b/src/surfaces/AgentTranscript.tsx
@@ -902,6 +902,9 @@ const TranscriptBlock = memo(function TranscriptBlock({
   }
 
   if (block.role === "system") {
+    if (block.interjection) {
+      return <InterjectionDivider block={block} />;
+    }
     return (
       <div className="px-4 py-2 text-content/50">
         <pre className="min-w-0 whitespace-pre-wrap break-words">
@@ -2197,6 +2200,60 @@ function HandoffDivider({ block }: { block: Block }) {
         </div>
         <div className="h-px min-w-4 flex-1 bg-content/12" />
       </div>
+    </div>
+  );
+}
+
+/** A mid-turn interjection, e.g. OMP advisor notes: a labeled boundary with
+ * the full advisory body below it. */
+function InterjectionDivider({ block }: { block: Block }) {
+  const meta = block.interjection;
+  if (!meta) return null;
+  const label =
+    meta.customType === "advisor"
+      ? "Advisor"
+      : meta.customType === "custom"
+        ? "Notice"
+        : meta.customType;
+  const severityText =
+    meta.severity === "blocker"
+      ? "Blocker"
+      : meta.severity === "concern"
+        ? "Concern"
+        : meta.severity === "nit"
+          ? "Nit"
+          : undefined;
+  const severityClass =
+    meta.severity === "blocker"
+      ? "text-red-400"
+      : meta.severity === "concern"
+        ? "text-amber-400"
+        : "text-content/55";
+  return (
+    <div className="px-4 py-4">
+      <div className="flex items-center gap-3">
+        <div className="h-px min-w-4 flex-1 bg-content/12" />
+        <div
+          role="separator"
+          aria-label={`Interjection: ${label}`}
+          className="flex items-center gap-2 px-1.5 font-sans text-[12px] text-content/55"
+        >
+          <span>{label}</span>
+          {severityText ? (
+            <span className={`text-[11px] ${severityClass}`}>
+              {severityText}
+            </span>
+          ) : null}
+        </div>
+        <div className="h-px min-w-4 flex-1 bg-content/12" />
+      </div>
+      {block.text ? (
+        <div className="mt-2 px-2">
+          <pre className="min-w-0 whitespace-pre-wrap break-words font-sans text-[12.5px] leading-5 text-content/70">
+            {block.text}
+          </pre>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/surfaces/AgentTranscript.tsx
+++ b/src/surfaces/AgentTranscript.tsx
@@ -2205,8 +2205,29 @@ function HandoffDivider({ block }: { block: Block }) {
 }
 
 /** A mid-turn interjection, e.g. OMP advisor notes: a labeled boundary with
- * the full advisory body below it. */
+ * a collapsible advisory body below it. */
 function InterjectionDivider({ block }: { block: Block }) {
+  const [expanded, setExpanded] = useState(false);
+  const [overflows, setOverflows] = useState(false);
+  const textRef = useRef<HTMLPreElement>(null);
+
+  useLayoutEffect(() => {
+    const el = textRef.current;
+    if (!el || !block.text) {
+      setOverflows(false);
+      return;
+    }
+    const measure = () => {
+      if (!expanded) {
+        setOverflows(el.scrollHeight > el.clientHeight + 1);
+      }
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [block.text, expanded]);
+
   const meta = block.interjection;
   if (!meta) return null;
   const label =
@@ -2249,9 +2270,22 @@ function InterjectionDivider({ block }: { block: Block }) {
       </div>
       {block.text ? (
         <div className="mt-2 px-2">
-          <pre className="min-w-0 whitespace-pre-wrap break-words font-sans text-[12.5px] leading-5 text-content/70">
+          <pre
+            ref={textRef}
+            className={`min-w-0 whitespace-pre-wrap break-words font-sans text-[12.5px] leading-5 text-content/70 ${expanded ? "" : "line-clamp-2"}`}
+          >
             {block.text}
           </pre>
+          {overflows ? (
+            <button
+              type="button"
+              aria-expanded={expanded}
+              onClick={() => setExpanded((value) => !value)}
+              className="mt-1 py-1 font-sans text-xs text-content/55 hover:text-content"
+            >
+              {expanded ? "Show less" : "Show more"}
+            </button>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/src/surfaces/transcriptActivity.test.ts
+++ b/src/surfaces/transcriptActivity.test.ts
@@ -677,6 +677,27 @@ describe("foldableWork", () => {
     expect(foldableWork(turn)).toEqual({ start: 3, end: 3 });
   });
 
+  it("uses an interjection as a hard boundary between answered work phases", () => {
+    const turn = items([
+      shell("before"),
+      note("answer", "The complete answer."),
+      {
+        id: "advisor",
+        role: "system",
+        text: "Check the fallback.",
+        interjection: { customType: "advisor", severity: "nit" },
+      },
+      shell("after"),
+      note("ack", "Checked."),
+    ]);
+    const fold = foldableWork(turn)!;
+
+    expect(fold).toEqual({ start: 3, end: 3 });
+    expect(foldedBlocks(turn, fold).map((block) => block.id)).toEqual([
+      "after",
+    ]);
+  });
+
   it("leaves an approval attached to earlier work outside the fold", () => {
     const turn = items([
       shell("pending", "pending", { requestId: 1 }),

--- a/src/surfaces/transcriptActivity.ts
+++ b/src/surfaces/transcriptActivity.ts
@@ -591,6 +591,10 @@ export type WorkFold = { start: number; end: number };
  * approval. As the turn streams, each new paragraph folds the work and running
  * commentary before it, leaving the final answer visible. A late approval can
  * reopen that boundary so its controls remain available.
+ *
+ * Persisted interjections (system blocks with interjection chrome) are neither
+ * prose nor work, so they stop the fold: an answer the harness already showed
+ * never folds behind an interjection that arrived after it.
  */
 export function foldableWork(items: TurnItem[]): WorkFold | undefined {
   let end = -1;


### PR DESCRIPTION
# Fix OMP advisor interjections folding away complete answers (#123)

Fixes #123

## Problem

When OMP's advisor interjects mid-turn, OMP emits `custom_message` (customType `advisor`, `display: true`) and `advisor_yielded` frames on the RPC stream. MonoCode dropped them silently, which had two visible effects:

- **Live turns**: the interjection was invisible, and worse, the fold logic could no longer distinguish "progress commentary" from "a complete answer followed by a new segment" — the complete earlier answer folded behind the work chrome, leaving only a short tail visible (screenshots in #123).
- **Already-saved sessions**: builds before this fix persisted `assistant → reasoning/tool → assistant` without the boundary. Some even **coalesced the two answers into a single assistant block** (streaming text appended across the boundary). Re-rendering those sessions still folded the complete answer.

## Fix, part 1 — live rendering

- `piFamily.ts` (omp flavor): `handleFrame` emits a new persisted `interjection` harness event for `custom_message` frames with `display: true` (structured advisor notes with severity `nit|concern|blocker`, plus generic custom types); `advisor_yielded` becomes a transient status line. `display: false` stays hidden.
- `apply.ts`: the event appends a `system` block carrying `interjection` chrome (`customType`, max `severity`).
- `AgentTranscript.tsx`: renders a distinct interjection row (severity styled) instead of an invisible system block.
- `transcriptActivity.ts`: interjection blocks are neither prose nor work, so `foldableWork` cannot extend a fold across them — an answer the harness already showed never folds behind a later interjection.

## Fix, part 2 — backfill for sessions saved by older builds

- New Tauri command `omp_session_interjections(providerSessionId)` (`src-tauri/src/fs.rs`) scans OMP's own session JSONL (`~/.omp/agent/sessions/**/*_<providerSessionId>.jsonl`) and returns display-true anchors: interjection text/type/severity, the **full text** of the preceding assistant message, its 1-based occurrence among identical texts, and — when the very next message is a text-only assistant reply — its full text as split evidence.
- `sessionStore.getSession` repairs persisted OMP sessions (only when harness is omp and a provider session id is bound): inserts the missing boundary blocks and, where an old build coalesced two answers, splits the block back into `assistant → interjection → assistant`.
- Matching is deliberately strict: exact full-text equality + occurrence disambiguation + source order; a coalesced block is split only when both source texts concatenate exactly to the persisted text. Anything that cannot be matched exactly is left untouched — the repair never guesses boundaries (progress prose between tool calls must keep folding).
- Deterministic block ids (`omp-interjection-<omp message id>`) make the repair idempotent; repaired sessions are persisted once via the normal upsert path. Other harnesses and unbound sessions are untouched; any source/log error degrades silently to today's rendering.

## Verification

- `npx vitest run`: 1515 tests green (1505 baseline + 10 new covering: fold no longer swallows the earlier answer, occurrence disambiguation, no-anchor turns unchanged, no fuzzy/prefix matching, idempotent re-run, live-random-id dedup, coalesced-block split, load persistence, error degradation).
- `src-tauri`: `cargo fmt --check` + `cargo check` clean; 2 new parser tests (anchor gating, no coalesce-evidence across thinking parts).
- Real-data validation on the reporter's machine: 13 affected persisted sessions; the heaviest (17 anchors in one session) matched 17/17 — 15 boundary insertions plus 2 exact coalesced-block splits (e.g. 1146+401=1547 chars restored to two answers); block count 1353 → 1372; second pass changed nothing.

## Notes

- Only the OMP flavor is affected; pi/fx/claude/codex/... paths are unchanged.
- No schema migration: repair happens lazily at load from OMP's own logs, so sessions saved by even older builds heal themselves without a one-shot migration pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added advisor notes and custom messages as transcript interjections with severity levels.
  - Added status updates when an advisor reviews a turn.
  - Recovered missing interjections from existing OMP session transcripts.
  - Interjections remain visible in session history and mark work-phase boundaries.
  - Long interjection messages can be expanded or collapsed.

- **Bug Fixes**
  - Improved matching and counting of repeated transcript content during recovery.
  - Preserved streaming content across status and interjection rows.
  - Preserved transcript content when recovery or persistence encounters errors.
  - Session setting updates now retain existing values not included in updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->