### PR TITLE
Add inbox provider connection flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -320,7 +320,8 @@ import { SessionPane } from "./surfaces/SessionPane";
 import { SessionSurface } from "./surfaces/SessionSurface";
 import { ProjectTerminalDock } from "./surfaces/ProjectTerminalDock";
 import { SearchView } from "./surfaces/SearchView";
-import { SettingsView } from "./surfaces/SettingsView";
+import { SettingsView, type SettingsAnchor } from "./surfaces/SettingsView";
+import type { ConnectableInboxSource } from "./lib/inboxFilters";
 import { InboxView } from "./surfaces/InboxView";
 import type { InboxSessionPortal } from "./surfaces/InboxDiscussionPanel";
 import { inboxAskKey, inboxAskPrompt } from "./lib/inboxAsk";
@@ -639,6 +640,9 @@ export default function App({
   const [whatsNewVersion, setWhatsNewVersion] = useState<string | null>(null);
   const [settingsSection, setSettingsSection] =
     useState<SettingsSectionId>(loadSettingsSection);
+  const [settingsAnchor, setSettingsAnchor] = useState<SettingsAnchor | null>(
+    null,
+  );
   const [editorNavigation, setEditorNavigation] =
     useState<EditorNavigationTarget | null>(null);
   const editorNavigationToken = useRef(0);
@@ -4789,19 +4793,28 @@ export default function App({
     setNotesViewOpen(false);
   }, []);
 
-  const openSettings = useCallback((section?: SettingsSectionId) => {
-    setFilePickerOpen(false);
-    setSearchViewOpen(false);
-    setInboxViewOpen(false);
-    setNotesViewOpen(false);
-    if (section) {
-      setSettingsSection(section);
-      saveSettingsSection(section);
-    }
-    setSettingsOpen(true);
-  }, []);
+  const openSettings = useCallback(
+    (section?: SettingsSectionId, anchor?: SettingsAnchor) => {
+      setFilePickerOpen(false);
+      setSearchViewOpen(false);
+      setInboxViewOpen(false);
+      setNotesViewOpen(false);
+      if (section) {
+        setSettingsSection(section);
+        saveSettingsSection(section);
+      }
+      setSettingsAnchor(anchor ?? null);
+      setSettingsOpen(true);
+    },
+    [],
+  );
 
   const onOpenSettings = useCallback(() => openSettings(), [openSettings]);
+
+  const onOpenInboxIntegrations = useCallback(
+    (source: ConnectableInboxSource) => openSettings("general", source),
+    [openSettings],
+  );
 
   const onCloseSettings = useCallback(() => {
     setSettingsOpen(false);
@@ -5613,6 +5626,7 @@ export default function App({
             sessions={inboxRelatedSessions}
             onOpenSession={onOpenInboxSession}
             target={inboxTarget}
+            onOpenIntegrations={onOpenInboxIntegrations}
           />
         ) : null}
         {notesViewOpen ? (
@@ -5626,6 +5640,7 @@ export default function App({
         {settingsOpen ? (
           <SettingsView
             section={settingsSection}
+            anchor={settingsAnchor}
             cwd={sidebarCwd}
             sessions={sidebarHistory}
             besideRail

--- a/src/chrome/InboxConnectMenu.tsx
+++ b/src/chrome/InboxConnectMenu.tsx
@@ -1,0 +1,62 @@
+import {
+  INBOX_SOURCE_LABELS,
+  type ConnectableInboxSource,
+} from "../lib/inboxFilters";
+import { InboxProviderMark } from "./InboxProviderMark";
+import { Popover, type PopoverAnchor } from "./Popover";
+
+const WIDTH = 188;
+
+/**
+ * The "+" flyout off the inbox source strip. Disconnected providers lose their
+ * tab but stay discoverable here, one click from where they are set up.
+ */
+export function InboxConnectMenu({
+  anchor,
+  sources,
+  onConnect,
+  onClose,
+}: {
+  anchor: PopoverAnchor;
+  sources: ConnectableInboxSource[];
+  onConnect: (source: ConnectableInboxSource) => void;
+  onClose: () => void;
+}) {
+  return (
+    <Popover
+      anchor={anchor}
+      gap={4}
+      width={WIDTH}
+      onDismiss={onClose}
+      role="menu"
+      aria-label="Connect an inbox source"
+      onContextMenu={(event) => event.preventDefault()}
+      className="p-1"
+    >
+      <div className="px-2 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-content/40">
+        Not connected
+      </div>
+      {sources.map((source) => (
+        <button
+          key={source}
+          type="button"
+          role="menuitem"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => {
+            onClose();
+            onConnect(source);
+          }}
+          className="flex h-7 w-full items-center gap-2 rounded-lg px-2 text-left text-[13px] leading-none text-content hover:bg-content/5"
+        >
+          <InboxProviderMark
+            provider={source}
+            className="block size-3.5 shrink-0"
+          />
+          <span className="min-w-0 flex-1 truncate">
+            Connect {INBOX_SOURCE_LABELS[source]}
+          </span>
+        </button>
+      ))}
+    </Popover>
+  );
+}

--- a/src/chrome/InboxConnectMenu.tsx
+++ b/src/chrome/InboxConnectMenu.tsx
@@ -7,10 +7,6 @@ import { Popover, type PopoverAnchor } from "./Popover";
 
 const WIDTH = 188;
 
-/**
- * The "+" flyout off the inbox source strip. Disconnected providers lose their
- * tab but stay discoverable here, one click from where they are set up.
- */
 export function InboxConnectMenu({
   anchor,
   sources,

--- a/src/lib/inboxFilters.test.ts
+++ b/src/lib/inboxFilters.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   applyInboxFilters,
   DEFAULT_INBOX_FILTERS,
@@ -13,6 +13,11 @@ import {
   LINEAR_NO_PROJECT,
   linearProjectOptions,
   pruneInboxFilters,
+  connectableInboxSources,
+  loadInboxConnections,
+  resolveInboxSource,
+  saveInboxConnections,
+  visibleInboxSources,
 } from "./inboxFilters";
 import type { InboxItem } from "./githubTasks";
 
@@ -464,5 +469,108 @@ describe("pruneInboxFilters", () => {
       ["/tmp/web"],
     );
     expect(pruned.hiddenProjects).toEqual(["/tmp/web"]);
+  });
+});
+
+describe("visibleInboxSources", () => {
+  it("keeps GitHub and drops sources that are known to be disconnected", () => {
+    expect(visibleInboxSources({ linear: false, gitlab: false })).toEqual([
+      "github",
+    ]);
+    expect(visibleInboxSources({ linear: true, gitlab: false })).toEqual([
+      "github",
+      "linear",
+    ]);
+    expect(visibleInboxSources({ linear: true, gitlab: true })).toEqual([
+      "github",
+      "linear",
+      "gitlab",
+    ]);
+  });
+
+  it("keeps unresolved sources visible so tabs do not flash away", () => {
+    expect(visibleInboxSources({ linear: null, gitlab: null })).toEqual([
+      "github",
+      "linear",
+      "gitlab",
+    ]);
+  });
+});
+
+describe("connectableInboxSources", () => {
+  it("offers only the sources confirmed to be disconnected", () => {
+    expect(connectableInboxSources({ linear: false, gitlab: true })).toEqual([
+      "linear",
+    ]);
+    expect(connectableInboxSources({ linear: false, gitlab: false })).toEqual([
+      "linear",
+      "gitlab",
+    ]);
+  });
+
+  it("offers nothing while the checks are unresolved", () => {
+    expect(connectableInboxSources({ linear: null, gitlab: null })).toEqual([]);
+  });
+});
+
+describe("resolveInboxSource", () => {
+  it("falls back to GitHub when the selected source loses its tab", () => {
+    expect(resolveInboxSource("linear", { linear: false, gitlab: true })).toBe(
+      "github",
+    );
+  });
+
+  it("leaves a still-visible selection alone", () => {
+    expect(resolveInboxSource("linear", { linear: true, gitlab: false })).toBe(
+      "linear",
+    );
+    expect(resolveInboxSource("github", { linear: false, gitlab: false })).toBe(
+      "github",
+    );
+  });
+});
+
+function mockLocalStorage() {
+  const data = new Map<string, string>();
+  const storage = {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    clear: () => {
+      data.clear();
+    },
+    key: (index: number) => [...data.keys()][index] ?? null,
+    get length() {
+      return data.size;
+    },
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storage,
+    configurable: true,
+  });
+}
+
+describe("inbox connection cache", () => {
+  const KEY = "monocode.inboxConnections";
+  beforeEach(mockLocalStorage);
+
+  it("round-trips the last known connect state", () => {
+    saveInboxConnections({ linear: true, gitlab: false });
+    expect(loadInboxConnections()).toEqual({ linear: true, gitlab: false });
+  });
+
+  it("reads unknown when nothing is stored", () => {
+    expect(loadInboxConnections()).toEqual({ linear: null, gitlab: null });
+  });
+
+  it("reads unknown rather than trusting a malformed value", () => {
+    localStorage.setItem(KEY, "not json");
+    expect(loadInboxConnections()).toEqual({ linear: null, gitlab: null });
+    localStorage.setItem(KEY, '{"linear":"yes"}');
+    expect(loadInboxConnections()).toEqual({ linear: null, gitlab: null });
   });
 });

--- a/src/lib/inboxFilters.ts
+++ b/src/lib/inboxFilters.ts
@@ -56,7 +56,6 @@ export const DEFAULT_INBOX_FILTERS: InboxFilters = {
 
 export type InboxSource = InboxProvider;
 
-/** The sources that carry a token this app holds, so have a connect step. */
 export type ConnectableInboxSource = "linear" | "gitlab";
 
 /** `null` means the status check has not resolved yet. */
@@ -71,7 +70,6 @@ export const INBOX_SOURCE_LABELS: Record<InboxSource, string> = {
   gitlab: "GitLab",
 };
 
-/** GitHub needs no connect step, so it is always offered. */
 export function visibleInboxSources(
   connections: InboxSourceConnections,
 ): InboxSource[] {
@@ -81,7 +79,6 @@ export function visibleInboxSources(
   return sources;
 }
 
-/** The gated sources a user could still connect, for the "+" menu. */
 export function connectableInboxSources(
   connections: InboxSourceConnections,
 ): ConnectableInboxSource[] {
@@ -91,7 +88,6 @@ export function connectableInboxSources(
   return sources;
 }
 
-/** Falls back to GitHub when the selected source loses its tab. */
 export function resolveInboxSource(
   source: InboxSource,
   connections: InboxSourceConnections,
@@ -130,9 +126,8 @@ function connectFlag(value: unknown): boolean | null {
 }
 
 /**
- * The status reads are async commands, so a cold start would paint every tab
- * and then drop two. Seeding from the last known answer keeps that first paint
- * right for the returning user; a wrong guess corrects itself on the read.
+ * Seeded from the last known answer so a returning user does not watch every
+ * tab paint and then drop two. A wrong guess corrects itself on the read.
  */
 export function loadInboxConnections(): InboxSourceConnections {
   try {

--- a/src/lib/inboxFilters.ts
+++ b/src/lib/inboxFilters.ts
@@ -56,8 +56,57 @@ export const DEFAULT_INBOX_FILTERS: InboxFilters = {
 
 export type InboxSource = InboxProvider;
 
+/** The sources that carry a token this app holds, so have a connect step. */
+export type ConnectableInboxSource = "linear" | "gitlab";
+
+/** `null` means the status check has not resolved yet. */
+export type InboxSourceConnections = Record<
+  ConnectableInboxSource,
+  boolean | null
+>;
+
+export const INBOX_SOURCE_LABELS: Record<InboxSource, string> = {
+  github: "GitHub",
+  linear: "Linear",
+  gitlab: "GitLab",
+};
+
+/** GitHub needs no connect step, so it is always offered. */
+export function visibleInboxSources(
+  connections: InboxSourceConnections,
+): InboxSource[] {
+  const sources: InboxSource[] = ["github"];
+  if (connections.linear !== false) sources.push("linear");
+  if (connections.gitlab !== false) sources.push("gitlab");
+  return sources;
+}
+
+/** The gated sources a user could still connect, for the "+" menu. */
+export function connectableInboxSources(
+  connections: InboxSourceConnections,
+): ConnectableInboxSource[] {
+  const sources: ConnectableInboxSource[] = [];
+  if (connections.linear === false) sources.push("linear");
+  if (connections.gitlab === false) sources.push("gitlab");
+  return sources;
+}
+
+/** Falls back to GitHub when the selected source loses its tab. */
+export function resolveInboxSource(
+  source: InboxSource,
+  connections: InboxSourceConnections,
+): InboxSource {
+  return visibleInboxSources(connections).includes(source) ? source : "github";
+}
+
 const FILTERS_KEY = "monocode.inboxFilters";
 const SOURCE_KEY = "monocode.inboxSource";
+const CONNECTIONS_KEY = "monocode.inboxConnections";
+
+const UNKNOWN_CONNECTIONS: InboxSourceConnections = {
+  linear: null,
+  gitlab: null,
+};
 
 export function loadInboxSource(): InboxSource {
   try {
@@ -71,6 +120,38 @@ export function loadInboxSource(): InboxSource {
 export function saveInboxSource(source: InboxSource) {
   try {
     localStorage.setItem(SOURCE_KEY, source);
+  } catch {
+    // private mode / quota
+  }
+}
+
+function connectFlag(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+/**
+ * The status reads are async commands, so a cold start would paint every tab
+ * and then drop two. Seeding from the last known answer keeps that first paint
+ * right for the returning user; a wrong guess corrects itself on the read.
+ */
+export function loadInboxConnections(): InboxSourceConnections {
+  try {
+    const raw = localStorage.getItem(CONNECTIONS_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : null;
+    if (!parsed || typeof parsed !== "object") return UNKNOWN_CONNECTIONS;
+    const record = parsed as Record<string, unknown>;
+    return {
+      linear: connectFlag(record.linear),
+      gitlab: connectFlag(record.gitlab),
+    };
+  } catch {
+    return UNKNOWN_CONNECTIONS;
+  }
+}
+
+export function saveInboxConnections(connections: InboxSourceConnections) {
+  try {
+    localStorage.setItem(CONNECTIONS_KEY, JSON.stringify(connections));
   } catch {
     // private mode / quota
   }

--- a/src/surfaces/InboxView.tsx
+++ b/src/surfaces/InboxView.tsx
@@ -453,21 +453,17 @@ export function InboxView({
     return () => window.removeEventListener(GITLAB_CHANGE_EVENT, onChange);
   }, []);
 
-  // The mount read is what does the work: opening Settings unmounts this view,
-  // so a token set there lands on the way back in. The listeners only keep a
-  // provider honest if it broadcasts while the inbox is up.
-  //
-  // Each read is an async command, so the first paint lands before either
-  // answer does. That is what seeding from loadInboxConnections is for.
-  //
-  // The two reads stay independent: a failing Linear check must not discard
-  // the GitLab answer, so each provider keeps its own previous value.
+  // The mount read does the real work: opening Settings unmounts this view, so
+  // a token set there lands on the way back in. Reads can also overlap, and
+  // only the newest may write, or a slow earlier answer restores a stale one.
   useEffect(() => {
     let cancelled = false;
+    let latest = 0;
     const read = () => {
+      const generation = ++latest;
       void Promise.allSettled([linearConnected(), gitlabConnected()]).then(
         ([linear, gitlab]) => {
-          if (cancelled) return;
+          if (cancelled || generation !== latest) return;
           setConnections((prev) => ({
             linear:
               linear.status === "fulfilled"
@@ -494,6 +490,15 @@ export function InboxView({
   useEffect(() => {
     saveInboxConnections(connections);
   }, [connections]);
+
+  // The initial source is resolved against cached status, so storage can still
+  // name a provider this view has already fallen back from.
+  useEffect(() => {
+    saveInboxSource(source);
+    // Mount only: the temporary switch to GitHub for a linked target must not
+    // be persisted.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Disconnecting can pull the tab out from under the current selection.
   useEffect(() => {

--- a/src/surfaces/InboxView.tsx
+++ b/src/surfaces/InboxView.tsx
@@ -15,6 +15,7 @@ import {
   ListFilter,
   LoaderCircle,
   MessageMultiple,
+  Plus,
   RefreshCw,
   Search,
   type IconComponent,
@@ -30,6 +31,7 @@ import {
   InboxFiltersMenu,
   INBOX_FILTER_MENU_WIDTH,
 } from "../chrome/InboxFiltersMenu";
+import { InboxConnectMenu } from "../chrome/InboxConnectMenu";
 import { InboxProviderMark } from "../chrome/InboxProviderMark";
 import { ProjectLogoIcon } from "../chrome/ProjectLogoIcon";
 import { ProjectMascot } from "../chrome/ProjectMascot";
@@ -67,14 +69,21 @@ import {
 } from "../lib/githubTasks";
 import {
   applyInboxFilters,
+  connectableInboxSources,
   hasActiveInboxFilters,
+  loadInboxConnections,
   linearProjectOptions,
   inboxFetchState,
   loadInboxFilters,
   loadInboxSource,
   pruneInboxFilters,
   saveInboxFilters,
+  resolveInboxSource,
+  saveInboxConnections,
   saveInboxSource,
+  visibleInboxSources,
+  INBOX_SOURCE_LABELS,
+  type ConnectableInboxSource,
   type InboxFilters,
   type InboxSource,
 } from "../lib/inboxFilters";
@@ -96,6 +105,7 @@ import {
 } from "../lib/inboxSeen";
 import {
   LINEAR_CHANGE_EVENT,
+  linearConnected,
   linearIssueComment,
   linearIssueDetails,
   linearIssueThread,
@@ -109,6 +119,7 @@ import {
 } from "../lib/linear";
 import {
   GITLAB_CHANGE_EVENT,
+  gitlabConnected,
   gitlabMrDiff,
   gitlabWorkItemComment,
   gitlabWorkItemDetails,
@@ -232,8 +243,7 @@ function InboxSourceTab({
   selected: boolean;
   onSelect: (source: InboxSource) => void;
 }) {
-  const label =
-    source === "linear" ? "Linear" : source === "gitlab" ? "GitLab" : "GitHub";
+  const label = INBOX_SOURCE_LABELS[source];
   return (
     <button
       type="button"
@@ -298,6 +308,8 @@ type Props = {
   onOpenSession?: (sessionId: string) => void | Promise<void>;
   /** Session-card destination to reveal after the Inbox list loads. */
   target?: LinkedWorkItem | null;
+  /** Opens Settings on the card where the given source is connected. */
+  onOpenIntegrations: (source: ConnectableInboxSource) => void;
 };
 
 export function InboxView({
@@ -313,6 +325,7 @@ export function InboxView({
   sessions = [],
   onOpenSession,
   target = null,
+  onOpenIntegrations,
 }: Props) {
   const [discussionOpen, setDiscussionOpen] = useState(false);
   const listLock = useLockOverscroll<HTMLDivElement>();
@@ -342,7 +355,12 @@ export function InboxView({
   );
   const [targetItem, setTargetItem] = useState<InboxItem | null>(null);
   const [filters, setFilters] = useState(loadInboxFilters);
-  const [source, setSource] = useState(loadInboxSource);
+  const [connections, setConnections] = useState(loadInboxConnections);
+  const [source, setSource] = useState(() =>
+    resolveInboxSource(loadInboxSource(), connections),
+  );
+  const [connectMenuOpen, setConnectMenuOpen] = useState(false);
+  const connectButtonRef = useRef<HTMLButtonElement | null>(null);
   const [filterMenu, setFilterMenu] = useState<{ x: number; y: number } | null>(
     null,
   );
@@ -410,11 +428,15 @@ export function InboxView({
         setFilterMenu(null);
         return;
       }
+      if (connectMenuOpen) {
+        setConnectMenuOpen(false);
+        return;
+      }
       onCloseRef.current?.();
     };
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);
-  }, [filterMenu]);
+  }, [connectMenuOpen, filterMenu]);
 
   useEffect(() => {
     const onChange = () => {
@@ -430,6 +452,59 @@ export function InboxView({
     window.addEventListener(GITLAB_CHANGE_EVENT, onChange);
     return () => window.removeEventListener(GITLAB_CHANGE_EVENT, onChange);
   }, []);
+
+  // The mount read is what does the work: opening Settings unmounts this view,
+  // so a token set there lands on the way back in. The listeners only keep a
+  // provider honest if it broadcasts while the inbox is up.
+  //
+  // Each read is an async command, so the first paint lands before either
+  // answer does. That is what seeding from loadInboxConnections is for.
+  //
+  // The two reads stay independent: a failing Linear check must not discard
+  // the GitLab answer, so each provider keeps its own previous value.
+  useEffect(() => {
+    let cancelled = false;
+    const read = () => {
+      void Promise.allSettled([linearConnected(), gitlabConnected()]).then(
+        ([linear, gitlab]) => {
+          if (cancelled) return;
+          setConnections((prev) => ({
+            linear:
+              linear.status === "fulfilled"
+                ? linear.value.connected
+                : prev.linear,
+            gitlab:
+              gitlab.status === "fulfilled"
+                ? gitlab.value.connected
+                : prev.gitlab,
+          }));
+        },
+      );
+    };
+    read();
+    window.addEventListener(LINEAR_CHANGE_EVENT, read);
+    window.addEventListener(GITLAB_CHANGE_EVENT, read);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(LINEAR_CHANGE_EVENT, read);
+      window.removeEventListener(GITLAB_CHANGE_EVENT, read);
+    };
+  }, []);
+
+  useEffect(() => {
+    saveInboxConnections(connections);
+  }, [connections]);
+
+  // Disconnecting can pull the tab out from under the current selection.
+  useEffect(() => {
+    const next = resolveInboxSource(source, connections);
+    if (next === source) return;
+    setSource(next);
+    saveInboxSource(next);
+  }, [connections, source]);
+
+  const visibleSources = visibleInboxSources(connections);
+  const connectableSources = connectableInboxSources(connections);
 
   // The roster has to come from Linear, not from the fetched issues: hiding a
   // team drops its issues, so a derived list could never offer it back.
@@ -615,26 +690,39 @@ export function InboxView({
       ref={resize.setPaneRef}
       className="relative flex h-full min-h-0 shrink-0 flex-col border-r border-content/10"
     >
-      <div
-        role="tablist"
-        aria-label="Inbox source"
-        className="flex h-9 shrink-0 items-center gap-px border-b border-content/10 px-2"
-      >
-        <InboxSourceTab
-          source="github"
-          selected={source === "github"}
-          onSelect={onSourceChange}
-        />
-        <InboxSourceTab
-          source="linear"
-          selected={source === "linear"}
-          onSelect={onSourceChange}
-        />
-        <InboxSourceTab
-          source="gitlab"
-          selected={source === "gitlab"}
-          onSelect={onSourceChange}
-        />
+      <div className="flex h-9 shrink-0 items-center gap-px border-b border-content/10 px-2">
+        <div
+          role="tablist"
+          aria-label="Inbox source"
+          className="flex min-w-0 flex-1 items-center gap-px"
+        >
+          {visibleSources.map((option) => (
+            <InboxSourceTab
+              key={option}
+              source={option}
+              selected={source === option}
+              onSelect={onSourceChange}
+            />
+          ))}
+        </div>
+        {connectableSources.length > 0 ? (
+          <button
+            ref={connectButtonRef}
+            type="button"
+            aria-label="Connect an inbox source"
+            aria-haspopup="menu"
+            aria-expanded={connectMenuOpen}
+            title="Connect an inbox source"
+            onClick={() => setConnectMenuOpen((open) => !open)}
+            className={`grid size-6 shrink-0 place-items-center rounded-md ${
+              connectMenuOpen
+                ? "bg-content/10 text-content"
+                : "text-content/40 hover:bg-content/5 hover:text-content"
+            }`}
+          >
+            <Plus className="size-3.5" strokeWidth={1.75} />
+          </button>
+        ) : null}
       </div>
       <div className="flex h-9 shrink-0 items-center gap-1 border-b border-content/10 px-2">
         <div className="relative flex h-7 min-w-0 flex-1 items-center">
@@ -788,6 +876,16 @@ export function InboxView({
     />
   ) : null;
 
+  const connectPortal =
+    connectMenuOpen && connectableSources.length > 0 ? (
+      <InboxConnectMenu
+        anchor={connectButtonRef}
+        sources={connectableSources}
+        onConnect={onOpenIntegrations}
+        onClose={() => setConnectMenuOpen(false)}
+      />
+    ) : null;
+
   return (
     <div
       role="region"
@@ -846,6 +944,7 @@ export function InboxView({
         </div>
       </div>
       {filtersPortal}
+      {connectPortal}
     </div>
   );
 }

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -194,7 +194,6 @@ import {
 
 import { SkillsPage } from "./SkillsPage";
 
-/** A General-page card a deep link can open Settings on. */
 export type SettingsAnchor = "gitlab" | "linear";
 
 const ANCHOR_IDS: Record<SettingsAnchor, string> = {
@@ -204,10 +203,7 @@ const ANCHOR_IDS: Record<SettingsAnchor, string> = {
 
 type Props = {
   section: SettingsSectionId;
-  /**
-   * Card to scroll to once the section renders. The General page is long, so
-   * "Connect GitLab" has to land on the card, not the top of the page.
-   */
+  /** Card to scroll to; the General page is too long to land at the top. */
   anchor?: SettingsAnchor | null;
   cwd: string;
   sessions: SessionSummary[];

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -194,8 +194,21 @@ import {
 
 import { SkillsPage } from "./SkillsPage";
 
+/** A General-page card a deep link can open Settings on. */
+export type SettingsAnchor = "gitlab" | "linear";
+
+const ANCHOR_IDS: Record<SettingsAnchor, string> = {
+  gitlab: "settings-gitlab",
+  linear: "settings-linear",
+};
+
 type Props = {
   section: SettingsSectionId;
+  /**
+   * Card to scroll to once the section renders. The General page is long, so
+   * "Connect GitLab" has to land on the card, not the top of the page.
+   */
+  anchor?: SettingsAnchor | null;
   cwd: string;
   sessions: SessionSummary[];
   besideRail?: boolean;
@@ -210,6 +223,7 @@ type Props = {
 
 export function SettingsView({
   section,
+  anchor = null,
   cwd,
   sessions,
   besideRail = false,
@@ -222,6 +236,12 @@ export function SettingsView({
   onOpenWhatsNew,
 }: Props) {
   const lockOverscroll = useLockOverscroll<HTMLDivElement>();
+  useEffect(() => {
+    if (!anchor) return;
+    document.getElementById(ANCHOR_IDS[anchor])?.scrollIntoView({
+      block: "start",
+    });
+  }, [anchor]);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
   const appearance = useAppearanceSettings();
@@ -539,10 +559,10 @@ function GeneralPage({
         />
       </Row>
 
-      <Heading title="GitLab" />
+      <Heading title="GitLab" id={ANCHOR_IDS.gitlab} />
       <GitlabSettings />
 
-      <Heading title="Linear" />
+      <Heading title="Linear" id={ANCHOR_IDS.linear} />
       <LinearSettings />
 
       <Heading title="About" />
@@ -1716,9 +1736,18 @@ function PageHeader({
   );
 }
 
-function Heading({ title, first = false }: { title: string; first?: boolean }) {
+function Heading({
+  title,
+  first = false,
+  id,
+}: {
+  title: string;
+  first?: boolean;
+  id?: string;
+}) {
   return (
     <h2
+      id={id}
       className={`pb-1 text-[15px] font-semibold text-content ${
         first ? "" : "pt-8"
       }`}


### PR DESCRIPTION
## What changed

Inbox source tabs now only appear for connected providers. A "+" button at the
end of the strip opens a menu to connect the rest, linking straight to their
card in Settings.

GitHub still always shows. Unlike Linear and GitLab it holds no token here — it
goes through the `gh` CLI — so hiding it needs repo detection rather than a
connect check. Left for a follow-up.

## Why

The inbox showed GitHub, Linear, and GitLab tabs at all times, so a user with no
Linear key still got a Linear tab that opened onto nothing.

Hiding unconnected sources outright would fix the clutter but lose
discoverability. On #158 you said:

> i would prefer for the inbox to stay just so that users are aware that it even
> exists. However keeping all tabs at all times is probably too much. I wonder
> what would be a in between approach...

The "+" button is that in-between: unconnected providers give up their tab but
stay one click from being set up. Happy to drop it and just hide them if you'd
rather keep this smaller.

## UI

Before:
<img width="431" height="223" alt="image" src="https://github.com/user-attachments/assets/171ae168-d927-45c7-88cf-a85a9d1f059c" />

After:
<img width="356" height="185" alt="image" src="https://github.com/user-attachments/assets/70387488-d853-4db9-9586-92279bf7ecff" />


## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes

Refs #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connection-aware inbox sources, showing available providers and connection options for unavailable ones.
  * Added a menu to connect Linear and GitLab inboxes.
  * Settings can now open directly to the relevant integration section.
  * Added automatic fallback to a valid inbox when a provider disconnects.

* **Bug Fixes**
  * Pressing Escape now closes the connection menu before closing the Inbox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->