### PR TITLE
Open project logo picker in the selected project directory

### DIFF
--- a/src/chrome/ProjectRail.tsx
+++ b/src/chrome/ProjectRail.tsx
@@ -525,7 +525,7 @@ export function ProjectRail({
             projectName(projectMenu.path),
           )}
           logoPath={resolveTabGroupLogo(projectMenu.projectKey, groupLogos)}
-          logoProject={projectMenu.projectKey}
+          logoProject={projectMenu.path}
           mascotName={resolveTabGroupMascot(
             projectMenu.projectKey,
             groupMascots,

--- a/src/chrome/TabGroupMenu.tsx
+++ b/src/chrome/TabGroupMenu.tsx
@@ -16,6 +16,7 @@ import {
   type ReactNode,
 } from "react";
 import { normalizeHex } from "../lib/colorUtils";
+import { projectKey } from "../lib/paths";
 import { clearProjectLogo, pickAndSetProjectLogo } from "../lib/projectLogos";
 import { PROJECT_MASCOTS, projectMascot } from "../lib/projectMascots";
 import { TAB_GROUP_COLORS } from "../lib/tabGroups";
@@ -49,6 +50,7 @@ type Props = {
   customColor: string | null;
   currentColor: string;
   logoPath: string | null;
+  /** Original project directory for the logo picker. */
   logoProject?: string | null;
   /** Explicit mascot pick; null means the one hashed from `mascotProject`. */
   mascotName: string | null;
@@ -218,7 +220,7 @@ export function TabGroupMenu({
               aria-label="Remove project logo"
               onMouseDown={(e) => e.preventDefault()}
               onClick={() => {
-                void clearProjectLogo(logoProject).then(onLogoChange);
+                void clearProjectLogo(projectKey(logoProject)).then(onLogoChange);
               }}
               className="grid size-7 shrink-0 place-items-center rounded-md text-content/50 hover:bg-content/10 hover:text-content"
             >

--- a/src/lib/projectLogos.test.ts
+++ b/src/lib/projectLogos.test.ts
@@ -1,14 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { projectKey } from "./paths";
-import { clearProjectLogo, droppableLogoFile } from "./projectLogos";
-import { saveTabGroupLogo } from "./tabGroups";
+import {
+  clearProjectLogo,
+  droppableLogoFile,
+  pickAndSetProjectLogo,
+} from "./projectLogos";
+import { loadTabGroupLogos, saveTabGroupLogo } from "./tabGroups";
 
-const mocks = vi.hoisted(() => ({ invoke: vi.fn() }));
+const mocks = vi.hoisted(() => ({ invoke: vi.fn(), open: vi.fn() }));
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: mocks.invoke,
   convertFileSrc: (path: string) => path,
 }));
-vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: mocks.open }));
 
 function mockLocalStorage() {
   const data = new Map<string, string>();
@@ -44,6 +48,46 @@ const FINANCE = projectKey("/Users/me/cortex-finance/agentbase");
 const CORTEX = projectKey("/Users/me/cortex/agentbase");
 // Both migrated projects still point at the one file saved under the old key.
 const SHARED = "/logos/agentbase.png";
+
+describe("pickAndSetProjectLogo", () => {
+  beforeEach(() => {
+    mockLocalStorage();
+    mockWindow();
+    mocks.invoke.mockReset();
+    mocks.open.mockReset();
+  });
+
+  it.each([
+    ["D:\\Work\\My Project", "d:/work/my project"],
+    ["D:\\", "d:"],
+    ["/Users/me/My Project", "/Users/me/My Project"],
+    ["\\\\server\\share\\My Project", "//server/share/my project"],
+  ])(
+    "opens in %s and saves the logo under its project key",
+    async (directory, key) => {
+      const sourcePath = "C:\\Pictures\\logo.png";
+      const savedPath = "/logos/saved.png";
+      mocks.open.mockResolvedValue(sourcePath);
+      mocks.invoke.mockResolvedValue(savedPath);
+
+      const result = await pickAndSetProjectLogo(directory);
+
+      expect(mocks.open).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultPath: directory,
+          directory: false,
+          multiple: false,
+        }),
+      );
+      expect(mocks.invoke).toHaveBeenCalledWith("save_project_logo", {
+        project: key,
+        sourcePath,
+      });
+      expect(result).toBe(savedPath);
+      expect(loadTabGroupLogos()[key]).toBe(savedPath);
+    },
+  );
+});
 
 describe("droppableLogoFile", () => {
   it("keeps a file another project still shows", () => {

--- a/src/lib/projectLogos.ts
+++ b/src/lib/projectLogos.ts
@@ -1,5 +1,6 @@
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
+import { projectKey } from "./paths";
 import {
   loadTabGroupLogos,
   notifyTabGroupLogosChanged,
@@ -7,8 +8,9 @@ import {
   tabGroupLogoDisplayRevision,
 } from "./tabGroups";
 
-export async function pickImageFile(): Promise<string | null> {
+export async function pickImageFile(directory: string): Promise<string | null> {
   const selected = await open({
+    defaultPath: directory,
     multiple: false,
     directory: false,
     title: "Choose project logo",
@@ -50,9 +52,10 @@ async function forgetLogoFile(path: string | null): Promise<void> {
   await invoke("forget_logo_file", { path }).catch(() => undefined);
 }
 
-export async function pickAndSetProjectLogo(project: string): Promise<string | null> {
-  const sourcePath = await pickImageFile();
+export async function pickAndSetProjectLogo(projectPath: string): Promise<string | null> {
+  const sourcePath = await pickImageFile(projectPath);
   if (!sourcePath) return null;
+  const project = projectKey(projectPath);
   const logos = loadTabGroupLogos();
   const path = await invoke<string>("save_project_logo", {
     project,


### PR DESCRIPTION
## What changed

The Project logo image picker now starts in the directory of the project whose menu was opened. Users can still select an image from another folder.

The menu passes the original project directory to the picker. Saving and removing a logo still use the normalized project key, so existing appearance settings remain associated with the same project. Passing the original directory also preserves Windows drive-root paths such as `D:\`.

## Why

The picker did not set Tauri's `defaultPath`, so its initial folder was unrelated to the selected project.

Fixes #162.

## UI

No layout change. Manually verified on Windows 10 that clicking Project logo opens the image picker in the saved project's directory.

## Validation

- The regression test failed before the fix because `defaultPath` was absent, then passed after the fix.
- The test covers Windows paths with spaces, drive roots, UNC paths, and POSIX paths. It also verifies that an image selected outside the project is saved under the existing project key.
- `npm run check:web`: 1,500 tests passed and TypeScript passed.
- `npm run check:rust`: formatting, Clippy with warnings denied, and 199 tests passed.
- Frontend and Windows debug application builds passed.

## Checklist

- [x] I ran the full checks via `npm run check:web` and `npm run check:rust`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project logos now resolve correctly from project filesystem paths across Windows and POSIX systems.
  * The logo picker opens directly in the selected project’s directory.
  * Removing a project logo now targets the correct project.

* **Tests**
  * Added coverage for logo selection, path normalization, saving, loading, and removal across supported path formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->