### PR TITLE
Gate Claude Sonnet 5 behind minimum CLI version

### DIFF
--- a/src/lib/harness/claudeCatalog.ts
+++ b/src/lib/harness/claudeCatalog.ts
@@ -24,6 +24,7 @@ import {
   MINIMUM_CLAUDE_OPUS_4_7_VERSION,
   MINIMUM_CLAUDE_OPUS_4_8_VERSION,
   MINIMUM_CLAUDE_OPUS_5_VERSION,
+  MINIMUM_CLAUDE_SONNET_5_VERSION,
   parseClaudeVersion,
   parseControlResponse,
   parseJsonLine,
@@ -449,6 +450,11 @@ export function modelsForClaudeVersion(
     if (slug === "claude-opus-5") {
       return version
         ? compareSemver(version, MINIMUM_CLAUDE_OPUS_5_VERSION) >= 0
+        : false;
+    }
+    if (slug === "claude-sonnet-5") {
+      return version
+        ? compareSemver(version, MINIMUM_CLAUDE_SONNET_5_VERSION) >= 0
         : false;
     }
     if (slug === "claude-fable-5") {

--- a/src/lib/harness/claudeProtocol.test.ts
+++ b/src/lib/harness/claudeProtocol.test.ts
@@ -264,8 +264,11 @@ describe("modelsForClaudeVersion", () => {
     expect(next).toContain("claude-sonnet-5");
   });
 
-  it("hides Sonnet 5 until 2.1.219, and rejects a missing version", () => {
-    const atMinimum = modelsForClaudeVersion("2.1.219").map((model) => model.nativeId);
+  it("hides Sonnet 5 until 2.1.197, and rejects a missing version", () => {
+    const beforeMinimum = modelsForClaudeVersion("2.1.196").map((model) => model.nativeId);
+    expect(beforeMinimum).not.toContain("claude-sonnet-5");
+
+    const atMinimum = modelsForClaudeVersion("2.1.197").map((model) => model.nativeId);
     expect(atMinimum).toContain("claude-sonnet-5");
 
     const missing = modelsForClaudeVersion(null).map((model) => model.nativeId);

--- a/src/lib/harness/claudeProtocol.test.ts
+++ b/src/lib/harness/claudeProtocol.test.ts
@@ -263,6 +263,14 @@ describe("modelsForClaudeVersion", () => {
     expect(next).toContain("claude-fable-5");
     expect(next).toContain("claude-sonnet-5");
   });
+
+  it("hides Sonnet 5 until 2.1.219, and rejects a missing version", () => {
+    const atMinimum = modelsForClaudeVersion("2.1.219").map((model) => model.nativeId);
+    expect(atMinimum).toContain("claude-sonnet-5");
+
+    const missing = modelsForClaudeVersion(null).map((model) => model.nativeId);
+    expect(missing).not.toContain("claude-sonnet-5");
+  });
 });
 
 describe("list_models catalog", () => {

--- a/src/lib/harness/claudeProtocol.ts
+++ b/src/lib/harness/claudeProtocol.ts
@@ -22,7 +22,7 @@ import type { ApprovalDecision, HarnessEvent } from "./types";
 
 /** Claude Code versions that first ship Opus 5 / Sonnet 5 / Fable 5 / Opus 4.8 / 4.7. */
 export const MINIMUM_CLAUDE_OPUS_5_VERSION = "2.1.219";
-export const MINIMUM_CLAUDE_SONNET_5_VERSION = "2.1.219";
+export const MINIMUM_CLAUDE_SONNET_5_VERSION = "2.1.197";
 export const MINIMUM_CLAUDE_FABLE_5_VERSION = "2.1.169";
 export const MINIMUM_CLAUDE_OPUS_4_8_VERSION = "2.1.154";
 export const MINIMUM_CLAUDE_OPUS_4_7_VERSION = "2.1.111";

--- a/src/lib/harness/claudeProtocol.ts
+++ b/src/lib/harness/claudeProtocol.ts
@@ -20,8 +20,9 @@ import {
 import { streamTextDelta } from "./streamText";
 import type { ApprovalDecision, HarnessEvent } from "./types";
 
-/** Claude Code versions that first ship Opus 5 / Fable 5 / Opus 4.8 / 4.7. */
+/** Claude Code versions that first ship Opus 5 / Sonnet 5 / Fable 5 / Opus 4.8 / 4.7. */
 export const MINIMUM_CLAUDE_OPUS_5_VERSION = "2.1.219";
+export const MINIMUM_CLAUDE_SONNET_5_VERSION = "2.1.219";
 export const MINIMUM_CLAUDE_FABLE_5_VERSION = "2.1.169";
 export const MINIMUM_CLAUDE_OPUS_4_8_VERSION = "2.1.154";
 export const MINIMUM_CLAUDE_OPUS_4_7_VERSION = "2.1.111";


### PR DESCRIPTION
## Summary
- Opus 5, Fable 5, Opus 4.8 and 4.7 are all excluded from the Claude model picker on CLI versions that predate them, but Sonnet 5 had no such gate in `modelsForClaudeVersion`.
- On older `claude` CLI installs, Sonnet 5 still showed in the picker and got passed via `--model`, which the CLI rejected as unrecognized ("There's an issue with the selected model...").
- Added `MINIMUM_CLAUDE_SONNET_5_VERSION` alongside the existing Opus 5 gate and filtered it the same way.

## Test plan
- [x] `npx vitest run src/lib/harness/registry.test.ts src/lib/harness/claudeProtocol.test.ts src/lib/harness/claudeLive.test.ts` — 55 passed
- [x] Reproduced locally: Sonnet 5 failed to start a session while Haiku 4.5 worked, matching the missing-gate hypothesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Claude Sonnet 5 when using Claude version 2.1.197 or later.
  - Sonnet 5 now appears in the available model list when the installed Claude version meets the required minimum.

- **Bug Fixes**
  - Prevented Claude Sonnet 5 from appearing on unsupported Claude versions, including versions earlier than 2.1.197 or when the Claude version cannot be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->