### PR TITLE
Split chat background opacity controls for empty and active sessions

### DIFF
--- a/src/chrome/ProjectBackgroundDialog.tsx
+++ b/src/chrome/ProjectBackgroundDialog.tsx
@@ -5,8 +5,9 @@ import {
   CHAT_BACKGROUND_OPACITY_MAX,
   CHAT_BACKGROUND_OPACITY_MIN,
   chatBackgroundSrc,
-  loadChatBackgroundOpacity,
+  loadChatBackgroundEmptyOpacity,
   loadChatBackgroundPath,
+  loadChatBackgroundSessionOpacity,
   loadChatBackgroundScope,
   type ChatBackgroundScope,
 } from "../lib/appearance";
@@ -17,9 +18,9 @@ import {
 } from "../lib/chatBackground";
 import {
   clearProjectChatBackgroundSetting,
-  loadProjectChatBackground,
+  loadProjectChatBackgroundSettings,
   projectChatBackgroundRevision,
-  saveProjectChatBackground,
+  saveProjectChatBackgroundSettings,
 } from "../lib/projectChatBackground";
 
 type Props = {
@@ -29,10 +30,13 @@ type Props = {
 };
 
 export function ProjectBackgroundDialog({ project, name, onClose }: Props) {
-  const initial = loadProjectChatBackground(project);
+  const initial = loadProjectChatBackgroundSettings(project);
   const [path, setPath] = useState(initial?.path ?? null);
-  const [opacity, setOpacity] = useState(
-    initial?.opacity ?? loadChatBackgroundOpacity(),
+  const [emptyOpacity, setEmptyOpacity] = useState(
+    initial?.emptyOpacity ?? loadChatBackgroundEmptyOpacity(),
+  );
+  const [sessionOpacity, setSessionOpacity] = useState(
+    initial?.sessionOpacity ?? loadChatBackgroundSessionOpacity(),
   );
   const [scope, setScope] = useState<ChatBackgroundScope>(
     initial?.scope ?? loadChatBackgroundScope(),
@@ -47,12 +51,14 @@ export function ProjectBackgroundDialog({ project, name, onClose }: Props) {
 
   const save = (
     nextPath: string,
-    nextOpacity: number,
+    nextEmptyOpacity: number,
+    nextSessionOpacity: number,
     nextScope: ChatBackgroundScope,
   ) => {
-    saveProjectChatBackground(project, {
+    saveProjectChatBackgroundSettings(project, {
       path: nextPath,
-      opacity: nextOpacity,
+      emptyOpacity: nextEmptyOpacity,
+      sessionOpacity: nextSessionOpacity,
       scope: nextScope,
     });
     setRevision(projectChatBackgroundRevision());
@@ -64,7 +70,7 @@ export function ProjectBackgroundDialog({ project, name, onClose }: Props) {
     try {
       const nextPath = await pickAndSaveProjectChatBackground(project);
       if (!nextPath) return;
-      save(nextPath, opacity, scope);
+      save(nextPath, emptyOpacity, sessionOpacity, scope);
       setPath(nextPath);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
@@ -80,7 +86,8 @@ export function ProjectBackgroundDialog({ project, name, onClose }: Props) {
       await clearProjectChatBackground(project);
       clearProjectChatBackgroundSetting(project);
       setPath(null);
-      setOpacity(loadChatBackgroundOpacity());
+      setEmptyOpacity(loadChatBackgroundEmptyOpacity());
+      setSessionOpacity(loadChatBackgroundSessionOpacity());
       setScope(loadChatBackgroundScope());
       setRevision(projectChatBackgroundRevision());
     } catch (cause) {
@@ -90,18 +97,21 @@ export function ProjectBackgroundDialog({ project, name, onClose }: Props) {
     }
   };
 
-  const updateOpacity = (percent: number) => {
+  const updateOpacity = (kind: "empty" | "session", percent: number) => {
     const next = Math.min(
       CHAT_BACKGROUND_OPACITY_MAX,
       Math.max(CHAT_BACKGROUND_OPACITY_MIN, percent / 100),
     );
-    setOpacity(next);
-    if (path) save(path, next, scope);
+    const nextEmptyOpacity = kind === "empty" ? next : emptyOpacity;
+    const nextSessionOpacity = kind === "session" ? next : sessionOpacity;
+    if (kind === "empty") setEmptyOpacity(next);
+    else setSessionOpacity(next);
+    if (path) save(path, nextEmptyOpacity, nextSessionOpacity, scope);
   };
 
   const updateScope = (next: ChatBackgroundScope) => {
     setScope(next);
-    if (path) save(path, opacity, next);
+    if (path) save(path, emptyOpacity, sessionOpacity, next);
   };
 
   return (
@@ -120,6 +130,7 @@ export function ProjectBackgroundDialog({ project, name, onClose }: Props) {
                 alt=""
                 draggable={false}
                 className="h-56 w-full object-cover"
+                style={{ opacity: emptyOpacity }}
               />
             ) : (
               <div className="grid h-56 place-items-center text-[12px] text-content/40">
@@ -176,19 +187,40 @@ export function ProjectBackgroundDialog({ project, name, onClose }: Props) {
           </div>
         </ProjectBackgroundRow>
 
-        <ProjectBackgroundRow label="Visibility">
+        <ProjectBackgroundRow label="Empty chat visibility">
           <div className="flex w-56 items-center gap-3">
             <input
               type="range"
               min={Math.round(CHAT_BACKGROUND_OPACITY_MIN * 100)}
               max={Math.round(CHAT_BACKGROUND_OPACITY_MAX * 100)}
-              value={Math.round(opacity * 100)}
-              aria-label="Project background visibility"
+              value={Math.round(emptyOpacity * 100)}
+              aria-label="Project background visibility in empty chats"
               className="sidebar-opacity-slider min-w-0 flex-1"
-              onChange={(event) => updateOpacity(Number(event.target.value))}
+              onChange={(event) =>
+                updateOpacity("empty", Number(event.target.value))
+              }
             />
             <span className="w-10 shrink-0 text-right text-[12px] tabular-nums text-content">
-              {Math.round(opacity * 100)}%
+              {Math.round(emptyOpacity * 100)}%
+            </span>
+          </div>
+        </ProjectBackgroundRow>
+
+        <ProjectBackgroundRow label="Session visibility">
+          <div className="flex w-56 items-center gap-3">
+            <input
+              type="range"
+              min={Math.round(CHAT_BACKGROUND_OPACITY_MIN * 100)}
+              max={Math.round(CHAT_BACKGROUND_OPACITY_MAX * 100)}
+              value={Math.round(sessionOpacity * 100)}
+              aria-label="Project background visibility in sessions"
+              className="sidebar-opacity-slider min-w-0 flex-1"
+              onChange={(event) =>
+                updateOpacity("session", Number(event.target.value))
+              }
+            />
+            <span className="w-10 shrink-0 text-right text-[12px] tabular-nums text-content">
+              {Math.round(sessionOpacity * 100)}%
             </span>
           </div>
         </ProjectBackgroundRow>

--- a/src/index.css
+++ b/src/index.css
@@ -29,7 +29,8 @@
   --theme-hue: 240;
   --theme-saturation: 0%;
   --sidebar-opacity: 0.85;
-  --chat-background-opacity: 0.24;
+  --chat-background-empty-opacity: 0.24;
+  --chat-background-session-opacity: 0.24;
   --background-lightness: 9%;
   --content-lightness: 92%;
   --link-color: #7dd3fc;
@@ -143,7 +144,13 @@ html.has-native-glass:not(.theme-light) .sidebar-glass {
 
 html.has-chat-background .chat-pane-background::before,
 .chat-pane-background[data-project-chat-background="true"]::before {
-  opacity: var(--chat-background-opacity);
+  opacity: var(--chat-background-empty-opacity);
+}
+
+html.has-chat-background
+  .chat-pane-background[data-session-empty="false"]::before,
+.chat-pane-background[data-project-chat-background="true"][data-session-empty="false"]::before {
+  opacity: var(--chat-background-session-opacity);
 }
 
 html.chat-background-empty-only

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -15,6 +15,9 @@ const TRANSCRIPT_LAYOUT_KEY = "monocode.transcriptLayout";
 const TRANSCRIPT_ANCHOR_KEY = "monocode.transcriptAnchor";
 const CHAT_BACKGROUND_PATH_KEY = "monocode.chatBackgroundPath";
 const CHAT_BACKGROUND_OPACITY_KEY = "monocode.chatBackgroundOpacity";
+const CHAT_BACKGROUND_EMPTY_OPACITY_KEY = "monocode.chatBackgroundEmptyOpacity";
+const CHAT_BACKGROUND_SESSION_OPACITY_KEY =
+  "monocode.chatBackgroundSessionOpacity";
 const CHAT_BACKGROUND_SCOPE_KEY = "monocode.chatBackgroundScope";
 const CHANGES_VIEW_KEY = "monocode.changesView";
 let chatBackgroundRevision = Date.now();
@@ -80,6 +83,10 @@ export const BODY_GLASS_DEFAULT = true;
 export const CHAT_BACKGROUND_OPACITY_MIN = 0.05;
 export const CHAT_BACKGROUND_OPACITY_MAX = 0.65;
 export const CHAT_BACKGROUND_OPACITY_DEFAULT = 0.24;
+export const CHAT_BACKGROUND_EMPTY_OPACITY_DEFAULT =
+  CHAT_BACKGROUND_OPACITY_DEFAULT;
+export const CHAT_BACKGROUND_SESSION_OPACITY_DEFAULT =
+  CHAT_BACKGROUND_OPACITY_DEFAULT;
 export const CHAT_BACKGROUND_SCOPE_DEFAULT: ChatBackgroundScope = "all";
 
 function clamp(value: number, min: number, max: number) {
@@ -153,9 +160,7 @@ export function loadThemeSaturation(): number {
 export function saveThemeSaturation(value: number) {
   writeNumber(
     THEME_SATURATION_KEY,
-    Math.round(
-      clamp(value, THEME_SATURATION_MIN, THEME_SATURATION_MAX),
-    ),
+    Math.round(clamp(value, THEME_SATURATION_MIN, THEME_SATURATION_MAX)),
   );
 }
 
@@ -174,7 +179,10 @@ export function applyThemeTint(hue: number, saturation: number) {
 
 export function initAppearance() {
   document.documentElement.classList.toggle("is-mac", IS_MAC);
-  document.documentElement.classList.toggle("has-native-glass", HAS_NATIVE_GLASS);
+  document.documentElement.classList.toggle(
+    "has-native-glass",
+    HAS_NATIVE_GLASS,
+  );
   applyThemeTint(loadThemeHue(), loadThemeSaturation());
   applyThemePreference(loadThemePreference());
   watchSystemColorScheme();
@@ -182,7 +190,8 @@ export function initAppearance() {
   applySidebarBlur(loadSidebarBlur());
   applyBodyGlass(loadBodyGlass());
   applyChatBackground(loadChatBackgroundPath());
-  applyChatBackgroundOpacity(loadChatBackgroundOpacity());
+  applyChatBackgroundEmptyOpacity(loadChatBackgroundEmptyOpacity());
+  applyChatBackgroundSessionOpacity(loadChatBackgroundSessionOpacity());
   applyChatBackgroundScope(loadChatBackgroundScope());
   void applyUiScale(loadUiScale());
 }
@@ -294,9 +303,7 @@ export function saveSidebarBlur(value: number) {
 }
 
 export function applySidebarBlur(value: number) {
-  const next = Math.round(
-    clamp(value, SIDEBAR_BLUR_MIN, SIDEBAR_BLUR_MAX),
-  );
+  const next = Math.round(clamp(value, SIDEBAR_BLUR_MIN, SIDEBAR_BLUR_MAX));
   void invoke("set_window_background_blur", { radius: next });
   return next;
 }
@@ -364,31 +371,82 @@ export function chatBackgroundSrc(path: string | null): string | null {
 }
 
 export function loadChatBackgroundOpacity(): number {
-  return clamp(
-    readNumber(CHAT_BACKGROUND_OPACITY_KEY) ?? CHAT_BACKGROUND_OPACITY_DEFAULT,
-    CHAT_BACKGROUND_OPACITY_MIN,
-    CHAT_BACKGROUND_OPACITY_MAX,
-  );
+  return loadChatBackgroundEmptyOpacity();
 }
 
 export function saveChatBackgroundOpacity(value: number) {
-  writeNumber(
-    CHAT_BACKGROUND_OPACITY_KEY,
-    clamp(value, CHAT_BACKGROUND_OPACITY_MIN, CHAT_BACKGROUND_OPACITY_MAX),
-  );
-}
-
-export function applyChatBackgroundOpacity(value: number) {
   const next = clamp(
     value,
     CHAT_BACKGROUND_OPACITY_MIN,
     CHAT_BACKGROUND_OPACITY_MAX,
   );
-  document.documentElement.style.setProperty(
-    "--chat-background-opacity",
-    String(next),
+  saveChatBackgroundEmptyOpacity(next);
+  saveChatBackgroundSessionOpacity(next);
+  writeNumber(CHAT_BACKGROUND_OPACITY_KEY, next);
+}
+
+export function applyChatBackgroundOpacity(value: number) {
+  const next = applyChatBackgroundEmptyOpacity(value);
+  applyChatBackgroundSessionOpacity(next);
+  return next;
+}
+
+function loadChatBackgroundOpacityValue(key: string): number {
+  const next = clamp(
+    readNumber(key) ??
+      readNumber(CHAT_BACKGROUND_OPACITY_KEY) ??
+      CHAT_BACKGROUND_OPACITY_DEFAULT,
+    CHAT_BACKGROUND_OPACITY_MIN,
+    CHAT_BACKGROUND_OPACITY_MAX,
   );
   return next;
+}
+
+function saveChatBackgroundOpacityValue(key: string, value: number) {
+  writeNumber(
+    key,
+    clamp(value, CHAT_BACKGROUND_OPACITY_MIN, CHAT_BACKGROUND_OPACITY_MAX),
+  );
+}
+
+function applyChatBackgroundOpacityValue(variable: string, value: number) {
+  const next = clamp(
+    value,
+    CHAT_BACKGROUND_OPACITY_MIN,
+    CHAT_BACKGROUND_OPACITY_MAX,
+  );
+  document.documentElement.style.setProperty(variable, String(next));
+  return next;
+}
+
+export function loadChatBackgroundEmptyOpacity(): number {
+  return loadChatBackgroundOpacityValue(CHAT_BACKGROUND_EMPTY_OPACITY_KEY);
+}
+
+export function saveChatBackgroundEmptyOpacity(value: number) {
+  saveChatBackgroundOpacityValue(CHAT_BACKGROUND_EMPTY_OPACITY_KEY, value);
+}
+
+export function applyChatBackgroundEmptyOpacity(value: number) {
+  return applyChatBackgroundOpacityValue(
+    "--chat-background-empty-opacity",
+    value,
+  );
+}
+
+export function loadChatBackgroundSessionOpacity(): number {
+  return loadChatBackgroundOpacityValue(CHAT_BACKGROUND_SESSION_OPACITY_KEY);
+}
+
+export function saveChatBackgroundSessionOpacity(value: number) {
+  saveChatBackgroundOpacityValue(CHAT_BACKGROUND_SESSION_OPACITY_KEY, value);
+}
+
+export function applyChatBackgroundSessionOpacity(value: number) {
+  return applyChatBackgroundOpacityValue(
+    "--chat-background-session-opacity",
+    value,
+  );
 }
 
 function isChatBackgroundScope(value: unknown): value is ChatBackgroundScope {
@@ -476,9 +534,7 @@ export function loadProjectRailWidth(): number {
 export function saveProjectRailWidth(value: number) {
   writeNumber(
     PROJECT_RAIL_WIDTH_KEY,
-    Math.round(
-      clamp(value, PROJECT_RAIL_WIDTH_MIN, PROJECT_RAIL_WIDTH_MAX),
-    ),
+    Math.round(clamp(value, PROJECT_RAIL_WIDTH_MIN, PROJECT_RAIL_WIDTH_MAX)),
   );
 }
 

--- a/src/lib/projectChatBackground.ts
+++ b/src/lib/projectChatBackground.ts
@@ -2,7 +2,8 @@ import {
   CHAT_BACKGROUND_OPACITY_MAX,
   CHAT_BACKGROUND_OPACITY_MIN,
   CHAT_BACKGROUND_SCOPE_DEFAULT,
-  loadChatBackgroundOpacity,
+  loadChatBackgroundEmptyOpacity,
+  loadChatBackgroundSessionOpacity,
   loadChatBackgroundScope,
   type ChatBackgroundScope,
 } from "./appearance";
@@ -18,7 +19,17 @@ export type ProjectChatBackground = {
   scope: ChatBackgroundScope;
 };
 
-type StoredProjectChatBackground = Partial<ProjectChatBackground>;
+export type ProjectChatBackgroundSettings = {
+  path: string;
+  emptyOpacity: number;
+  sessionOpacity: number;
+  scope: ChatBackgroundScope;
+};
+
+type StoredProjectChatBackground = Partial<ProjectChatBackground> & {
+  emptyOpacity?: number;
+  sessionOpacity?: number;
+};
 
 let revision = Date.now();
 
@@ -54,20 +65,70 @@ function validScope(value: unknown): value is ChatBackgroundScope {
   return value === "empty" || value === "all";
 }
 
-export function loadProjectChatBackground(
+function storedOpacity(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? clampOpacity(value)
+    : fallback;
+}
+
+export function loadProjectChatBackgroundSettings(
   project: string,
-): ProjectChatBackground | null {
+): ProjectChatBackgroundSettings | null {
   const stored = read()[project];
   const path = typeof stored?.path === "string" ? stored.path.trim() : "";
   if (!path) return null;
-  const opacity =
-    typeof stored.opacity === "number" && Number.isFinite(stored.opacity)
-      ? clampOpacity(stored.opacity)
-      : loadChatBackgroundOpacity();
+  const legacyOpacity = storedOpacity(
+    stored.opacity,
+    loadChatBackgroundEmptyOpacity(),
+  );
+  const hasStoredOpacity =
+    typeof stored.opacity === "number" && Number.isFinite(stored.opacity);
+  const hasStoredEmptyOpacity =
+    typeof stored.emptyOpacity === "number" &&
+    Number.isFinite(stored.emptyOpacity);
   return {
     path,
-    opacity,
+    emptyOpacity: storedOpacity(stored.emptyOpacity, legacyOpacity),
+    sessionOpacity: storedOpacity(
+      stored.sessionOpacity,
+      hasStoredEmptyOpacity
+        ? storedOpacity(stored.emptyOpacity, legacyOpacity)
+        : hasStoredOpacity
+          ? legacyOpacity
+          : loadChatBackgroundSessionOpacity(),
+    ),
     scope: validScope(stored.scope) ? stored.scope : loadChatBackgroundScope(),
+  };
+}
+
+export function saveProjectChatBackgroundSettings(
+  project: string,
+  value: ProjectChatBackgroundSettings,
+) {
+  const path = value.path.trim();
+  if (!project || !path) return;
+  const next = read();
+  next[project] = {
+    path,
+    emptyOpacity: clampOpacity(value.emptyOpacity),
+    sessionOpacity: clampOpacity(value.sessionOpacity),
+    scope: validScope(value.scope)
+      ? value.scope
+      : CHAT_BACKGROUND_SCOPE_DEFAULT,
+  };
+  write(next);
+  notifyProjectChatBackgroundChanged();
+}
+
+export function loadProjectChatBackground(
+  project: string,
+): ProjectChatBackground | null {
+  const settings = loadProjectChatBackgroundSettings(project);
+  if (!settings) return null;
+  return {
+    path: settings.path,
+    opacity: settings.emptyOpacity,
+    scope: settings.scope,
   };
 }
 

--- a/src/surfaces/SessionPane.tsx
+++ b/src/surfaces/SessionPane.tsx
@@ -46,7 +46,7 @@ import { isAstraModel } from "../lib/astraWelcome";
 import { AstraWelcome } from "./AstraWelcome";
 import { projectKey } from "../lib/paths";
 import {
-  loadProjectChatBackground,
+  loadProjectChatBackgroundSettings,
   projectChatBackgroundRevision,
   subscribeProjectChatBackground,
 } from "../lib/projectChatBackground";
@@ -181,6 +181,7 @@ export const SessionPane = memo(function SessionPane({
   onPaneDragStart,
 }: Props) {
   const title = sessionDisplayTitle(session.title, session.harness);
+  const isEmpty = session.blocks.length === 0;
   const backgroundRevision = useSyncExternalStore(
     subscribeProjectChatBackground,
     projectChatBackgroundRevision,
@@ -191,13 +192,20 @@ export const SessionPane = memo(function SessionPane({
     loadChatBackgroundPath,
     loadChatBackgroundPath,
   );
-  const projectBackground = loadProjectChatBackground(projectKey(session.cwd));
+  const projectBackground = loadProjectChatBackgroundSettings(
+    projectKey(session.cwd),
+  );
   const projectBackgroundStyle = projectBackground
     ? ({
         "--chat-background-image": `url(${JSON.stringify(
           projectChatBackgroundSrc(projectBackground.path, backgroundRevision),
         )})`,
-        "--chat-background-opacity": String(projectBackground.opacity),
+        "--chat-background-empty-opacity": String(
+          projectBackground.emptyOpacity,
+        ),
+        "--chat-background-session-opacity": String(
+          projectBackground.sessionOpacity,
+        ),
       } as CSSProperties)
     : undefined;
   const approve = useCallback(
@@ -294,7 +302,6 @@ export const SessionPane = memo(function SessionPane({
     return () => window.removeEventListener(ADD_TO_CHAT_EVENT, onAdd);
   }, [addSelectionToChat, addToChatTarget]);
   const workCwd = sessionWorkCwd(session);
-  const isEmpty = session.blocks.length === 0;
   const showDeckProjectPicker = isEmpty && !looksLikeProject(session.cwd);
   const dockComposer = !isEmpty || inSplit || !!session.inboxAsk;
   const draftRef = useRef<string | undefined>(undefined);

--- a/src/surfaces/SettingsView.tsx
+++ b/src/surfaces/SettingsView.tsx
@@ -29,7 +29,8 @@ import { useLockOverscroll } from "../hooks/useLockOverscroll";
 import { useColorScheme } from "../hooks/useColorScheme";
 import {
   applyChatBackground,
-  applyChatBackgroundOpacity,
+  applyChatBackgroundEmptyOpacity,
+  applyChatBackgroundSessionOpacity,
   applyChatBackgroundScope,
   applyBodyGlass,
   applyThemePreference,
@@ -37,15 +38,17 @@ import {
   applySidebarOpacity,
   applyThemeTint,
   BODY_GLASS_DEFAULT,
-  CHAT_BACKGROUND_OPACITY_DEFAULT,
+  CHAT_BACKGROUND_EMPTY_OPACITY_DEFAULT,
   CHAT_BACKGROUND_OPACITY_MAX,
   CHAT_BACKGROUND_OPACITY_MIN,
+  CHAT_BACKGROUND_SESSION_OPACITY_DEFAULT,
   CHAT_BACKGROUND_SCOPE_DEFAULT,
   THEME_PREFERENCE_DEFAULT,
   chatBackgroundSrc,
   loadBodyGlass,
-  loadChatBackgroundOpacity,
+  loadChatBackgroundEmptyOpacity,
   loadChatBackgroundPath,
+  loadChatBackgroundSessionOpacity,
   loadChatBackgroundScope,
   loadThemePreference,
   loadSidebarBlur,
@@ -55,8 +58,9 @@ import {
   loadTranscriptLayout,
   loadTranscriptAnchor,
   saveBodyGlass,
-  saveChatBackgroundOpacity,
+  saveChatBackgroundEmptyOpacity,
   saveChatBackgroundPath,
+  saveChatBackgroundSessionOpacity,
   saveChatBackgroundScope,
   saveThemePreference,
   saveSidebarBlur,
@@ -1040,9 +1044,11 @@ function useAppearanceSettings() {
   const [chatBackgroundPath, setChatBackgroundPath] = useState(
     loadChatBackgroundPath,
   );
-  const [chatBackgroundOpacity, setChatBackgroundOpacity] = useState(
-    loadChatBackgroundOpacity,
+  const [chatBackgroundEmptyOpacity, setChatBackgroundEmptyOpacity] = useState(
+    loadChatBackgroundEmptyOpacity,
   );
+  const [chatBackgroundSessionOpacity, setChatBackgroundSessionOpacity] =
+    useState(loadChatBackgroundSessionOpacity);
   const [chatBackgroundScope, setChatBackgroundScope] =
     useState<ChatBackgroundScope>(loadChatBackgroundScope);
   const [chatBackgroundBusy, setChatBackgroundBusy] = useState(false);
@@ -1120,10 +1126,16 @@ function useAppearanceSettings() {
     }
   }, []);
 
-  const onChatBackgroundOpacity = useCallback((percent: number) => {
-    const next = applyChatBackgroundOpacity(percent / 100);
-    saveChatBackgroundOpacity(next);
-    setChatBackgroundOpacity(next);
+  const onChatBackgroundEmptyOpacity = useCallback((percent: number) => {
+    const next = applyChatBackgroundEmptyOpacity(percent / 100);
+    saveChatBackgroundEmptyOpacity(next);
+    setChatBackgroundEmptyOpacity(next);
+  }, []);
+
+  const onChatBackgroundSessionOpacity = useCallback((percent: number) => {
+    const next = applyChatBackgroundSessionOpacity(percent / 100);
+    saveChatBackgroundSessionOpacity(next);
+    setChatBackgroundSessionOpacity(next);
   }, []);
 
   const onChatBackgroundScope = useCallback((next: ChatBackgroundScope) => {
@@ -1144,7 +1156,12 @@ function useAppearanceSettings() {
     onBlur(SIDEBAR_BLUR_DEFAULT);
     onTint(THEME_HUE_DEFAULT, THEME_SATURATION_DEFAULT);
     onBodyGlass(BODY_GLASS_DEFAULT);
-    onChatBackgroundOpacity(Math.round(CHAT_BACKGROUND_OPACITY_DEFAULT * 100));
+    onChatBackgroundEmptyOpacity(
+      Math.round(CHAT_BACKGROUND_EMPTY_OPACITY_DEFAULT * 100),
+    );
+    onChatBackgroundSessionOpacity(
+      Math.round(CHAT_BACKGROUND_SESSION_OPACITY_DEFAULT * 100),
+    );
     onChatBackgroundScope(CHAT_BACKGROUND_SCOPE_DEFAULT);
     if (chatBackgroundPath) void onClearChatBackground();
     onUiScale(Math.round(UI_SCALE_DEFAULT * 100));
@@ -1152,7 +1169,8 @@ function useAppearanceSettings() {
     chatBackgroundPath,
     onBlur,
     onBodyGlass,
-    onChatBackgroundOpacity,
+    onChatBackgroundEmptyOpacity,
+    onChatBackgroundSessionOpacity,
     onChatBackgroundScope,
     onClearChatBackground,
     onThemePreference,
@@ -1169,7 +1187,8 @@ function useAppearanceSettings() {
     themeSaturation,
     bodyGlass,
     chatBackgroundPath,
-    chatBackgroundOpacity,
+    chatBackgroundEmptyOpacity,
+    chatBackgroundSessionOpacity,
     chatBackgroundScope,
     chatBackgroundBusy,
     chatBackgroundError,
@@ -1181,7 +1200,8 @@ function useAppearanceSettings() {
     onBodyGlass,
     onChooseChatBackground,
     onClearChatBackground,
-    onChatBackgroundOpacity,
+    onChatBackgroundEmptyOpacity,
+    onChatBackgroundSessionOpacity,
     onChatBackgroundScope,
     onUiScale,
     restoreDefaults,
@@ -1311,7 +1331,12 @@ function ChatBackgroundCard({
 }) {
   const src = chatBackgroundSrc(appearance.chatBackgroundPath);
   const hasImage = Boolean(appearance.chatBackgroundPath && src);
-  const visibility = Math.round(appearance.chatBackgroundOpacity * 100);
+  const emptyVisibility = Math.round(
+    appearance.chatBackgroundEmptyOpacity * 100,
+  );
+  const sessionVisibility = Math.round(
+    appearance.chatBackgroundSessionOpacity * 100,
+  );
   const busy = appearance.chatBackgroundBusy;
 
   return (
@@ -1355,10 +1380,10 @@ function ChatBackgroundCard({
               alt=""
               draggable={false}
               className="size-full object-cover"
-              style={{ opacity: appearance.chatBackgroundOpacity }}
+              style={{ opacity: appearance.chatBackgroundEmptyOpacity }}
             />
             <span className="pointer-events-none absolute bottom-2 left-2 text-[11px] text-content/40">
-              Preview at {visibility}%
+              Empty chat preview at {emptyVisibility}%
             </span>
           </div>
         ) : (
@@ -1397,18 +1422,38 @@ function ChatBackgroundCard({
             </div>
             <div className="flex items-center justify-between gap-4 border-t border-content/5 px-3 py-2.5">
               <div className="min-w-0">
-                <div className="text-[12px] text-content">Visibility</div>
+                <div className="text-[12px] text-content">
+                  Empty chat visibility
+                </div>
                 <p className="text-[11px] text-content/40">
-                  Keep it subtle so long conversations stay readable.
+                  Background strength before a chat has messages.
                 </p>
               </div>
               <Slider
-                label="Background visibility"
-                value={visibility}
-                display={`${visibility}%`}
+                label="Empty chat background visibility"
+                value={emptyVisibility}
+                display={`${emptyVisibility}%`}
                 min={Math.round(CHAT_BACKGROUND_OPACITY_MIN * 100)}
                 max={Math.round(CHAT_BACKGROUND_OPACITY_MAX * 100)}
-                onChange={appearance.onChatBackgroundOpacity}
+                onChange={appearance.onChatBackgroundEmptyOpacity}
+              />
+            </div>
+            <div className="flex items-center justify-between gap-4 border-t border-content/5 px-3 py-2.5">
+              <div className="min-w-0">
+                <div className="text-[12px] text-content">
+                  Session visibility
+                </div>
+                <p className="text-[11px] text-content/40">
+                  Background strength once the conversation has messages.
+                </p>
+              </div>
+              <Slider
+                label="Session background visibility"
+                value={sessionVisibility}
+                display={`${sessionVisibility}%`}
+                min={Math.round(CHAT_BACKGROUND_OPACITY_MIN * 100)}
+                max={Math.round(CHAT_BACKGROUND_OPACITY_MAX * 100)}
+                onChange={appearance.onChatBackgroundSessionOpacity}
               />
             </div>
           </div>
@@ -2150,14 +2195,9 @@ function Select({
                     : "text-content hover:bg-content/5"
                 }`}
               >
-                <span className="min-w-0 flex-1 truncate">
-                  {option.label}
-                </span>
+                <span className="min-w-0 flex-1 truncate">{option.label}</span>
                 {isSelected ? (
-                  <Check
-                    className="size-3.5 shrink-0"
-                    strokeWidth={2.25}
-                  />
+                  <Check className="size-3.5 shrink-0" strokeWidth={2.25} />
                 ) : null}
               </button>
             );


### PR DESCRIPTION
## What changed

Adds separate background visibility sliders for empty chats and active sessions in both global Appearance settings and project-specific background settings. Existing opacity preferences are preserved through backward-compatible fallbacks.

Fixes Issue #190.

## Why

A single opacity setting made the background equally prominent in empty and filled chats. Separate controls let users keep empty chats expressive while reducing the background behind active conversations for readability.

## UI

<img width="1010" height="390" alt="Screenshot 2026-09-12 at 10 53 07 PM" src="https://github.com/user-attachments/assets/2241d577-dd6c-41ca-a107-19468bd15dce" />

## Checklist

- [x] npm run check:web
- [x] 167 test files passed; 1,859 tests passed
- [x] TypeScript check passed
- [x] npm run build
- [x] git diff --check
- [x] UI detector run
- [x] No tests added or modified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate visibility controls for chat backgrounds in empty chats and active sessions.
  * Chat background opacity settings now persist independently for empty and active sessions.
  * Project-specific backgrounds support distinct opacity values for each state.
  * Updated previews and background rendering to reflect the selected visibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->