### PR TITLE
Send Supervised as a Claude permission flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Subagents now get a row each in the transcript, sitting under the agent's own work with an animated mascot, a shimmering name while the run is live, and a count of the steps it has taken. Clicking a row opens the subagent's trail inline, grouped into phases the same way the main transcript groups work, so a long run reads as what it said and the calls that followed rather than one flat dump. The rows keep their place while the work above them folds and re-folds. Claude and Codex both report their subagents' work; Codex spawns are named from their brief, stay running until the agent itself reports otherwise, and one spawned agent no longer shows up as several rows.
 - GitLab's **Needs attention** Inbox view now uses pending GitLab To-Dos to include assignments, mentions, and review requests from every accessible repository. Remote-only items support details, discussions, comments, and merge-request diffs without requiring a local checkout.
 
+### Fixed
+
+- **Supervised** access now reaches Claude Code as a permission flag. It was the one mode MonoCode sent nothing for, so the CLI fell back to `permissions.defaultMode` from your settings files, and a session the picker labelled Supervised could run as `auto` or `bypassPermissions` without asking.
+
 ## [0.1.44] - 2026-09-12
 
 ### Added

--- a/src/lib/harness/claudeProtocol.test.ts
+++ b/src/lib/harness/claudeProtocol.test.ts
@@ -37,10 +37,20 @@ import {
 
 describe("runtimeModeToPermission", () => {
   it("maps runtime modes onto Claude permission flags", () => {
-    expect(runtimeModeToPermission("supervised")).toBeUndefined();
+    expect(runtimeModeToPermission("supervised")).toBe("default");
     expect(runtimeModeToPermission("auto-accept-edits")).toBe("acceptEdits");
     expect(runtimeModeToPermission("auto")).toBe("auto");
     expect(runtimeModeToPermission("full-access")).toBe("bypassPermissions");
+  });
+
+  it("sends supervised as a flag so settings cannot lower it", () => {
+    const args = buildClaudeSpawnArgs({
+      permissionMode: runtimeModeToPermission("supervised"),
+      sessionId: "sess-supervised",
+    });
+    expect(args).toEqual(
+      expect.arrayContaining(["--permission-mode", "default"]),
+    );
   });
 });
 

--- a/src/lib/harness/claudeProtocol.ts
+++ b/src/lib/harness/claudeProtocol.ts
@@ -96,9 +96,15 @@ export function compareSemver(left: string, right: string): number {
   return 0;
 }
 
+/**
+ * Supervised maps onto a flag like every other mode. Sending nothing left the
+ * CLI free to fall back to `permissions.defaultMode` from the user's settings,
+ * so a session the picker called Supervised could silently run as `auto`.
+ * `default` is the value that asks; `manual` is its alias but needs CLI 2.1.200.
+ */
 export function runtimeModeToPermission(
   mode: RuntimeMode,
-): ClaudePermissionMode | undefined {
+): ClaudePermissionMode {
   switch (mode) {
     case "auto-accept-edits":
       return "acceptEdits";
@@ -107,7 +113,7 @@ export function runtimeModeToPermission(
     case "full-access":
       return "bypassPermissions";
     default:
-      return undefined;
+      return "default";
   }
 }
 


### PR DESCRIPTION
## What changed

`runtimeModeToPermission` now returns `"default"` for `supervised` instead of `undefined`, so `buildClaudeSpawnArgs` puts `--permission-mode default` on the command line.

## Why

Supervised was the only access mode that sent no flag. Claude Code then falls back to `permissions.defaultMode` from the user's settings files — and `--permission-mode` is documented to override exactly that. With `"defaultMode": "auto"` in `~/.claude/settings.json`, a session the picker labelled **Supervised — Ask before commands and file changes** ran as `auto` instead, with an AI reviewer approving actions. `rm` on a file in the repo root went through without a prompt.

The other three modes (`acceptEdits`, `auto`, `bypassPermissions`) already send a flag, so supervised was the only one a settings file could quietly lower. An explicit choice in the picker should win over a config default, and for this mode in particular the gap is a safety one.

`"default"` rather than its `"manual"` alias: both select the same mode, but `manual` requires Claude Code 2.1.200 or later, while `default` works on every version. `ClaudePermissionMode` already listed `"default"`; nothing produced it.

The return type drops `| undefined` since no mode maps to nothing now. `runtimeModeToPermission` has one caller, `launchOptions` in `claude.ts`, whose `plan` intent still short-circuits ahead of it.

## UI

No visual change. The **Supervised** option now behaves the way its own hint describes.

## Checklist

- [x] I ran `npm run check`
- [x] This PR is small and focused
- [x] I did not mix unrelated changes

On the first box: `cargo fmt`/`clippy`/`cargo test` and `tsc --noEmit` are clean, and all 463 tests under `src/lib/harness` pass. Four unrelated test files (`ModelPicker`, `SkillsPage`, `useInboxUnseen`, `linkedSessionSeen`) fail for me on a clean `main` too, with `localStorage` undefined under happy-dom on Node 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Supervised sessions now consistently use the default permission mode when launching Claude Code.
  - Configured permission settings can no longer silently lower Supervised access to modes such as automatic execution or bypassed permissions.
  - Added coverage to verify the correct permission mode is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->