### PR TITLE
Keep the composer's height across tab switches

### DIFF
--- a/src/chrome/Composer.tsx
+++ b/src/chrome/Composer.tsx
@@ -35,6 +35,7 @@ import {
   pickAttachments,
   revokeAttachment,
 } from "../lib/attachments";
+import { resizeComposer } from "../lib/composerResize";
 import type { ContextUsage } from "../lib/contextUsage";
 import {
   loadProjectFiles,
@@ -689,17 +690,26 @@ export function Composer({
     );
   }, [rankedFiles.length]);
 
-  const resizeTextarea = (el: HTMLTextAreaElement) => {
-    el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
-  };
-
   useEffect(() => {
     const el = ref.current;
     if (!el || !initialDraft) return;
     if (el.value !== initialDraft) el.value = initialDraft;
-    resizeTextarea(el);
+    resizeComposer(el);
   }, [initialDraft]);
+
+  // Drafts changed while hidden could not be measured. Inbox panes are portaled
+  // into place by a parent effect that runs after this one, so the first pass
+  // can still find no layout box; retry once the move has landed.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el || !enabled) return;
+    resizeComposer(el);
+    if (el.scrollHeight !== 0) return;
+    const frame = requestAnimationFrame(() => {
+      if (ref.current === el) resizeComposer(el);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [enabled]);
 
   useEffect(() => {
     onDraftChange?.(draft);
@@ -751,7 +761,7 @@ export function Composer({
     consumedQuoteId.current = result.consumedId;
     if (result.changed) {
       el.value = result.draft;
-      resizeTextarea(el);
+      resizeComposer(el);
       setDraft(result.draft);
       syncHasValue(result.draft, attachmentsRef.current);
       setSlash(null);
@@ -786,7 +796,7 @@ export function Composer({
           SESSION_FOLDER_COMMAND.invocation,
         );
         el.value = next;
-        resizeTextarea(el);
+        resizeComposer(el);
         let cursor = token.start + SESSION_FOLDER_COMMAND.invocation.length + 1;
         if (next[cursor] === " ") cursor += 1;
         el.setSelectionRange(cursor, cursor);
@@ -803,7 +813,7 @@ export function Composer({
             .replace(/^\s/, "")}`
         : replaceSlashToken(el.value, token, skill.invocation);
       el.value = next;
-      resizeTextarea(el);
+      resizeComposer(el);
       let cursor = planCommand
         ? token.start
         : token.start + skill.invocation.length + 1;
@@ -832,7 +842,7 @@ export function Composer({
         : mentionLabel(file, mentionIndexRef.current);
       const next = replaceMentionToken(el.value, token, label);
       el.value = next;
-      resizeTextarea(el);
+      resizeComposer(el);
       let cursor = token.start + label.length + 1;
       if (next[cursor] === " ") cursor += 1;
       el.setSelectionRange(cursor, cursor);
@@ -1175,7 +1185,7 @@ export function Composer({
                 const cursor = el.selectionStart ?? el.value.length;
                 if (/^\s*\/add-to-folder$/i.test(el.value)) {
                   el.value = `${el.value} `;
-                  resizeTextarea(el);
+                  resizeComposer(el);
                   setDraft(el.value);
                   syncHasValue(el.value, attachmentsRef.current);
                   el.setSelectionRange(el.value.length, el.value.length);
@@ -1224,7 +1234,7 @@ export function Composer({
                       const rest = el.value.slice(token.end).replace(/^\s/, "");
                       const next = `${el.value.slice(0, token.start)}${rest}`;
                       el.value = next;
-                      resizeTextarea(el);
+                      resizeComposer(el);
                       el.setSelectionRange(token.start, token.start);
                       setDraft(next);
                       syncHasValue(next, attachments);
@@ -1377,7 +1387,7 @@ export function Composer({
               onSelect={(e) => syncTokensFromTextarea(e.currentTarget)}
               onInput={(e) => {
                 const el = e.currentTarget;
-                resizeTextarea(el);
+                resizeComposer(el);
                 setDraft(el.value);
                 if (
                   sessionFolderSelected &&

--- a/src/lib/composerResize.test.ts
+++ b/src/lib/composerResize.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { COMPOSER_MAX_HEIGHT, resizeComposer } from "./composerResize";
+
+function field(scrollHeight: number, height = "") {
+  return { style: { height }, scrollHeight };
+}
+
+describe("resizeComposer", () => {
+  it("grows the field to fit the draft", () => {
+    const el = field(88);
+    resizeComposer(el);
+    expect(el.style.height).toBe("88px");
+  });
+
+  it("stops growing at the max height", () => {
+    const el = field(400);
+    resizeComposer(el);
+    expect(el.style.height).toBe(`${COMPOSER_MAX_HEIGHT}px`);
+  });
+
+  it("leaves the height alone when the field has no layout box", () => {
+    const el = field(0, "88px");
+    resizeComposer(el);
+    expect(el.style.height).toBe("88px");
+  });
+});

--- a/src/lib/composerResize.ts
+++ b/src/lib/composerResize.ts
@@ -1,0 +1,14 @@
+/** Matches the composer's `max-h-40`, so the field stops growing where it clips. */
+export const COMPOSER_MAX_HEIGHT = 160;
+
+type Resizable = {
+  style: { height: string };
+  scrollHeight: number;
+};
+
+/** A hidden tab stays mounted with no layout box, so it reports 0 here. */
+export function resizeComposer(el: Resizable) {
+  if (el.scrollHeight === 0) return;
+  el.style.height = "auto";
+  el.style.height = `${Math.min(el.scrollHeight, COMPOSER_MAX_HEIGHT)}px`;
+}


### PR DESCRIPTION
## What changed

The composer no longer writes a height it measured while its tab was hidden, and
re-measures when the tab becomes visible again.

## Why

Fill a prompt box to several lines, switch tabs, switch back, and it collapses
to one row with the draft stranded behind a scrollbar. Hidden tabs stay mounted
under `display: none`, so `scrollHeight` reads `0` and the resize wrote
`height: 0px`; nothing re-measured on the way back.

Opening the Inbox reproduces it. Settings does not, because `visible` ignores
`settingsOpen`, so `SessionPane` never re-renders and the bad measurement never
fires.

`GitChangesPanel` already guards the same pattern via `enabled`
(`src/chrome/GitChangesPanel.tsx:288`); this applies it to the composer.

## UI

Before: 

https://github.com/user-attachments/assets/1b8a7e99-4af7-41c9-982e-aa75ea9f47c1

After: 

https://github.com/user-attachments/assets/d556025e-cce1-4b8e-a39f-564627ca72eb

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved composer resizing as text is entered or content changes.
  * Composer height now grows to fit content while remaining within a maximum size.
  * Improved resizing when switching views or using the composer in panels where layout may load later.
  * Preserved the current composer height when its layout is temporarily unavailable.

* **Tests**
  * Added coverage for composer growth, maximum height limits, and unavailable layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->