### PR TITLE
fix: removing --active from git cmg args

### DIFF
--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -570,8 +570,10 @@ fn git_github_status_for() -> GitHubStatus {
             authenticated: false,
         };
     };
+    // Do not pass `--active`: it was added in gh 2.57 and older installs treat it as
+    // unknown, which made Settings report "Sign in required" despite a valid login.
     let mut cmd = Command::new(program);
-    cmd.args(["auth", "status", "--active", "--hostname", "github.com"])
+    cmd.args(["auth", "status", "--hostname", "github.com"])
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("GH_PROMPT_DISABLED", "1")
         .env("GH_PAGER", "cat")


### PR DESCRIPTION
## What changed

Removing --active flag from the cmd args for users to be able to login to git. 

## Why

For gh versions less than 2.5, the --active flag doesn't work. Therefore one couldn't sign in to git to check PRs (inbox). 


## UI
Before: 

https://github.com/user-attachments/assets/bb5870b1-db0f-4d78-ac2e-8a4a1fd50111

After: 


https://github.com/user-attachments/assets/e55f7954-215f-4da3-b25e-5801dbaa3f23



## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub authentication status detection for compatibility with older GitHub CLI versions.
  * Prevented valid authentication from being incorrectly reported as requiring sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->