### PR TITLE
Fix GitLab inbox console popups on Windows

### DIFF
--- a/src-tauri/src/gitlab.rs
+++ b/src-tauri/src/gitlab.rs
@@ -861,7 +861,9 @@ fn encode_path_component(value: &str) -> String {
 }
 
 fn gitlab_repo_for(root: &Path, gitlab_url: &str) -> Result<String, String> {
-    let output = Command::new("git")
+    let mut cmd = Command::new("git");
+    crate::hide_window_console(&mut cmd);
+    let output = cmd
         .args(["config", "--get-regexp", r"^remote\..*\.url$"])
         .current_dir(root)
         .output()


### PR DESCRIPTION
## What changed

Apply the existing Windows console-hiding helper before the GitLab remote resolver runs `git config`. The lookup behavior and output are unchanged.

## Why

This prevents visible console windows from opening while the Inbox resolves GitLab remotes for recent projects on Windows.

Closes #192

## UI

No layout change. This only changes Windows child-process launch behavior.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented console windows from appearing during GitLab repository operations on supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->